### PR TITLE
Removed impossible EOFError raise

### DIFF
--- a/lib/openssl/buffering.rb
+++ b/lib/openssl/buffering.rb
@@ -186,7 +186,6 @@ module OpenSSL::Buffering
       buf.replace(ret)
       ret = buf
     end
-    raise EOFError if ret.empty?
     ret
   end
 


### PR DESCRIPTION
With exceptionless NIO, we return nil on EOF rather than raising. Having this raise either way makes it inconsistent with the Ruby API (when using exceptionless NIO). Upon further investigation though, I don't see how it's ever possible that EOFError happens, because:

We check `rbuffer.empty?` on L181, and if it's true we never proceed past L182. Then `consume_rbuff` cannot return an empty string, it can only return nil if it's empty, but we handle that on L181.

A blank string would require hitting L77, which should never happen on an empty string since `empty?` is already being calledc