### PR TITLE
Make PKey.read raise PKey::PKeyError rather than ArgumentError

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -35,6 +35,10 @@ Backward compatibility notes
 * RC4 cipher suites are removed from OpenSSL::SSL::SSLContext::DEFAULT_PARAMS.
   RC4 is now considered to be weak. [GH ruby/openssl#50]
 
+* OpenSSL::PKey.read raises OpenSSL::PKey::PKeyError instead of ArgumentError
+  for consistency with OpenSSL::PKey::{DH,DSA,RSA,EC}#new.
+  [Bug #11774] [GH ruby/openssl#55]
+
 Updates since Ruby 2.3
 ----------------------
 
@@ -78,6 +82,10 @@ Updates since Ruby 2.3
     OpenSSL::PKey::RSA#set_key, #set_factors, #set_crt_params,
     OpenSSL::PKey::DSA#set_pqg, #set_key, OpenSSL::PKey::DH#set_pqg and #set_key
     are added.
+
+  - OpenSSL::PKey.read raises OpenSSL::PKey::PKeyError instead of ArgumentError
+    for consistency with OpenSSL::PKey::{DH,DSA,RSA,EC}#new.
+    [Bug #11774] [GH ruby/openssl#55]
 
 * OpenSSL::Random
 

--- a/NEWS
+++ b/NEWS
@@ -1,0 +1,108 @@
+Version x.y.z
+=============
+
+This is the first release of openssl gem, formerly a standard library of Ruby,
+ext/openssl. This is the successor of the version included in Ruby 2.3.
+
+
+Backward compatibility notes
+----------------------------
+
+* Support for OpenSSL version 0.9.6 and 0.9.7 is completely removed. openssl gem
+  still works with OpenSSL 0.9.8, but users are strongly encouraged to upgrade
+  to at least 1.0.1, as OpenSSL < 1.0.1 will not receive any security fixes from
+  the OpenSSL development team.
+
+* OpenSSL::Cipher#key= and #iv= reject too long inputs. They used to truncate
+  silently. [Bug #12561]
+
+* OpenSSL::PKey::RSA#n=, #e=, #d=, #p=, #q=, #dmp1=, #dmq1=, #iqmp=,
+  OpenSSL::PKey::DSA#p=, #q=, #g=, #priv_key=, #pub_key=,
+  OpenSSL::PKey::DH#p=, #g=, #priv_key= and #pub_key= are deprecated. They are
+  disabled when built with OpenSSL 1.1.0, due to its API change. Instead,
+  OpenSSL::PKey::RSA#set_key, #set_factors, #set_crt_params,
+  OpenSSL::PKey::DSA#set_pqg, #set_key, OpenSSL::PKey::DH#set_pqg and #set_key
+  are added.
+
+* OpenSSL::Random.pseudo_bytes is deprecated, and not defined when built with
+  OpenSSL 1.1.0. Use OpenSSL::Random.random_bytes instead.
+
+* OpenSSL::SSL::SSLContext#tmp_ecdh_callback is deprecated. To specify the curve
+  to be used in ephemeral ECDH, use OpenSSL::SSL::SSLContext#ecdh_curves=. The
+  automatic curve selection is also now enabled by default when built with a
+  capable OpenSSL.
+
+* RC4 cipher suites are removed from OpenSSL::SSL::SSLContext::DEFAULT_PARAMS.
+  RC4 is now considered to be weak. [GH ruby/openssl#50]
+
+Updates since Ruby 2.3
+----------------------
+
+* Supported platform
+
+  - Supports OpenSSL 1.1.0. [Feature #12324]
+
+  - OpenSSL < 0.9.8 is no longer supported.
+
+* OpenSSL::Cipher
+
+  - OpenSSL::Cipher#key= and #iv= reject too long inputs. They used to truncate
+    silently. [Bug #12561]
+
+* OpenSSL::Engine
+
+  - OpenSSL::Engine.cleanup does nothing when built with OpenSSL 1.1.0.
+
+* OpenSSL::OCSP
+
+  - Accessor methods are added to OpenSSL::OCSP::CertificateId. [Feature #7181]
+
+  - OpenSSL::OCSP::Request and BasicResponse can be signed with non-SHA-1 hash
+    algorithm. [Feature #11552]
+
+  - OpenSSL::OCSP::CertificateId and BasicResponse can be encoded into DER.
+
+  - A new class OpenSSL::OCSP::SingleResponse is added for convenience.
+
+  - OpenSSL::OCSP::BasicResponse#add_status accepts absolute times. They used to
+    accept only relative seconds from the current time.
+
+* OpenSSL::PKey
+
+  - OpenSSL::PKey::EC follows the general PKey interface. [Bug #6567]
+
+  - OpenSSL::PKey::RSA#n=, #e=, #d=, #p=, #q=, #dmp1=, #dmq1=, #iqmp=,
+    OpenSSL::PKey::DSA#p=, #q=, #g=, #priv_key=, #pub_key=,
+    OpenSSL::PKey::DH#p=, #g=, #priv_key= and #pub_key= are deprecated. They are
+    disabled when built with OpenSSL 1.1.0, due to its API change. Instead,
+    OpenSSL::PKey::RSA#set_key, #set_factors, #set_crt_params,
+    OpenSSL::PKey::DSA#set_pqg, #set_key, OpenSSL::PKey::DH#set_pqg and #set_key
+    are added.
+
+* OpenSSL::Random
+
+  - OpenSSL::Random.pseudo_bytes is deprecated, and not defined when built with
+    OpenSSL 1.1.0. Use OpenSSL::Random.random_bytes instead.
+
+* OpenSSL::SSL
+
+  - OpenSSL::PKey::DH::DEFAULT_512 is removed. Hence servers no longer use
+    512-bit DH group by default. It is considered too weak nowadays.
+    [Bug #11968] [GH ruby/ruby#1196]
+
+  - OpenSSL::SSL::SSLSocket#tmp_key is added. A client can call it after the
+    connection is established to retrieve the ephemeral key. [GH ruby/ruby#1318]
+
+  - The automatic ephemeral ECDH curve selection is enabled by default when
+    built with OpenSSL >= 1.0.2 or LibreSSL.
+
+  - OpenSSL::SSL::SSLContext#tmp_ecdh_callback is deprecated, as the underlying
+    API SSL_CTX_set_tmp_ecdh_callback() is removed in OpenSSL 1.1.0. It was
+    first added in Ruby 2.3.0.
+
+  - OpenSSL::SSL::SSLContext#security_level= is added. You can set the "security
+    level" of the SSL context. This is effective only when built with OpenSSL
+    1.1.0.
+
+  - RC4 cipher suites are removed from OpenSSL::SSL::SSLContext::DEFAULT_PARAMS.
+    RC4 is now considered to be weak. [GH ruby/openssl#50]

--- a/ext/openssl/ossl_pkey.c
+++ b/ext/openssl/ossl_pkey.c
@@ -158,7 +158,8 @@ ossl_pkey_new_from_data(int argc, VALUE *argv, VALUE self)
 
     BIO_free(bio);
     if (!pkey)
-	ossl_raise(rb_eArgError, "Could not parse PKey");
+	ossl_raise(ePKeyError, "Could not parse PKey");
+
     return ossl_pkey_new(pkey);
 }
 

--- a/test/test_pkey_dsa.rb
+++ b/test/test_pkey_dsa.rb
@@ -221,7 +221,7 @@ YNMbNw==
   def test_export_password_funny
     key = OpenSSL::TestUtils::TEST_KEY_DSA256
     pem = key.export(OpenSSL::Cipher.new('AES-128-CBC'), "pass\0wd")
-    assert_raise(ArgumentError) do
+    assert_raise(OpenSSL::PKey::PKeyError) do
       OpenSSL::PKey.read(pem, "pass")
     end
     key2 = OpenSSL::PKey.read(pem, "pass\0wd")

--- a/test/test_pkey_ec.rb
+++ b/test/test_pkey_ec.rb
@@ -233,7 +233,7 @@ class OpenSSL::TestEC < OpenSSL::TestCase
   def test_export_password_funny
     key = OpenSSL::TestUtils::TEST_KEY_EC_P256V1
     pem = key.export(OpenSSL::Cipher.new('AES-128-CBC'), "pass\0wd")
-    assert_raise(ArgumentError) do
+    assert_raise(OpenSSL::PKey::PKeyError) do
       OpenSSL::PKey.read(pem, "pass")
     end
     key2 = OpenSSL::PKey.read(pem, "pass\0wd")

--- a/test/test_pkey_rsa.rb
+++ b/test/test_pkey_rsa.rb
@@ -260,7 +260,7 @@ AwEAAQ==
   def test_read_private_key_pem_pw_exception
     pem = OpenSSL::TestUtils::TEST_KEY_RSA1024.to_pem(OpenSSL::Cipher.new('AES-128-CBC'), 'secret')
     # it raises an ArgumentError from PEM reading. The exception raised inside are ignored for now.
-    assert_raise(ArgumentError) do
+    assert_raise(OpenSSL::PKey::PKeyError) do
       OpenSSL::PKey.read(pem) do
         raise RuntimeError
       end
@@ -285,7 +285,7 @@ AwEAAQ==
     end
     # password containing NUL byte
     pem = key.export(OpenSSL::Cipher.new('AES-128-CBC'), "pass\0wd")
-    assert_raise(ArgumentError) do
+    assert_raise(OpenSSL::PKey::PKeyError) do
       OpenSSL::PKey.read(pem, "pass")
     end
     key2 = OpenSSL::PKey.read(pem, "pass\0wd")


### PR DESCRIPTION
PKey.read is a generic method to load an arbitrary PKey structure from a
PEM or DER encoded String. Each PKey classes's constructor also can load
from a String, but the behavior on error is different. While they raises
its own exception (are subclasses of PKey::PKeyError), PKey.read raises
ArguementError.

https://bugs.ruby-lang.org/issues/11774