### PR TITLE
Remove 512-bit DH group

### DIFF
--- a/lib/openssl/pkey.rb
+++ b/lib/openssl/pkey.rb
@@ -4,13 +4,6 @@ module OpenSSL
     if defined?(OpenSSL::PKey::DH)
 
     class DH
-      DEFAULT_512 = new <<-_end_of_pem_
------BEGIN DH PARAMETERS-----
-MEYCQQD0zXHljRg/mJ9PYLACLv58Cd8VxBxxY7oEuCeURMiTqEhMym16rhhKgZG2
-zk2O9uUIBIxSj+NKMURHGaFKyIvLAgEC
------END DH PARAMETERS-----
-      _end_of_pem_
-
       DEFAULT_1024 = new <<-_end_of_pem_
 -----BEGIN DH PARAMETERS-----
 MIGHAoGBAJ0lOVy0VIr/JebWn0zDwY2h+rqITFOpdNr6ugsgvkDXuucdcChhYExJ
@@ -23,7 +16,6 @@ T4h7KZ/2zmjvV+eF8kBUHBJAojUlzxKj4QeO2x20FP9X5xmNUXeDAgEC
     DEFAULT_TMP_DH_CALLBACK = lambda { |ctx, is_export, keylen|
       warn "using default DH parameters." if $VERBOSE
       case keylen
-      when 512  then OpenSSL::PKey::DH::DEFAULT_512
       when 1024 then OpenSSL::PKey::DH::DEFAULT_1024
       else
         nil

--- a/test/test_pkey_dh.rb
+++ b/test/test_pkey_dh.rb
@@ -6,16 +6,6 @@ class OpenSSL::TestPKeyDH < Test::Unit::TestCase
 
   NEW_KEYLEN = 256
 
-  def test_DEFAULT_512
-    params = <<-eop
------BEGIN DH PARAMETERS-----
-MEYCQQD0zXHljRg/mJ9PYLACLv58Cd8VxBxxY7oEuCeURMiTqEhMym16rhhKgZG2
-zk2O9uUIBIxSj+NKMURHGaFKyIvLAgEC
------END DH PARAMETERS-----
-    eop
-    assert_equal params, OpenSSL::PKey::DH::DEFAULT_512.to_s
-  end
-
   def test_DEFAULT_1024
     params = <<-eop
 -----BEGIN DH PARAMETERS-----
@@ -64,14 +54,14 @@ T4h7KZ/2zmjvV+eF8kBUHBJAojUlzxKj4QeO2x20FP9X5xmNUXeDAgEC
   end
 
   def test_generate_key
-    dh = OpenSSL::TestUtils::TEST_KEY_DH512_PUB.public_key # creates a copy
+    dh = OpenSSL::TestUtils::TEST_KEY_DH1024.public_key # creates a copy
     assert_no_key(dh)
     dh.generate_key!
     assert_key(dh)
   end
 
   def test_key_exchange
-    dh = OpenSSL::TestUtils::TEST_KEY_DH512_PUB
+    dh = OpenSSL::TestUtils::TEST_KEY_DH1024
     dh2 = dh.public_key
     dh.generate_key!
     dh2.generate_key!

--- a/test/utils.rb
+++ b/test/utils.rb
@@ -97,13 +97,6 @@ CeBUl+MahZtn9fO1JKdF4qJmS39dXnpENg==
 
 end
 
-  TEST_KEY_DH512_PUB = OpenSSL::PKey::DH.new <<-_end_of_pem_
------BEGIN DH PARAMETERS-----
-MEYCQQDmWXGPqk76sKw/edIOdhAQD4XzjJ+AR/PTk2qzaGs+u4oND2yU5D2NN4wr
-aPgwHyJBiK1/ebK3tYcrSKrOoRyrAgEC
------END DH PARAMETERS-----
-  _end_of_pem_
-
   TEST_KEY_DH1024 = OpenSSL::PKey::DH.new <<-_end_of_pem_
 -----BEGIN DH PARAMETERS-----
 MIGHAoGBAKnKQ8MNK6nYZzLrrcuTsLxuiJGXoOO5gT+tljOTbHBuiktdMTITzIY0


### PR DESCRIPTION
512-bit DH keys are severely weak and have been implicated in recent attacks:

https://weakdh.org/