### PR TITLE
ssl: reject keys without private components [Bug #8673]

### DIFF
--- a/ext/openssl/ossl_pkey.c
+++ b/ext/openssl/ossl_pkey.c
@@ -15,7 +15,7 @@
 VALUE mPKey;
 VALUE cPKey;
 VALUE ePKeyError;
-ID id_private_q;
+static ID id_private_q;
 
 /*
  * callback for generating keys
@@ -196,20 +196,6 @@ DupPKeyPtr(VALUE obj)
     return pkey;
 }
 
-EVP_PKEY *
-DupPrivPKeyPtr(VALUE obj)
-{
-    EVP_PKEY *pkey;
-
-    if (rb_funcallv(obj, id_private_q, 0, NULL) != Qtrue) {
-	ossl_raise(rb_eArgError, "Private key is needed.");
-    }
-    SafeGetPKey(obj, pkey);
-    EVP_PKEY_up_ref(pkey);
-
-    return pkey;
-}
-
 /*
  * Private
  */
@@ -271,9 +257,7 @@ ossl_pkey_sign(VALUE self, VALUE digest, VALUE data)
     VALUE str;
     int result;
 
-    if (rb_funcallv(self, id_private_q, 0, NULL) != Qtrue)
-	ossl_raise(rb_eArgError, "Private key is needed.");
-    GetPKey(self, pkey);
+    pkey = GetPrivPKeyPtr(self);
     md = GetDigestPtr(digest);
     StringValue(data);
     str = rb_str_new(0, EVP_PKEY_size(pkey)+16);

--- a/ext/openssl/ossl_pkey.h
+++ b/ext/openssl/ossl_pkey.h
@@ -13,7 +13,6 @@
 extern VALUE mPKey;
 extern VALUE cPKey;
 extern VALUE ePKeyError;
-extern ID id_private_q;
 extern const rb_data_type_t ossl_evp_pkey_type;
 
 #define OSSL_PKEY_SET_PRIVATE(obj) rb_iv_set((obj), "private", Qtrue)
@@ -53,7 +52,6 @@ VALUE ossl_pkey_new_from_file(VALUE);
 EVP_PKEY *GetPKeyPtr(VALUE);
 EVP_PKEY *DupPKeyPtr(VALUE);
 EVP_PKEY *GetPrivPKeyPtr(VALUE);
-EVP_PKEY *DupPrivPKeyPtr(VALUE);
 void Init_ossl_pkey(void);
 
 /*

--- a/ext/openssl/ossl_ssl.c
+++ b/ext/openssl/ossl_ssl.c
@@ -228,7 +228,7 @@ ossl_call_client_cert_cb(VALUE obj)
     ary = rb_funcall(cb, rb_intern("call"), 1, obj);
     Check_Type(ary, T_ARRAY);
     GetX509CertPtr(cert = rb_ary_entry(ary, 0));
-    GetPKeyPtr(key = rb_ary_entry(ary, 1));
+    GetPrivPKeyPtr(key = rb_ary_entry(ary, 1));
 
     return rb_ary_new3(2, cert, key);
 }
@@ -774,7 +774,7 @@ ossl_sslctx_setup(VALUE self)
     val = ossl_sslctx_get_cert(self);
     cert = NIL_P(val) ? NULL : GetX509CertPtr(val); /* NO DUP NEEDED */
     val = ossl_sslctx_get_key(self);
-    key = NIL_P(val) ? NULL : GetPKeyPtr(val); /* NO DUP NEEDED */
+    key = NIL_P(val) ? NULL : GetPrivPKeyPtr(val); /* NO DUP NEEDED */
     if (cert && key) {
         if (!SSL_CTX_use_certificate(ctx, cert)) {
             /* Adds a ref => Safe to FREE */


### PR DESCRIPTION
OpenSSL checks if the PKey's public key matches with the certificate,
but does not check that the PKey contains the private components. As a
result, OpenSSL does a NULL dereference while doing SSL/TLS negotiation.

https://bugs.ruby-lang.org/issues/8673