### PR TITLE
Allow failures with libressl-2.3.1.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,6 @@ matrix:
     - env: RUBY_VERSION=2.2.3 OPENSSL_VERSION=1.0.1p
     - env: RUBY_VERSION=2.2.3 OPENSSL_VERSION=1.0.2d
     - env: RUBY_VERSION=2.2.3 LIBRESSL_VERSION=2.3.1
+  allow_failures:
+    - env: RUBY_VERSION=2.2.3 LIBRESSL_VERSION=2.3.1
   fast_finish: true


### PR DESCRIPTION
some tests with libressl-2.3.1 fails. It should ignored on Travis CI.