### PR TITLE
Apply patch @viktorium to dispose of context after signing

### DIFF
--- a/ext/openssl/ossl_pkey.c
+++ b/ext/openssl/ossl_pkey.c
@@ -289,6 +289,7 @@ ossl_pkey_sign(VALUE self, VALUE digest, VALUE data)
     EVP_MD_CTX ctx;
     unsigned int buf_len;
     VALUE str;
+    int result;
 
     if (rb_funcallv(self, id_private_q, 0, NULL) != Qtrue) {
 	ossl_raise(rb_eArgError, "Private key is needed.");
@@ -298,7 +299,9 @@ ossl_pkey_sign(VALUE self, VALUE digest, VALUE data)
     StringValue(data);
     EVP_SignUpdate(&ctx, RSTRING_PTR(data), RSTRING_LEN(data));
     str = rb_str_new(0, EVP_PKEY_size(pkey)+16);
-    if (!EVP_SignFinal(&ctx, (unsigned char *)RSTRING_PTR(str), &buf_len, pkey))
+    result = EVP_SignFinal(&ctx, (unsigned char *)RSTRING_PTR(str), &buf_len, pkey)
+    EVP_MD_CTX_cleanup(&ctx);
+    if (!result)
 	ossl_raise(ePKeyError, NULL);
     assert((long)buf_len <= RSTRING_LEN(str));
     rb_str_set_len(str, buf_len);


### PR DESCRIPTION
[Bug-#10735](https://bugs.ruby-lang.org/issues/10735)

We have been using the bug fix in production for over 5 months now without any issue. We'd like to upgrade our Ruby to the latest mainline, but as this bug is still present we cannot.

Would it be possible to merge this fix in?