### PR TITLE
LibreSSL compatibility on Windows

### DIFF
--- a/ext/openssl/extconf.rb
+++ b/ext/openssl/extconf.rb
@@ -50,6 +50,8 @@ unless result
   end
 end
 
+have_header("openssl/e_os2.h")
+
 unless have_header("openssl/conf_api.h")
   raise "OpenSSL 0.9.6 or later required."
 end

--- a/ext/openssl/ossl.h
+++ b/ext/openssl/ossl.h
@@ -44,7 +44,7 @@ extern "C" {
 #  define assert(condition)
 #endif
 
-#if defined(_WIN32)
+#if defined(_WIN32) && HAVE_OPENSSL_E_OS2_H
 #  include <openssl/e_os2.h>
 #  define OSSL_NO_CONF_API 1
 #  if !defined(OPENSSL_SYS_WIN32)


### PR DESCRIPTION
This patch makes the openssl gem compatible with the official release of LibreSSL from the OpenBSD team (https://github.com/libressl-portable/portable) on Windows.

Note: it's actually quite hard to use a particular installed version of the openssl gem. If you just run a script without bundler, it always seems to pick up the built-in version. Meanwhile, if you use bundler, bundler itself seems to load the built-in openssl before starting your program (and in fact, even if the built-in version isn't available, it still somehow seems to load libeay32.dll from OpenSSL). The only way I have found to get the gem and the LibreSSL libraries on their own is to remove or rename the files of the built-in version, and not use bundler.

However, having done this, I have succeeded in using the LibreSSL 2.3.1 Windows x86 binaries (under MinGW) with this gem to download a file using HTTPS (and I've verified that it is only loading the LibreSSL libraries).

See also: issue #37