### PR TITLE
Documentation fix regarding .public? method

### DIFF
--- a/ext/openssl/ossl.c
+++ b/ext/openssl/ossl.c
@@ -656,7 +656,7 @@ static void Init_ossl_locks(void)
  *
  * A key can also be loaded from a file.
  *
- *   key2 = OpenSSL::PKey::RSA.new File.read 'private_key.pem'
+ *   key2 = OpenSSL::PKey::RSA.new File.read 'public_key.pem'
  *   key2.public? # => true
  *
  * or


### PR DESCRIPTION
In the docs, the .public? method returned true for a file called "private_key.pem".  

I think this is an error and should return true for "public_key.pem".