### PR TITLE
Improve 'Loading a key' section of the documentation

### DIFF
--- a/ext/openssl/ossl.c
+++ b/ext/openssl/ossl.c
@@ -660,10 +660,12 @@ static void Init_ossl_locks(void)
  *
  *   key2 = OpenSSL::PKey::RSA.new File.read 'private_key.pem'
  *   key2.public? # => true
+ *   key2.private? # => true
  *
  * or
  *
  *   key3 = OpenSSL::PKey::RSA.new File.read 'public_key.pem'
+ *   key3.public? # => true
  *   key3.private? # => false
  *
  * === Loading an Encrypted Key


### PR DESCRIPTION
Show the return values of both PKey::RSA#public? and #private? for each
two .pem files. The current example is not technically incorrect, but
very confusing.

This is based on the reports by Rob Nichols and Brett Goulder.
[Bug #10115] [GH ruby/openssl#52]