### PR TITLE
Remove RC4 cipher

### DIFF
--- a/lib/openssl/ssl.rb
+++ b/lib/openssl/ssl.rb
@@ -50,9 +50,6 @@ module OpenSSL
           AES256-SHA256
           AES128-SHA
           AES256-SHA
-          ECDHE-ECDSA-RC4-SHA
-          ECDHE-RSA-RC4-SHA
-          RC4-SHA
         }.join(":"),
         :options => -> {
           opts = OpenSSL::SSL::OP_ALL


### PR DESCRIPTION
RC4 has insecure biases and both clients and servers should [not](https://tools.ietf.org/html/rfc7465) be using it.