### PR TITLE
pkey: add format keyword argument to PKey::PKey#to_der and #export

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -96,6 +96,11 @@ Updates since Ruby 2.3
     for consistency with OpenSSL::PKey::{DH,DSA,RSA,EC}#new.
     [Bug #11774] [GH ruby/openssl#55]
 
+  - OpenSSL::PKey::{RSA,DSA,EC}#to_der and #export learnt a new keyword argument
+    'format'. This allows encoding a PKey containing the private key to DER/PEM
+    string in SubjectPublicKeyInfo format without duplicating the PKey first.
+    [GH ruby/openssl#61]
+
 * OpenSSL::Random
 
   - OpenSSL::Random.pseudo_bytes is deprecated, and not defined when built with

--- a/ext/openssl/ossl.h
+++ b/ext/openssl/ossl.h
@@ -120,6 +120,22 @@ do{\
 }while(0)
 
 /*
+ * Encodes +obj+ into DER string using +i2d_func+ and stores to +out+. Note that
+ * it may raise.
+ */
+#define ossl_i2d(i2d_func, obj, out) do { \
+    long len; \
+    unsigned char *p; \
+    if ((len = (i2d_func)(obj, NULL)) <= 0) \
+	ossl_raise(eOSSLError, #i2d_func); \
+    (out) = rb_str_new(0, len); \
+    p = (unsigned char *)RSTRING_PTR((out)); \
+    if (((i2d_func)(obj, &p)) <= 0) \
+	ossl_raise(eOSSLError, #i2d_func); \
+    ossl_str_adjust((out), p); \
+} while (0)
+
+/*
  * Our default PEM callback
  */
 /* Convert the argument to String and validate the length. Note this may raise. */

--- a/ext/openssl/ossl_ns_spki.c
+++ b/ext/openssl/ossl_ns_spki.c
@@ -110,17 +110,9 @@ ossl_spki_to_der(VALUE self)
 {
     NETSCAPE_SPKI *spki;
     VALUE str;
-    long len;
-    unsigned char *p;
 
     GetSPKI(self, spki);
-    if ((len = i2d_NETSCAPE_SPKI(spki, NULL)) <= 0)
-        ossl_raise(eX509CertError, NULL);
-    str = rb_str_new(0, len);
-    p = (unsigned char *)RSTRING_PTR(str);
-    if (i2d_NETSCAPE_SPKI(spki, &p) <= 0)
-        ossl_raise(eX509CertError, NULL);
-    ossl_str_adjust(str, p);
+    ossl_i2d(i2d_NETSCAPE_SPKI, spki, str);
 
     return str;
 }

--- a/ext/openssl/ossl_ocsp.c
+++ b/ext/openssl/ossl_ocsp.c
@@ -450,17 +450,9 @@ ossl_ocspreq_to_der(VALUE self)
 {
     OCSP_REQUEST *req;
     VALUE str;
-    unsigned char *p;
-    long len;
 
     GetOCSPReq(self, req);
-    if((len = i2d_OCSP_REQUEST(req, NULL)) <= 0)
-	ossl_raise(eOCSPError, NULL);
-    str = rb_str_new(0, len);
-    p = (unsigned char *)RSTRING_PTR(str);
-    if(i2d_OCSP_REQUEST(req, &p) <= 0)
-	ossl_raise(eOCSPError, NULL);
-    ossl_str_adjust(str, p);
+    ossl_i2d(i2d_OCSP_REQUEST, req, str);
 
     return str;
 }
@@ -631,17 +623,9 @@ ossl_ocspres_to_der(VALUE self)
 {
     OCSP_RESPONSE *res;
     VALUE str;
-    long len;
-    unsigned char *p;
 
     GetOCSPRes(self, res);
-    if((len = i2d_OCSP_RESPONSE(res, NULL)) <= 0)
-	ossl_raise(eOCSPError, NULL);
-    str = rb_str_new(0, len);
-    p = (unsigned char *)RSTRING_PTR(str);
-    if(i2d_OCSP_RESPONSE(res, &p) <= 0)
-	ossl_raise(eOCSPError, NULL);
-    ossl_str_adjust(str, p);
+    ossl_i2d(i2d_OCSP_RESPONSE, res, str);
 
     return str;
 }
@@ -1132,17 +1116,9 @@ ossl_ocspbres_to_der(VALUE self)
 {
     OCSP_BASICRESP *res;
     VALUE str;
-    long len;
-    unsigned char *p;
 
     GetOCSPBasicRes(self, res);
-    if ((len = i2d_OCSP_BASICRESP(res, NULL)) <= 0)
-	ossl_raise(eOCSPError, NULL);
-    str = rb_str_new(0, len);
-    p = (unsigned char *)RSTRING_PTR(str);
-    if (i2d_OCSP_BASICRESP(res, &p) <= 0)
-	ossl_raise(eOCSPError, NULL);
-    ossl_str_adjust(str, p);
+    ossl_i2d(i2d_OCSP_BASICRESP, res, str);
 
     return str;
 }
@@ -1423,17 +1399,9 @@ ossl_ocspsres_to_der(VALUE self)
 {
     OCSP_SINGLERESP *sres;
     VALUE str;
-    long len;
-    unsigned char *p;
 
     GetOCSPSingleRes(self, sres);
-    if ((len = i2d_OCSP_SINGLERESP(sres, NULL)) <= 0)
-	ossl_raise(eOCSPError, NULL);
-    str = rb_str_new(0, len);
-    p = (unsigned char *)RSTRING_PTR(str);
-    if (i2d_OCSP_SINGLERESP(sres, &p) <= 0)
-	ossl_raise(eOCSPError, NULL);
-    ossl_str_adjust(str, p);
+    ossl_i2d(i2d_OCSP_SINGLERESP, sres, str);
 
     return str;
 }
@@ -1669,17 +1637,9 @@ ossl_ocspcid_to_der(VALUE self)
 {
     OCSP_CERTID *id;
     VALUE str;
-    long len;
-    unsigned char *p;
 
     GetOCSPCertId(self, id);
-    if ((len = i2d_OCSP_CERTID(id, NULL)) <= 0)
-	ossl_raise(eOCSPError, NULL);
-    str = rb_str_new(0, len);
-    p = (unsigned char *)RSTRING_PTR(str);
-    if (i2d_OCSP_CERTID(id, &p) <= 0)
-	ossl_raise(eOCSPError, NULL);
-    ossl_str_adjust(str, p);
+    ossl_i2d(i2d_OCSP_CERTID, id, str);
 
     return str;
 }

--- a/ext/openssl/ossl_pkcs12.c
+++ b/ext/openssl/ossl_pkcs12.c
@@ -217,17 +217,9 @@ ossl_pkcs12_to_der(VALUE self)
 {
     PKCS12 *p12;
     VALUE str;
-    long len;
-    unsigned char *p;
 
     GetPKCS12(self, p12);
-    if((len = i2d_PKCS12(p12, NULL)) <= 0)
-	ossl_raise(ePKCS12Error, NULL);
-    str = rb_str_new(0, len);
-    p = (unsigned char *)RSTRING_PTR(str);
-    if(i2d_PKCS12(p12, &p) <= 0)
-	ossl_raise(ePKCS12Error, NULL);
-    ossl_str_adjust(str, p);
+    ossl_i2d(i2d_PKCS12, p12, str);
 
     return str;
 }

--- a/ext/openssl/ossl_pkcs7.c
+++ b/ext/openssl/ossl_pkcs7.c
@@ -870,17 +870,9 @@ ossl_pkcs7_to_der(VALUE self)
 {
     PKCS7 *pkcs7;
     VALUE str;
-    long len;
-    unsigned char *p;
 
     GetPKCS7(self, pkcs7);
-    if((len = i2d_PKCS7(pkcs7, NULL)) <= 0)
-	ossl_raise(ePKCS7Error, NULL);
-    str = rb_str_new(0, len);
-    p = (unsigned char *)RSTRING_PTR(str);
-    if(i2d_PKCS7(pkcs7, &p) <= 0)
-	ossl_raise(ePKCS7Error, NULL);
-    ossl_str_adjust(str, p);
+    ossl_i2d(i2d_PKCS7, pkcs7, str);
 
     return str;
 }

--- a/ext/openssl/ossl_pkey.c
+++ b/ext/openssl/ossl_pkey.c
@@ -310,6 +310,127 @@ ossl_pkey_verify(VALUE self, VALUE digest, VALUE sig, VALUE data)
     return Qnil; /* dummy */
 }
 
+enum ossl_pkey_export_format
+ossl_pkey_parse_export_format(VALUE obj, VALUE opts)
+{
+    ID kwids[1], id;
+    VALUE kwargs[1];
+
+    kwids[0] = rb_intern("format");
+    rb_get_kwargs(opts, kwids, 0, 1, kwargs);
+    if (kwargs[0] == Qundef || !RTEST(kwargs[0])) {
+	if (RTEST(rb_funcall(obj, id_private_q, 0)))
+	    return OSSL_PKEY_EXPORT_PRIVATE;
+	else
+	    return OSSL_PKEY_EXPORT_PUBKEY;
+    }
+
+    id = rb_to_id(kwargs[0]);
+    if (id == rb_intern("public")) {
+	return OSSL_PKEY_EXPORT_PUBKEY;
+    }
+    else if (id == rb_intern("private")) {
+	if (!RTEST(rb_funcall(obj, id_private_q, 0)))
+	    ossl_raise(ePKeyError, "private key required");
+	return OSSL_PKEY_EXPORT_PRIVATE;
+    }
+    else {
+	ossl_raise(rb_eArgError, "unsupported format %"PRIsVALUE, kwargs[0]);
+    }
+}
+
+/*
+ * call-seq:
+ *   key.export([cipher, pass_phrase,] format: nil) -> String
+ *   key.to_pem([cipher, pass_phrase,] format: nil) -> String
+ *   key.to_s([cipher, pass_phrase,] format: nil)   -> String
+ *
+ * Encodes the PKey into a PEM string. If +cipher+ and +pass_phrase+ are given,
+ * they will be used to encrypt the key. +cipher+ must be an OpenSSL::Cipher
+ * instance. Note that encryption will only be effective for a private key,
+ * public keys will always be encoded in unencrypted format. The output format
+ * can be specified with +format+. It must be one of these:
+ *
+ * private:: Raw private key format. For example, PKCS #1 RSAPrivateKey format
+ *           for RSA keys, OpenSSL's DSAPrivateKey format for DSA keys, SEC 1
+ *           ECPrivateKey format for EC keys.
+ * public:: X.509 SubjectPublicKeyInfo format.
+ *
+ * When +format+ is not given, the default (:private for PKeys containing private
+ * component, :public otherwise) is used.
+ *
+ * === Examples
+ *  dsa = OpenSSL::PKey::DSA.new(1024) # generates a new key
+ *  dsa.to_pem
+ *  #=> "-----BEGIN DSA PRIVATE KEY-----\n..."
+ *  dsa.to_pem(format: "public")
+ *  #=> "-----BEGIN PUBLIC KEY-----\n..."
+ */
+static VALUE
+ossl_pkey_export(int argc, VALUE *argv, VALUE self)
+{
+    EVP_PKEY *pkey;
+    BIO *out;
+    const EVP_CIPHER *ciph = NULL;
+    VALUE cipher, pass, opts;
+    int ret;
+    enum ossl_pkey_export_format format;
+
+    GetPKey(self, pkey);
+    rb_scan_args(argc, argv, "02:", &cipher, &pass, &opts);
+    format = ossl_pkey_parse_export_format(self, opts);
+    if (!NIL_P(cipher)) {
+	ciph = GetCipherPtr(cipher);
+	pass = ossl_pem_passwd_value(pass);
+    }
+
+    if (!(out = BIO_new(BIO_s_mem())))
+	ossl_raise(ePKeyError, "BIO_new");
+    switch (format) {
+      case OSSL_PKEY_EXPORT_PUBKEY:
+	ret = PEM_write_bio_PUBKEY(out, pkey);
+	break;
+      default:
+	BIO_free(out);
+	rb_notimplement();
+    }
+    if (!ret) {
+	BIO_free(out);
+	ossl_raise(ePKeyError, NULL);
+    }
+
+    return ossl_membio2str(out);
+}
+
+/*
+ * call-seq:
+ *   key.to_der(format: nil) -> String
+ *
+ * Encodes the PKey into a DER string. +format+ is handled in the same way as
+ * #export.
+ */
+static VALUE
+ossl_pkey_to_der(int argc, VALUE *argv, VALUE self)
+{
+    EVP_PKEY *pkey;
+    VALUE cipher, pass, opts, str;
+    enum ossl_pkey_export_format format;
+
+    GetPKey(self, pkey);
+    rb_scan_args(argc, argv, "02:", &cipher, &pass, &opts);
+    format = ossl_pkey_parse_export_format(self, opts);
+
+    switch (format) {
+      case OSSL_PKEY_EXPORT_PUBKEY:
+	ossl_i2d(i2d_PUBKEY, pkey, str);
+	break;
+      default:
+	rb_notimplement();
+    }
+
+    return str;
+}
+
 /*
  * INIT
  */
@@ -398,6 +519,11 @@ Init_ossl_pkey(void)
 
     rb_define_method(cPKey, "sign", ossl_pkey_sign, 2);
     rb_define_method(cPKey, "verify", ossl_pkey_verify, 3);
+
+    rb_define_method(cPKey, "export", ossl_pkey_export, -1);
+    rb_define_alias(cPKey, "to_pem", "export");
+    rb_define_alias(cPKey, "to_s", "export");
+    rb_define_method(cPKey, "to_der", ossl_pkey_to_der, -1);
 
     id_private_q = rb_intern("private?");
 

--- a/ext/openssl/ossl_pkey.c
+++ b/ext/openssl/ossl_pkey.c
@@ -100,27 +100,6 @@ ossl_pkey_new(EVP_PKEY *pkey)
     UNREACHABLE;
 }
 
-VALUE
-ossl_pkey_new_from_file(VALUE filename)
-{
-    FILE *fp;
-    EVP_PKEY *pkey;
-
-    rb_check_safe_obj(filename);
-    if (!(fp = fopen(StringValueCStr(filename), "r"))) {
-	ossl_raise(ePKeyError, "%s", strerror(errno));
-    }
-    rb_fd_fix_cloexec(fileno(fp));
-
-    pkey = PEM_read_PrivateKey(fp, NULL, ossl_pem_passwd_cb, NULL);
-    fclose(fp);
-    if (!pkey) {
-	ossl_raise(ePKeyError, NULL);
-    }
-
-    return ossl_pkey_new(pkey);
-}
-
 /*
  *  call-seq:
  *     OpenSSL::PKey.read(string [, pwd ] ) -> PKey

--- a/ext/openssl/ossl_pkey.c
+++ b/ext/openssl/ossl_pkey.c
@@ -300,6 +300,7 @@ ossl_pkey_verify(VALUE self, VALUE digest, VALUE sig, VALUE data)
     EVP_MD_CTX_free(ctx);
     switch (result) {
     case 0:
+	ossl_clear_error();
 	return Qfalse;
     case 1:
 	return Qtrue;

--- a/ext/openssl/ossl_pkey.h
+++ b/ext/openssl/ossl_pkey.h
@@ -48,7 +48,6 @@ int ossl_generate_cb_2(int p, int n, BN_GENCB *cb);
 void ossl_generate_cb_stop(void *ptr);
 
 VALUE ossl_pkey_new(EVP_PKEY *);
-VALUE ossl_pkey_new_from_file(VALUE);
 EVP_PKEY *GetPKeyPtr(VALUE);
 EVP_PKEY *DupPKeyPtr(VALUE);
 EVP_PKEY *GetPrivPKeyPtr(VALUE);

--- a/ext/openssl/ossl_pkey.h
+++ b/ext/openssl/ossl_pkey.h
@@ -47,6 +47,20 @@ struct ossl_generate_cb_arg {
 int ossl_generate_cb_2(int p, int n, BN_GENCB *cb);
 void ossl_generate_cb_stop(void *ptr);
 
+enum ossl_pkey_export_format {
+    /*
+     * X.509 SubjectPublicKeyInfo format. The default format for PKeys
+     * containing only public data.
+     */
+    OSSL_PKEY_EXPORT_PUBKEY,
+    /*
+     * PKCS #1 RSAPrivateKey, OpenSSL's DSAPrivateKey or SEC 1 ECPrivateKey
+     * format. The default format for PKeys containing a private key.
+     */
+    OSSL_PKEY_EXPORT_PRIVATE,
+};
+enum ossl_pkey_export_format ossl_pkey_parse_export_format(VALUE, VALUE);
+
 VALUE ossl_pkey_new(EVP_PKEY *);
 EVP_PKEY *GetPKeyPtr(VALUE);
 EVP_PKEY *DupPKeyPtr(VALUE);

--- a/ext/openssl/ossl_pkey_dh.c
+++ b/ext/openssl/ossl_pkey_dh.c
@@ -356,18 +356,10 @@ static VALUE
 ossl_dh_to_der(VALUE self)
 {
     DH *dh;
-    unsigned char *p;
-    long len;
     VALUE str;
 
     GetDH(self, dh);
-    if((len = i2d_DHparams(dh, NULL)) <= 0)
-	ossl_raise(eDHError, NULL);
-    str = rb_str_new(0, len);
-    p = (unsigned char *)RSTRING_PTR(str);
-    if(i2d_DHparams(dh, &p) < 0)
-	ossl_raise(eDHError, NULL);
-    ossl_str_adjust(str, p);
+    ossl_i2d(i2d_DHparams, dh, str);
 
     return str;
 }

--- a/ext/openssl/ossl_pkey_dsa.c
+++ b/ext/openssl/ossl_pkey_dsa.c
@@ -387,27 +387,16 @@ static VALUE
 ossl_dsa_to_der(VALUE self)
 {
     DSA *dsa;
-    int (*i2d_func)(DSA *, unsigned char **);
-    unsigned char *p;
-    long len;
     VALUE str;
 
     GetDSA(self, dsa);
-    if(DSA_HAS_PRIVATE(dsa))
-	i2d_func = (int (*)(DSA *,unsigned char **))i2d_DSAPrivateKey;
+    if (DSA_HAS_PRIVATE(dsa))
+	ossl_i2d(i2d_DSAPrivateKey, dsa, str);
     else
-	i2d_func = i2d_DSA_PUBKEY;
-    if((len = i2d_func(dsa, NULL)) <= 0)
-	ossl_raise(eDSAError, NULL);
-    str = rb_str_new(0, len);
-    p = (unsigned char *)RSTRING_PTR(str);
-    if(i2d_func(dsa, &p) < 0)
-	ossl_raise(eDSAError, NULL);
-    ossl_str_adjust(str, p);
+	ossl_i2d(i2d_DSA_PUBKEY, dsa, str);
 
     return str;
 }
-
 
 /*
  *  call-seq:

--- a/ext/openssl/ossl_pkey_rsa.c
+++ b/ext/openssl/ossl_pkey_rsa.c
@@ -383,23 +383,13 @@ static VALUE
 ossl_rsa_to_der(VALUE self)
 {
     RSA *rsa;
-    int (*i2d_func)(const RSA *, unsigned char **);
-    unsigned char *p;
-    long len;
     VALUE str;
 
     GetRSA(self, rsa);
     if (RSA_HAS_PRIVATE(rsa))
-	i2d_func = i2d_RSAPrivateKey;
+	ossl_i2d(i2d_RSAPrivateKey, rsa, str);
     else
-	i2d_func = (int (*)(const RSA *, unsigned char **))i2d_RSA_PUBKEY;
-    if((len = i2d_func(rsa, NULL)) <= 0)
-	ossl_raise(eRSAError, NULL);
-    str = rb_str_new(0, len);
-    p = (unsigned char *)RSTRING_PTR(str);
-    if(i2d_func(rsa, &p) < 0)
-	ossl_raise(eRSAError, NULL);
-    ossl_str_adjust(str, p);
+	ossl_i2d(i2d_RSA_PUBKEY, rsa, str);
 
     return str;
 }

--- a/ext/openssl/ossl_ssl_session.c
+++ b/ext/openssl/ossl_ssl_session.c
@@ -240,24 +240,16 @@ static VALUE ossl_ssl_session_get_id(VALUE self)
  *
  * Returns an ASN1 encoded String that contains the Session object.
 */
-static VALUE ossl_ssl_session_to_der(VALUE self)
+static VALUE
+ossl_ssl_session_to_der(VALUE self)
 {
-	SSL_SESSION *ctx;
-	unsigned char *p;
-	int len;
-	VALUE str;
+    SSL_SESSION *ctx;
+    VALUE str;
 
-	GetSSLSession(self, ctx);
-	len = i2d_SSL_SESSION(ctx, NULL);
-	if (len <= 0) {
-		ossl_raise(eSSLSession, "i2d_SSL_SESSION");
-	}
+    GetSSLSession(self, ctx);
+    ossl_i2d(i2d_SSL_SESSION, ctx, str);
 
-	str = rb_str_new(0, len);
-	p = (unsigned char *)RSTRING_PTR(str);
-	i2d_SSL_SESSION(ctx, &p);
-	ossl_str_adjust(str, p);
-	return str;
+    return str;
 }
 
 /*

--- a/ext/openssl/ossl_x509attr.c
+++ b/ext/openssl/ossl_x509attr.c
@@ -287,17 +287,9 @@ ossl_x509attr_to_der(VALUE self)
 {
     X509_ATTRIBUTE *attr;
     VALUE str;
-    int len;
-    unsigned char *p;
 
     GetX509Attr(self, attr);
-    if((len = i2d_X509_ATTRIBUTE(attr, NULL)) <= 0)
-	ossl_raise(eX509AttrError, NULL);
-    str = rb_str_new(0, len);
-    p = (unsigned char *)RSTRING_PTR(str);
-    if(i2d_X509_ATTRIBUTE(attr, &p) <= 0)
-	ossl_raise(eX509AttrError, NULL);
-    ossl_str_adjust(str, p);
+    ossl_i2d(i2d_X509_ATTRIBUTE, attr, str);
 
     return str;
 }

--- a/ext/openssl/ossl_x509cert.c
+++ b/ext/openssl/ossl_x509cert.c
@@ -204,17 +204,9 @@ ossl_x509_to_der(VALUE self)
 {
     X509 *x509;
     VALUE str;
-    long len;
-    unsigned char *p;
 
     GetX509(self, x509);
-    if ((len = i2d_X509(x509, NULL)) <= 0)
-	ossl_raise(eX509CertError, NULL);
-    str = rb_str_new(0, len);
-    p = (unsigned char *)RSTRING_PTR(str);
-    if (i2d_X509(x509, &p) <= 0)
-	ossl_raise(eX509CertError, NULL);
-    ossl_str_adjust(str, p);
+    ossl_i2d(i2d_X509, x509, str);
 
     return str;
 }

--- a/ext/openssl/ossl_x509crl.c
+++ b/ext/openssl/ossl_x509crl.c
@@ -382,21 +382,10 @@ static VALUE
 ossl_x509crl_to_der(VALUE self)
 {
     X509_CRL *crl;
-    BIO *out;
-    BUF_MEM *buf;
     VALUE str;
 
     GetX509CRL(self, crl);
-    if (!(out = BIO_new(BIO_s_mem()))) {
-	ossl_raise(eX509CRLError, NULL);
-    }
-    if (!i2d_X509_CRL_bio(out, crl)) {
-	BIO_free(out);
-	ossl_raise(eX509CRLError, NULL);
-    }
-    BIO_get_mem_ptr(out, &buf);
-    str = rb_str_new(buf->data, buf->length);
-    BIO_free(out);
+    ossl_i2d(i2d_X509_CRL, crl, str);
 
     return str;
 }

--- a/ext/openssl/ossl_x509ext.c
+++ b/ext/openssl/ossl_x509ext.c
@@ -443,18 +443,10 @@ static VALUE
 ossl_x509ext_to_der(VALUE obj)
 {
     X509_EXTENSION *ext;
-    unsigned char *p;
-    long len;
     VALUE str;
 
     GetX509Ext(obj, ext);
-    if((len = i2d_X509_EXTENSION(ext, NULL)) <= 0)
-	ossl_raise(eX509ExtError, NULL);
-    str = rb_str_new(0, len);
-    p = (unsigned char *)RSTRING_PTR(str);
-    if(i2d_X509_EXTENSION(ext, &p) < 0)
-	ossl_raise(eX509ExtError, NULL);
-    ossl_str_adjust(str, p);
+    ossl_i2d(i2d_X509_EXTENSION, ext, str);
 
     return str;
 }

--- a/ext/openssl/ossl_x509name.c
+++ b/ext/openssl/ossl_x509name.c
@@ -435,17 +435,9 @@ ossl_x509name_to_der(VALUE self)
 {
     X509_NAME *name;
     VALUE str;
-    long len;
-    unsigned char *p;
 
     GetX509Name(self, name);
-    if((len = i2d_X509_NAME(name, NULL)) <= 0)
-	ossl_raise(eX509NameError, NULL);
-    str = rb_str_new(0, len);
-    p = (unsigned char *)RSTRING_PTR(str);
-    if(i2d_X509_NAME(name, &p) <= 0)
-	ossl_raise(eX509NameError, NULL);
-    ossl_str_adjust(str, p);
+    ossl_i2d(i2d_X509_NAME, name, str);
 
     return str;
 }

--- a/ext/openssl/ossl_x509req.c
+++ b/ext/openssl/ossl_x509req.c
@@ -183,17 +183,9 @@ ossl_x509req_to_der(VALUE self)
 {
     X509_REQ *req;
     VALUE str;
-    long len;
-    unsigned char *p;
 
     GetX509Req(self, req);
-    if ((len = i2d_X509_REQ(req, NULL)) <= 0)
-	ossl_raise(eX509ReqError, NULL);
-    str = rb_str_new(0, len);
-    p = (unsigned char *)RSTRING_PTR(str);
-    if (i2d_X509_REQ(req, &p) <= 0)
-	ossl_raise(eX509ReqError, NULL);
-    ossl_str_adjust(str, p);
+    ossl_i2d(i2d_X509_REQ, req, str);
 
     return str;
 }

--- a/test/test_pkey.rb
+++ b/test/test_pkey.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: false
+require_relative "utils"
+
+if defined?(OpenSSL::TestUtils)
+
+class OpenSSL::TestPKey < OpenSSL::PKeyTestCase
+  PKEYS = {
+    OpenSSL::PKey::RSA => {
+      key: OpenSSL::TestUtils::TEST_KEY_RSA1024,
+      digest: OpenSSL::Digest::SHA1,
+    },
+    OpenSSL::PKey::DSA => {
+      key: OpenSSL::TestUtils::TEST_KEY_DSA512,
+      digest: OpenSSL::Digest::SHA1,
+    },
+  }
+  PKEYS[OpenSSL::PKey::EC] = {
+    key: OpenSSL::TestUtils::TEST_KEY_EC_P256V1,
+    digest: OpenSSL::TestUtils::DSA_SIGNATURE_DIGEST,
+  } if defined?(OpenSSL::PKey::EC)
+
+  def test_sign_verify
+    data = "Sign me!"
+    invalid_data = "Sign me?"
+    PKEYS.each do |klass, prop|
+      key = prop[:key]
+      pub_key = dup_public(prop[:key])
+      digest = prop[:digest].new
+      signature = key.sign(digest, data)
+      assert_equal(true, pub_key.verify(digest, signature, data))
+      assert_equal(false, pub_key.verify(digest, signature, invalid_data))
+      # digest state is irrelevant
+      digest << "unya"
+      assert_equal(true, pub_key.verify(digest, signature, data))
+      assert_equal(false, pub_key.verify(digest, signature, invalid_data))
+
+      if OpenSSL::OPENSSL_VERSION_NUMBER > 0x10000000
+        digest = OpenSSL::Digest::SHA256.new
+        signature = key.sign(digest, data)
+        assert_equal(true, pub_key.verify(digest, signature, data))
+        assert_equal(false, pub_key.verify(digest, signature, invalid_data))
+      end
+    end
+  end
+end
+
+end

--- a/test/test_pkey_dh.rb
+++ b/test/test_pkey_dh.rb
@@ -8,28 +8,17 @@ class OpenSSL::TestPKeyDH < OpenSSL::TestCase
   NEW_KEYLEN = 256
 
   def test_DEFAULT_1024
-    params = <<-eop
------BEGIN DH PARAMETERS-----
-MIGHAoGBAJ0lOVy0VIr/JebWn0zDwY2h+rqITFOpdNr6ugsgvkDXuucdcChhYExJ
-AV/ZD2AWPbrTqV76mGRgJg4EddgT1zG0jq3rnFdMj2XzkBYx3BVvfR0Arnby0RHR
-T4h7KZ/2zmjvV+eF8kBUHBJAojUlzxKj4QeO2x20FP9X5xmNUXeDAgEC
------END DH PARAMETERS-----
-    eop
-    assert_equal params, OpenSSL::PKey::DH::DEFAULT_1024.to_s
+    assert_equal(1024, OpenSSL::PKey::DH::DEFAULT_1024.p.num_bits)
+    assert_predicate(OpenSSL::PKey::DH::DEFAULT_1024.p, :prime_fasttest?)
+    assert_equal(nil, OpenSSL::PKey::DH::DEFAULT_1024.priv_key)
+    assert_equal(nil, OpenSSL::PKey::DH::DEFAULT_1024.pub_key)
   end
 
   def test_DEFAULT_2048
-    params = <<-eop
------BEGIN DH PARAMETERS-----
-MIIBCAKCAQEA7E6kBrYiyvmKAMzQ7i8WvwVk9Y/+f8S7sCTN712KkK3cqd1jhJDY
-JbrYeNV3kUIKhPxWHhObHKpD1R84UpL+s2b55+iMd6GmL7OYmNIT/FccKhTcveab
-VBmZT86BZKYyf45hUF9FOuUM9xPzuK3Vd8oJQvfYMCd7LPC0taAEljQLR4Edf8E6
-YoaOffgTf5qxiwkjnlVZQc3whgnEt9FpVMvQ9eknyeGB5KHfayAc3+hUAvI3/Cr3
-1bNveX5wInh5GDx1FGhKBZ+s1H+aedudCm7sCgRwv8lKWYGiHzObSma8A86KG+MD
-7Lo5JquQ3DlBodj3IDyPrxIv96lvRPFtAwIBAg==
------END DH PARAMETERS-----
-    eop
-    assert_equal params, OpenSSL::PKey::DH::DEFAULT_2048.to_s
+    assert_equal(2048, OpenSSL::PKey::DH::DEFAULT_2048.p.num_bits)
+    assert_predicate(OpenSSL::PKey::DH::DEFAULT_2048.p, :prime_fasttest?)
+    assert_equal(nil, OpenSSL::PKey::DH::DEFAULT_2048.priv_key)
+    assert_equal(nil, OpenSSL::PKey::DH::DEFAULT_2048.pub_key)
   end
 
   def test_new

--- a/test/test_pkey_dsa.rb
+++ b/test/test_pkey_dsa.rb
@@ -4,7 +4,9 @@ require 'base64'
 
 if defined?(OpenSSL::TestUtils)
 
-class OpenSSL::TestPKeyDSA < OpenSSL::TestCase
+class OpenSSL::TestPKeyDSA < OpenSSL::PKeyTestCase
+  DSA512 = OpenSSL::TestUtils::TEST_KEY_DSA512
+
   def test_private
     key = OpenSSL::PKey::DSA.new(256)
     assert(key.private?)
@@ -63,29 +65,102 @@ end
     assert(key.verify(digest2, sig, data))
   end
 
-  def test_read_DSA_PUBKEY
-    p = 7188211954100152441468596248707152960171255279130004340103875772401008316444412091945435731597638374542374929457672178957081124632837356913990200866056699
-    q = 957032439192465935099784319494405376402293318491
-    g = 122928973717064636255205666162891733518376475981809749897454444301389338825906076467196186192907631719698166056821519884939865041993585844526937010746285
-    y = 1235756183583465414789073313502727057075641172514181938731172021825149551960029708596057102104063395063907739571546165975727369183495540798749742124846271
-    algo = OpenSSL::ASN1::ObjectId.new('DSA')
-    params = OpenSSL::ASN1::Sequence.new([OpenSSL::ASN1::Integer.new(p),
-                                          OpenSSL::ASN1::Integer.new(q),
-                                          OpenSSL::ASN1::Integer.new(g)])
-    algo_id = OpenSSL::ASN1::Sequence.new ([algo, params])
-    pub_key = OpenSSL::ASN1::Integer.new(y)
-    seq = OpenSSL::ASN1::Sequence.new([algo_id, OpenSSL::ASN1::BitString.new(pub_key.to_der)])
-    key = OpenSSL::PKey::DSA.new(seq.to_der)
-    assert(key.public?)
-    assert(!key.private?)
-    assert_equal(p, key.p)
-    assert_equal(q, key.q)
-    assert_equal(g, key.g)
-    assert_equal(y, key.pub_key)
-    assert_equal(nil, key.priv_key)
+  def test_DSAPrivateKey
+    # OpenSSL DSAPrivateKey format; similar to RSAPrivateKey
+    asn1 = OpenSSL::ASN1::Sequence([
+      OpenSSL::ASN1::Integer(0),
+      OpenSSL::ASN1::Integer(DSA512.p),
+      OpenSSL::ASN1::Integer(DSA512.q),
+      OpenSSL::ASN1::Integer(DSA512.g),
+      OpenSSL::ASN1::Integer(DSA512.pub_key),
+      OpenSSL::ASN1::Integer(DSA512.priv_key)
+    ])
+    key = OpenSSL::PKey::DSA.new(asn1.to_der)
+    assert_predicate(key, :private?)
+    assert_same_dsa(DSA512, key)
+
+    pem = <<~EOF
+    -----BEGIN DSA PRIVATE KEY-----
+    MIH4AgEAAkEA5lB4GvEwjrsMlGDqGsxrbqeFRh6o9OWt6FgTYiEEHaOYhkIxv0Ok
+    RZPDNwOG997mDjBnvDJ1i56OmS3MbTnovwIVAJgub/aDrSDB4DZGH7UyarcaGy6D
+    AkB9HdFw/3td8K4l1FZHv7TCZeJ3ZLb7dF3TWoGUP003RCqoji3/lHdKoVdTQNuR
+    S/m6DlCwhjRjiQ/lBRgCLCcaAkEAjN891JBjzpMj4bWgsACmMggFf57DS0Ti+5++
+    Q1VB8qkJN7rA7/2HrCR3gTsWNb1YhAsnFsoeRscC+LxXoXi9OAIUBG98h4tilg6S
+    55jreJD3Se3slps=
+    -----END DSA PRIVATE KEY-----
+    EOF
+    key = OpenSSL::PKey::DSA.new(pem)
+    assert_same_dsa(DSA512, key)
+
+    assert_equal(asn1.to_der, DSA512.to_der)
+    assert_equal(pem, DSA512.export)
+  end
+
+  def test_DSAPrivateKey_encrypted
+    # key = abcdef
+    pem = <<~EOF
+    -----BEGIN DSA PRIVATE KEY-----
+    Proc-Type: 4,ENCRYPTED
+    DEK-Info: AES-128-CBC,F8BB7BFC7EAB9118AC2E3DA16C8DB1D9
+
+    D2sIzsM9MLXBtlF4RW42u2GB9gX3HQ3prtVIjWPLaKBYoToRUiv8WKsjptfZuLSB
+    74ZPdMS7VITM+W1HIxo/tjS80348Cwc9ou8H/E6WGat8ZUk/igLOUEII+coQS6qw
+    QpuLMcCIavevX0gjdjEIkojBB81TYDofA1Bp1z1zDI/2Zhw822xapI79ZF7Rmywt
+    OSyWzFaGipgDpdFsGzvT6//z0jMr0AuJVcZ0VJ5lyPGQZAeVBlbYEI4T72cC5Cz7
+    XvLiaUtum6/sASD2PQqdDNpgx/WA6Vs1Po2kIUQIM5TIwyJI0GdykZcYm6xIK/ta
+    Wgx6c8K+qBAIVrilw3EWxw==
+    -----END DSA PRIVATE KEY-----
+    EOF
+    key = OpenSSL::PKey::DSA.new(pem, "abcdef")
+    assert_same_dsa(DSA512, key)
+    key = OpenSSL::PKey::DSA.new(pem) { "abcdef" }
+    assert_same_dsa(DSA512, key)
+
+    cipher = OpenSSL::Cipher.new("aes-128-cbc")
+    exported = DSA512.to_pem(cipher, "abcdef\0\1")
+    assert_same_dsa(DSA512, OpenSSL::PKey::DSA.new(exported, "abcdef\0\1"))
+    assert_raise(OpenSSL::PKey::DSAError) {
+      OpenSSL::PKey::DSA.new(exported, "abcdef")
+    }
+  end
+
+  def test_PUBKEY
+    asn1 = OpenSSL::ASN1::Sequence([
+      OpenSSL::ASN1::Sequence([
+        OpenSSL::ASN1::ObjectId("DSA"),
+        OpenSSL::ASN1::Sequence([
+          OpenSSL::ASN1::Integer(DSA512.p),
+          OpenSSL::ASN1::Integer(DSA512.q),
+          OpenSSL::ASN1::Integer(DSA512.g)
+        ])
+      ]),
+      OpenSSL::ASN1::BitString(
+        OpenSSL::ASN1::Integer(DSA512.pub_key).to_der
+      )
+    ])
+    key = OpenSSL::PKey::DSA.new(asn1.to_der)
+    assert_not_predicate(key, :private?)
+    assert_same_dsa(dup_public(DSA512), key)
+
+    pem = <<~EOF
+    -----BEGIN PUBLIC KEY-----
+    MIHxMIGoBgcqhkjOOAQBMIGcAkEA5lB4GvEwjrsMlGDqGsxrbqeFRh6o9OWt6FgT
+    YiEEHaOYhkIxv0OkRZPDNwOG997mDjBnvDJ1i56OmS3MbTnovwIVAJgub/aDrSDB
+    4DZGH7UyarcaGy6DAkB9HdFw/3td8K4l1FZHv7TCZeJ3ZLb7dF3TWoGUP003RCqo
+    ji3/lHdKoVdTQNuRS/m6DlCwhjRjiQ/lBRgCLCcaA0QAAkEAjN891JBjzpMj4bWg
+    sACmMggFf57DS0Ti+5++Q1VB8qkJN7rA7/2HrCR3gTsWNb1YhAsnFsoeRscC+LxX
+    oXi9OA==
+    -----END PUBLIC KEY-----
+    EOF
+    key = OpenSSL::PKey::DSA.new(pem)
+    assert_same_dsa(dup_public(DSA512), key)
+
+    assert_equal(asn1.to_der, dup_public(DSA512).to_der)
+    assert_equal(pem, dup_public(DSA512).export)
   end
 
   def test_read_DSAPublicKey_pem
+    # TODO: where is the standard? PKey::DSA.new can read only PEM
     p = 12260055936871293565827712385212529106400444521449663325576634579961635627321079536132296996623400607469624537382977152381984332395192110731059176842635699
     q = 979494906553787301107832405790107343409973851677
     g = 3731695366899846297271147240305742456317979984190506040697507048095553842519347835107669437969086119948785140453492839427038591924536131566350847469993845
@@ -109,127 +184,6 @@ fWLOqqkzFeRrYMDzUpl36XktY6Yq8EJYlW9pCMmBVNy/dQ==
     assert_equal(nil, key.priv_key)
   end
 
-  def test_read_DSA_PUBKEY_pem
-    p = 12260055936871293565827712385212529106400444521449663325576634579961635627321079536132296996623400607469624537382977152381984332395192110731059176842635699
-    q = 979494906553787301107832405790107343409973851677
-    g = 3731695366899846297271147240305742456317979984190506040697507048095553842519347835107669437969086119948785140453492839427038591924536131566350847469993845
-    y = 10505239074982761504240823422422813362721498896040719759460296306305851824586095328615844661273887569281276387605297130014564808567159023649684010036304695
-    pem = <<-EOF
------BEGIN PUBLIC KEY-----
-MIHxMIGoBgcqhkjOOAQBMIGcAkEA6hXntfQXEo78+s1r8yShbOQIpX+HOESnTNsV
-2yJzD6EiMntLpJ38WUOWjz0dBnYW69YnrAYszWPTSvf34XapswIVAKuSEhdIb6Kz
-fuHPUhoF4S52MHYdAkBHQCWhq8G+2yeDyhuyMtvsQqcH6lJ4ev8F0hDdUft9Ys6q
-qTMV5GtgwPNSmXfpeS1jpirwQliVb2kIyYFU3L91A0QAAkEAyJSJ+g+P/knVcgDw
-wTzC7Pwg/pWs2EMd/r+lYlXhNfzg0biuXRul8VR4VUC/phySExY0PdcqItkR/xYA
-YNMbNw==
------END PUBLIC KEY-----
-    EOF
-    key = OpenSSL::PKey::DSA.new(pem)
-    assert(key.public?)
-    assert(!key.private?)
-    assert_equal(p, key.p)
-    assert_equal(q, key.q)
-    assert_equal(g, key.g)
-    assert_equal(y, key.pub_key)
-    assert_equal(nil, key.priv_key)
-  end
-
-  def test_export_format_is_DSA_PUBKEY_pem
-    key = OpenSSL::TestUtils::TEST_KEY_DSA256
-    pem = key.public_key.to_pem
-    pem.gsub!(/^-+(\w|\s)+-+$/, "") # eliminate --------BEGIN...-------
-    asn1 = OpenSSL::ASN1.decode(Base64.decode64(pem))
-    assert_equal(OpenSSL::ASN1::SEQUENCE, asn1.tag)
-    assert_equal(2, asn1.value.size)
-    seq = asn1.value
-    assert_equal(OpenSSL::ASN1::SEQUENCE, seq[0].tag)
-    assert_equal(2, seq[0].value.size)
-    algo_id = seq[0].value
-    assert_equal(OpenSSL::ASN1::OBJECT, algo_id[0].tag)
-    assert_equal('DSA', algo_id[0].value)
-    assert_equal(OpenSSL::ASN1::SEQUENCE, algo_id[1].tag)
-    assert_equal(3, algo_id[1].value.size)
-    params = algo_id[1].value
-    assert_equal(OpenSSL::ASN1::INTEGER, params[0].tag)
-    assert_equal(key.p, params[0].value)
-    assert_equal(OpenSSL::ASN1::INTEGER, params[1].tag)
-    assert_equal(key.q, params[1].value)
-    assert_equal(OpenSSL::ASN1::INTEGER, params[2].tag)
-    assert_equal(key.g, params[2].value)
-    assert_equal(OpenSSL::ASN1::BIT_STRING, seq[1].tag)
-    assert_equal(0, seq[1].unused_bits)
-    pub_key = OpenSSL::ASN1.decode(seq[1].value)
-    assert_equal(OpenSSL::ASN1::INTEGER, pub_key.tag)
-    assert_equal(key.pub_key, pub_key.value)
-  end
-
-  def test_read_private_key_der
-    key = OpenSSL::TestUtils::TEST_KEY_DSA256
-    der = key.to_der
-    key2 = OpenSSL::PKey.read(der)
-    assert(key2.private?)
-    assert_equal(der, key2.to_der)
-  end
-
-  def test_read_private_key_pem
-    key = OpenSSL::TestUtils::TEST_KEY_DSA256
-    pem = key.to_pem
-    key2 = OpenSSL::PKey.read(pem)
-    assert(key2.private?)
-    assert_equal(pem, key2.to_pem)
-  end
-
-  def test_read_public_key_der
-    key = OpenSSL::TestUtils::TEST_KEY_DSA256.public_key
-    der = key.to_der
-    key2 = OpenSSL::PKey.read(der)
-    assert(!key2.private?)
-    assert_equal(der, key2.to_der)
-  end
-
-  def test_read_public_key_pem
-    key = OpenSSL::TestUtils::TEST_KEY_DSA256.public_key
-    pem = key.to_pem
-    key2 = OpenSSL::PKey.read(pem)
-    assert(!key2.private?)
-    assert_equal(pem, key2.to_pem)
-  end
-
-  def test_read_private_key_pem_pw
-    key = OpenSSL::TestUtils::TEST_KEY_DSA256
-    pem = key.to_pem(OpenSSL::Cipher.new('AES-128-CBC'), 'secret')
-    #callback form for password
-    key2 = OpenSSL::PKey.read(pem) do
-      'secret'
-    end
-    assert(key2.private?)
-    # pass password directly
-    key2 = OpenSSL::PKey.read(pem, 'secret')
-    assert(key2.private?)
-    #omit pem equality check, will be different due to cipher iv
-  end
-
-  def test_export_password_length
-    key = OpenSSL::TestUtils::TEST_KEY_DSA256
-    assert_raise(OpenSSL::OpenSSLError) do
-      key.export(OpenSSL::Cipher.new('AES-128-CBC'), 'sec')
-    end
-    pem = key.export(OpenSSL::Cipher.new('AES-128-CBC'), 'secr')
-    assert(pem)
-  end
-
-  def test_export_password_funny
-    key = OpenSSL::TestUtils::TEST_KEY_DSA256
-    pem = key.export(OpenSSL::Cipher.new('AES-128-CBC'), "pass\0wd")
-    assert_raise(OpenSSL::PKey::PKeyError) do
-      OpenSSL::PKey.read(pem, "pass")
-    end
-    key2 = OpenSSL::PKey.read(pem, "pass\0wd")
-    assert(key2.private?)
-    key3 = OpenSSL::PKey::DSA.new(pem, "pass\0wd")
-    assert(key3.private?)
-  end
-
   def test_dup
     key = OpenSSL::PKey::DSA.new(256)
     key2 = key.dup
@@ -239,12 +193,15 @@ YNMbNw==
   end
 
   private
-
   def check_sign_verify(digest)
     key = OpenSSL::TestUtils::TEST_KEY_DSA256
     data = 'Sign me!'
     sig = key.sign(digest, data)
     assert(key.verify(digest, sig, data))
+  end
+
+  def assert_same_dsa(expected, key)
+    check_component(expected, key, [:p, :q, :g, :pub_key, :priv_key])
   end
 end
 

--- a/test/test_pkey_dsa.rb
+++ b/test/test_pkey_dsa.rb
@@ -39,32 +39,6 @@ class OpenSSL::TestPKeyDSA < OpenSSL::PKeyTestCase
     assert(key.sysverify(digest, sig))
   end
 
-  def test_sign_verify
-    check_sign_verify(OpenSSL::Digest::DSS1.new)
-  end if defined?(OpenSSL::Digest::DSS1)
-
-if (OpenSSL::OPENSSL_VERSION_NUMBER > 0x10000000)
-  def test_sign_verify_sha1
-    check_sign_verify(OpenSSL::Digest::SHA1.new)
-  end
-
-  def test_sign_verify_sha256
-    check_sign_verify(OpenSSL::Digest::SHA256.new)
-  end
-end
-
-  def test_digest_state_irrelevant_verify
-    key = OpenSSL::TestUtils::TEST_KEY_DSA256
-    digest1 = OpenSSL::TestUtils::DSA_SIGNATURE_DIGEST.new
-    digest2 = OpenSSL::TestUtils::DSA_SIGNATURE_DIGEST.new
-    data = 'Sign me!'
-    sig = key.sign(digest1, data)
-    digest1.reset
-    digest1 << 'Change state of digest1'
-    assert(key.verify(digest1, sig, data))
-    assert(key.verify(digest2, sig, data))
-  end
-
   def test_DSAPrivateKey
     # OpenSSL DSAPrivateKey format; similar to RSAPrivateKey
     asn1 = OpenSSL::ASN1::Sequence([
@@ -193,13 +167,6 @@ fWLOqqkzFeRrYMDzUpl36XktY6Yq8EJYlW9pCMmBVNy/dQ==
   end
 
   private
-  def check_sign_verify(digest)
-    key = OpenSSL::TestUtils::TEST_KEY_DSA256
-    data = 'Sign me!'
-    sig = key.sign(digest, data)
-    assert(key.verify(digest, sig, data))
-  end
-
   def assert_same_dsa(expected, key)
     check_component(expected, key, [:p, :q, :g, :pub_key, :priv_key])
   end

--- a/test/test_pkey_dsa.rb
+++ b/test/test_pkey_dsa.rb
@@ -67,7 +67,15 @@ class OpenSSL::TestPKeyDSA < OpenSSL::PKeyTestCase
     assert_same_dsa(DSA512, key)
 
     assert_equal(asn1.to_der, DSA512.to_der)
+    assert_equal(asn1.to_der, DSA512.to_der(format: :private))
+    assert_raise(OpenSSL::PKey::PKeyError) {
+      dup_public(DSA512).to_der(format: :private)
+    }
     assert_equal(pem, DSA512.export)
+    assert_equal(pem, DSA512.export(format: :private))
+    assert_raise(OpenSSL::PKey::PKeyError) {
+      dup_public(DSA512).export(format: :private)
+    }
   end
 
   def test_DSAPrivateKey_encrypted
@@ -130,7 +138,9 @@ class OpenSSL::TestPKeyDSA < OpenSSL::PKeyTestCase
     assert_same_dsa(dup_public(DSA512), key)
 
     assert_equal(asn1.to_der, dup_public(DSA512).to_der)
+    assert_equal(asn1.to_der, DSA512.to_der(format: :public))
     assert_equal(pem, dup_public(DSA512).export)
+    assert_equal(pem, DSA512.export(format: :public))
   end
 
   def test_read_DSAPublicKey_pem

--- a/test/test_pkey_ec.rb
+++ b/test/test_pkey_ec.rb
@@ -201,7 +201,15 @@ class OpenSSL::TestEC < OpenSSL::PKeyTestCase
     assert_same_ec(P256, key)
 
     assert_equal(asn1.to_der, P256.to_der)
+    assert_equal(asn1.to_der, P256.to_der(format: :private))
+    assert_raise(OpenSSL::PKey::PKeyError) {
+      dup_public(P256).to_der(format: :private)
+    }
     assert_equal(pem, P256.export)
+    assert_equal(pem, P256.export(format: :private))
+    assert_raise(OpenSSL::PKey::PKeyError) {
+      dup_public(P256).export(format: :private)
+    }
   end
 
   def test_ECPrivateKey_encrypted
@@ -253,7 +261,9 @@ class OpenSSL::TestEC < OpenSSL::PKeyTestCase
     assert_same_ec(dup_public(P256), key)
 
     assert_equal(asn1.to_der, dup_public(P256).to_der)
+    assert_equal(asn1.to_der, P256.to_der(format: :public))
     assert_equal(pem, dup_public(P256).export)
+    assert_equal(pem, P256.export(format: :public))
   end
 
   def test_ec_point_mul

--- a/test/test_pkey_rsa.rb
+++ b/test/test_pkey_rsa.rb
@@ -160,7 +160,15 @@ class OpenSSL::TestPKeyRSA < OpenSSL::PKeyTestCase
     assert_same_rsa(RSA1024, key)
 
     assert_equal(asn1.to_der, RSA1024.to_der)
+    assert_equal(asn1.to_der, RSA1024.to_der(format: :private))
+    assert_raise(OpenSSL::PKey::PKeyError) {
+      dup_public(RSA1024).to_der(format: :private)
+    }
     assert_equal(pem, RSA1024.export)
+    assert_equal(pem, RSA1024.export(format: :private))
+    assert_raise(OpenSSL::PKey::PKeyError) {
+      dup_public(RSA1024).export(format: :private)
+    }
   end
 
   def test_RSAPrivateKey_encrypted
@@ -247,7 +255,9 @@ class OpenSSL::TestPKeyRSA < OpenSSL::PKeyTestCase
     assert_same_rsa(dup_public(RSA1024), key)
 
     assert_equal(asn1.to_der, dup_public(RSA1024).to_der)
+    assert_equal(asn1.to_der, RSA1024.to_der(format: :public))
     assert_equal(pem, dup_public(RSA1024).export)
+    assert_equal(pem, RSA1024.export(format: :public))
   end
 
   def test_dup

--- a/test/test_pkey_rsa.rb
+++ b/test/test_pkey_rsa.rb
@@ -70,14 +70,6 @@ class OpenSSL::TestPKeyRSA < OpenSSL::PKeyTestCase
     end
   end
 
-  def test_sign_verify
-    key = RSA1024
-    digest = OpenSSL::Digest::SHA1.new
-    data = 'Sign me!'
-    sig = key.sign(digest, data)
-    assert(key.verify(digest, sig, data))
-  end
-
   def test_sign_verify_memory_leak
     bug9743 = '[ruby-core:62038] [Bug #9743]'
     assert_no_memory_leak(%w[-ropenssl], <<-PREP, <<-CODE, bug9743, rss: true, timeout: 30)

--- a/test/test_pkey_rsa.rb
+++ b/test/test_pkey_rsa.rb
@@ -4,7 +4,9 @@ require 'base64'
 
 if defined?(OpenSSL::TestUtils)
 
-class OpenSSL::TestPKeyRSA < OpenSSL::TestCase
+class OpenSSL::TestPKeyRSA < OpenSSL::PKeyTestCase
+  RSA1024 = OpenSSL::TestUtils::TEST_KEY_RSA1024
+
   def test_padding
     key = OpenSSL::PKey::RSA.new(512, 3)
 
@@ -69,7 +71,7 @@ class OpenSSL::TestPKeyRSA < OpenSSL::TestCase
   end
 
   def test_sign_verify
-    key = OpenSSL::TestUtils::TEST_KEY_RSA1024
+    key = RSA1024
     digest = OpenSSL::Digest::SHA1.new
     data = 'Sign me!'
     sig = key.sign(digest, data)
@@ -107,7 +109,7 @@ class OpenSSL::TestPKeyRSA < OpenSSL::TestCase
   end
 
   def test_digest_state_irrelevant_sign
-    key = OpenSSL::TestUtils::TEST_KEY_RSA1024
+    key = RSA1024
     digest1 = OpenSSL::Digest::SHA1.new
     digest2 = OpenSSL::Digest::SHA1.new
     data = 'Sign me!'
@@ -118,7 +120,7 @@ class OpenSSL::TestPKeyRSA < OpenSSL::TestCase
   end
 
   def test_digest_state_irrelevant_verify
-    key = OpenSSL::TestUtils::TEST_KEY_RSA1024
+    key = RSA1024
     digest1 = OpenSSL::Digest::SHA1.new
     digest2 = OpenSSL::Digest::SHA1.new
     data = 'Sign me!'
@@ -129,169 +131,131 @@ class OpenSSL::TestPKeyRSA < OpenSSL::TestCase
     assert(key.verify(digest2, sig, data))
   end
 
-  def test_read_RSAPublicKey
-    modulus = 10664264882656732240315063514678024569492171560814833397008094754351396057398262071307709191731289492697968568138092052265293364132872019762410446076526351
-    exponent = 65537
-    seq = OpenSSL::ASN1::Sequence.new([OpenSSL::ASN1::Integer.new(modulus), OpenSSL::ASN1::Integer.new(exponent)])
-    key = OpenSSL::PKey::RSA.new(seq.to_der)
-    assert(key.public?)
-    assert(!key.private?)
-    assert_equal(modulus, key.n)
-    assert_equal(exponent, key.e)
-    assert_equal(nil, key.d)
-    assert_equal(nil, key.p)
-    assert_equal(nil, key.q)
-    assert_equal([], OpenSSL.errors)
-  end
+  def test_RSAPrivateKey
+    asn1 = OpenSSL::ASN1::Sequence([
+      OpenSSL::ASN1::Integer(0),
+      OpenSSL::ASN1::Integer(RSA1024.n),
+      OpenSSL::ASN1::Integer(RSA1024.e),
+      OpenSSL::ASN1::Integer(RSA1024.d),
+      OpenSSL::ASN1::Integer(RSA1024.p),
+      OpenSSL::ASN1::Integer(RSA1024.q),
+      OpenSSL::ASN1::Integer(RSA1024.dmp1),
+      OpenSSL::ASN1::Integer(RSA1024.dmq1),
+      OpenSSL::ASN1::Integer(RSA1024.iqmp)
+    ])
+    key = OpenSSL::PKey::RSA.new(asn1.to_der)
+    assert_predicate(key, :private?)
+    assert_same_rsa(RSA1024, key)
 
-  def test_read_RSA_PUBKEY
-    modulus = 10664264882656732240315063514678024569492171560814833397008094754351396057398262071307709191731289492697968568138092052265293364132872019762410446076526351
-    exponent = 65537
-    algo = OpenSSL::ASN1::ObjectId.new('rsaEncryption')
-    null_params = OpenSSL::ASN1::Null.new(nil)
-    algo_id = OpenSSL::ASN1::Sequence.new ([algo, null_params])
-    pub_key = OpenSSL::ASN1::Sequence.new([OpenSSL::ASN1::Integer.new(modulus), OpenSSL::ASN1::Integer.new(exponent)])
-    seq = OpenSSL::ASN1::Sequence.new([algo_id, OpenSSL::ASN1::BitString.new(pub_key.to_der)])
-    key = OpenSSL::PKey::RSA.new(seq.to_der)
-    assert(key.public?)
-    assert(!key.private?)
-    assert_equal(modulus, key.n)
-    assert_equal(exponent, key.e)
-    assert_equal(nil, key.d)
-    assert_equal(nil, key.p)
-    assert_equal(nil, key.q)
-    assert_equal([], OpenSSL.errors)
-  end
-
-  def test_read_RSAPublicKey_pem
-    modulus = 9416340886363418692990906464787534854462163316648195510702927337693641649864839352187127240942127674615733815606532506566068276485089353644309497938966061
-    exponent = 65537
-    pem = <<-EOF
------BEGIN RSA PUBLIC KEY-----
-MEgCQQCzyh2RIZK62E2PbTWqUljD+K23XR9AGBKNtXjal6WD2yRGcLqzPJLNCa60
-AudJR1JobbIbDJrQu6AXnWh5k/YtAgMBAAE=
------END RSA PUBLIC KEY-----
+    pem = <<~EOF
+    -----BEGIN RSA PRIVATE KEY-----
+    MIICXgIBAAKBgQDLwsSw1ECnPtT+PkOgHhcGA71nwC2/nL85VBGnRqDxOqjVh7Cx
+    aKPERYHsk4BPCkE3brtThPWc9kjHEQQ7uf9Y1rbCz0layNqHyywQEVLFmp1cpIt/
+    Q3geLv8ZD9pihowKJDyMDiN6ArYUmZczvW4976MU3+l54E6lF/JfFEU5hwIDAQAB
+    AoGBAKSl/MQarye1yOysqX6P8fDFQt68VvtXkNmlSiKOGuzyho0M+UVSFcs6k1L0
+    maDE25AMZUiGzuWHyaU55d7RXDgeskDMakD1v6ZejYtxJkSXbETOTLDwUWTn618T
+    gnb17tU1jktUtU67xK/08i/XodlgnQhs6VoHTuCh3Hu77O6RAkEA7+gxqBuZR572
+    74/akiW/SuXm0SXPEviyO1MuSRwtI87B02D0qgV8D1UHRm4AhMnJ8MCs1809kMQE
+    JiQUCrp9mQJBANlt2ngBO14us6NnhuAseFDTBzCHXwUUu1YKHpMMmxpnGqaldGgX
+    sOZB3lgJsT9VlGf3YGYdkLTNVbogQKlKpB8CQQDiSwkb4vyQfDe8/NpU5Not0fII
+    8jsDUCb+opWUTMmfbxWRR3FBNu8wnym/m19N4fFj8LqYzHX4KY0oVPu6qvJxAkEA
+    wa5snNekFcqONLIE4G5cosrIrb74sqL8GbGb+KuTAprzj5z1K8Bm0UW9lTjVDjDi
+    qRYgZfZSL+x1P/54+xTFSwJAY1FxA/N3QPCXCjPh5YqFxAMQs2VVYTfg+t0MEcJD
+    dPMQD5JX6g5HKnHFg2mZtoXQrWmJSn7p8GJK8yNTopEErA==
+    -----END RSA PRIVATE KEY-----
     EOF
     key = OpenSSL::PKey::RSA.new(pem)
-    assert(key.public?)
-    assert(!key.private?)
-    assert_equal(modulus, key.n)
-    assert_equal(exponent, key.e)
-    assert_equal(nil, key.d)
-    assert_equal(nil, key.p)
-    assert_equal(nil, key.q)
+    assert_same_rsa(RSA1024, key)
+
+    assert_equal(asn1.to_der, RSA1024.to_der)
+    assert_equal(pem, RSA1024.export)
   end
 
-  def test_read_RSA_PUBKEY_pem
-    modulus = 9416340886363418692990906464787534854462163316648195510702927337693641649864839352187127240942127674615733815606532506566068276485089353644309497938966061
-    exponent = 65537
-    pem = <<-EOF
------BEGIN PUBLIC KEY-----
-MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALPKHZEhkrrYTY9tNapSWMP4rbdd
-H0AYEo21eNqXpYPbJEZwurM8ks0JrrQC50lHUmhtshsMmtC7oBedaHmT9i0C
-AwEAAQ==
------END PUBLIC KEY-----
+  def test_RSAPrivateKey_encrypted
+    # key = abcdef
+    pem = <<~EOF
+    -----BEGIN RSA PRIVATE KEY-----
+    Proc-Type: 4,ENCRYPTED
+    DEK-Info: AES-128-CBC,733F5302505B34701FC41F5C0746E4C0
+
+    zgJniZZQfvv8TFx3LzV6zhAQVayvQVZlAYqFq2yWbbxzF7C+IBhKQle9IhUQ9j/y
+    /jkvol550LS8vZ7TX5WxyDLe12cdqzEvpR6jf3NbxiNysOCxwG4ErhaZGP+krcoB
+    ObuL0nvls/+3myy5reKEyy22+0GvTDjaChfr+FwJjXMG+IBCLscYdgZC1LQL6oAn
+    9xY5DH3W7BW4wR5ttxvtN32TkfVQh8xi3jrLrduUh+hV8DTiAiLIhv0Vykwhep2p
+    WZA+7qbrYaYM8GLLgLrb6LfBoxeNxAEKiTpl1quFkm+Hk1dKq0EhVnxHf92x0zVF
+    jRGZxAMNcrlCoE4f5XK45epVZSZvihdo1k73GPbp84aZ5P/xlO4OwZ3i4uCQXynl
+    jE9c+I+4rRWKyPz9gkkqo0+teJL8ifeKt/3ab6FcdA0aArynqmsKJMktxmNu83We
+    YVGEHZPeOlyOQqPvZqWsLnXQUfg54OkbuV4/4mWSIzxFXdFy/AekSeJugpswMXqn
+    oNck4qySNyfnlyelppXyWWwDfVus9CVAGZmJQaJExHMT/rQFRVchlmY0Ddr5O264
+    gcjv90o1NBOc2fNcqjivuoX7ROqys4K/YdNQ1HhQ7usJghADNOtuLI8ZqMh9akXD
+    Eqp6Ne97wq1NiJj0nt3SJlzTnOyTjzrTe0Y+atPkVKp7SsjkATMI9JdhXwGhWd7a
+    qFVl0owZiDasgEhyG2K5L6r+yaJLYkPVXZYC/wtWC3NEchnDWZGQcXzB4xROCQkD
+    OlWNYDkPiZioeFkA3/fTMvG4moB2Pp9Q4GU5fJ6k43Ccu1up8dX/LumZb4ecg5/x
+    -----END RSA PRIVATE KEY-----
+    EOF
+    key = OpenSSL::PKey::RSA.new(pem, "abcdef")
+    assert_same_rsa(RSA1024, key)
+    key = OpenSSL::PKey::RSA.new(pem) { "abcdef" }
+    assert_same_rsa(RSA1024, key)
+
+    cipher = OpenSSL::Cipher.new("aes-128-cbc")
+    exported = RSA1024.to_pem(cipher, "abcdef\0\1")
+    assert_same_rsa(RSA1024, OpenSSL::PKey::RSA.new(exported, "abcdef\0\1"))
+    assert_raise(OpenSSL::PKey::RSAError) {
+      OpenSSL::PKey::RSA.new(exported, "abcdef")
+    }
+  end
+
+  def test_RSAPublicKey
+    asn1 = OpenSSL::ASN1::Sequence([
+      OpenSSL::ASN1::Integer(RSA1024.n),
+      OpenSSL::ASN1::Integer(RSA1024.e)
+    ])
+    key = OpenSSL::PKey::RSA.new(asn1.to_der)
+    assert_not_predicate(key, :private?)
+    assert_same_rsa(dup_public(RSA1024), key)
+
+    pem = <<~EOF
+    -----BEGIN RSA PUBLIC KEY-----
+    MIGJAoGBAMvCxLDUQKc+1P4+Q6AeFwYDvWfALb+cvzlUEadGoPE6qNWHsLFoo8RF
+    geyTgE8KQTduu1OE9Zz2SMcRBDu5/1jWtsLPSVrI2ofLLBARUsWanVyki39DeB4u
+    /xkP2mKGjAokPIwOI3oCthSZlzO9bj3voxTf6XngTqUX8l8URTmHAgMBAAE=
+    -----END RSA PUBLIC KEY-----
     EOF
     key = OpenSSL::PKey::RSA.new(pem)
-    assert(key.public?)
-    assert(!key.private?)
-    assert_equal(modulus, key.n)
-    assert_equal(exponent, key.e)
-    assert_equal(nil, key.d)
-    assert_equal(nil, key.p)
-    assert_equal(nil, key.q)
+    assert_same_rsa(dup_public(RSA1024), key)
   end
 
-  def test_export_format_is_RSA_PUBKEY
-    key = OpenSSL::PKey::RSA.new(512)
-    asn1 = OpenSSL::ASN1.decode(key.public_key.to_der)
-    check_PUBKEY(asn1, key)
-  end
+  def test_PUBKEY
+    asn1 = OpenSSL::ASN1::Sequence([
+      OpenSSL::ASN1::Sequence([
+        OpenSSL::ASN1::ObjectId("rsaEncryption"),
+        OpenSSL::ASN1::Null(nil)
+      ]),
+      OpenSSL::ASN1::BitString(
+        OpenSSL::ASN1::Sequence([
+          OpenSSL::ASN1::Integer(RSA1024.n),
+          OpenSSL::ASN1::Integer(RSA1024.e)
+        ]).to_der
+      )
+    ])
+    key = OpenSSL::PKey::RSA.new(asn1.to_der)
+    assert_not_predicate(key, :private?)
+    assert_same_rsa(dup_public(RSA1024), key)
 
-  def test_export_format_is_RSA_PUBKEY_pem
-    key = OpenSSL::PKey::RSA.new(512)
-    pem = key.public_key.to_pem
-    pem.gsub!(/^-+(\w|\s)+-+$/, "") # eliminate --------BEGIN...-------
-    asn1 = OpenSSL::ASN1.decode(Base64.decode64(pem))
-    check_PUBKEY(asn1, key)
-  end
+    pem = <<~EOF
+    -----BEGIN PUBLIC KEY-----
+    MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDLwsSw1ECnPtT+PkOgHhcGA71n
+    wC2/nL85VBGnRqDxOqjVh7CxaKPERYHsk4BPCkE3brtThPWc9kjHEQQ7uf9Y1rbC
+    z0layNqHyywQEVLFmp1cpIt/Q3geLv8ZD9pihowKJDyMDiN6ArYUmZczvW4976MU
+    3+l54E6lF/JfFEU5hwIDAQAB
+    -----END PUBLIC KEY-----
+    EOF
+    key = OpenSSL::PKey::RSA.new(pem)
+    assert_same_rsa(dup_public(RSA1024), key)
 
-  def test_read_private_key_der
-    der = OpenSSL::TestUtils::TEST_KEY_RSA1024.to_der
-    key = OpenSSL::PKey.read(der)
-    assert(key.private?)
-    assert_equal(der, key.to_der)
-  end
-
-  def test_read_private_key_pem
-    pem = OpenSSL::TestUtils::TEST_KEY_RSA1024.to_pem
-    key = OpenSSL::PKey.read(pem)
-    assert(key.private?)
-    assert_equal(pem, key.to_pem)
-  end
-
-  def test_read_public_key_der
-    der = OpenSSL::TestUtils::TEST_KEY_RSA1024.public_key.to_der
-    key = OpenSSL::PKey.read(der)
-    assert(!key.private?)
-    assert_equal(der, key.to_der)
-  end
-
-  def test_read_public_key_pem
-    pem = OpenSSL::TestUtils::TEST_KEY_RSA1024.public_key.to_pem
-    key = OpenSSL::PKey.read(pem)
-    assert(!key.private?)
-    assert_equal(pem, key.to_pem)
-  end
-
-  def test_read_private_key_pem_pw
-    pem = OpenSSL::TestUtils::TEST_KEY_RSA1024.to_pem(OpenSSL::Cipher.new('AES-128-CBC'), 'secret')
-    #callback form for password
-    key = OpenSSL::PKey.read(pem) do
-      'secret'
-    end
-    assert(key.private?)
-    # pass password directly
-    key = OpenSSL::PKey.read(pem, 'secret')
-    assert(key.private?)
-    #omit pem equality check, will be different due to cipher iv
-  end
-
-  def test_read_private_key_pem_pw_exception
-    pem = OpenSSL::TestUtils::TEST_KEY_RSA1024.to_pem(OpenSSL::Cipher.new('AES-128-CBC'), 'secret')
-    # it raises an ArgumentError from PEM reading. The exception raised inside are ignored for now.
-    assert_raise(OpenSSL::PKey::PKeyError) do
-      OpenSSL::PKey.read(pem) do
-        raise RuntimeError
-      end
-    end
-  end
-
-  def test_export_password_length
-    key = OpenSSL::TestUtils::TEST_KEY_RSA1024
-    assert_raise(OpenSSL::OpenSSLError) do
-      key.export(OpenSSL::Cipher.new('AES-128-CBC'), 'sec')
-    end
-    pem = key.export(OpenSSL::Cipher.new('AES-128-CBC'), 'secr')
-    assert(pem)
-  end
-
-  def test_export_password_funny
-    key = OpenSSL::TestUtils::TEST_KEY_RSA1024
-    # this assertion may fail in the future because of OpenSSL change.
-    # the current upper limit is 1024
-    assert_raise(OpenSSL::OpenSSLError) do
-      key.export(OpenSSL::Cipher.new('AES-128-CBC'), 'secr' * 1024)
-    end
-    # password containing NUL byte
-    pem = key.export(OpenSSL::Cipher.new('AES-128-CBC'), "pass\0wd")
-    assert_raise(OpenSSL::PKey::PKeyError) do
-      OpenSSL::PKey.read(pem, "pass")
-    end
-    key2 = OpenSSL::PKey.read(pem, "pass\0wd")
-    assert(key2.private?)
-    key3 = OpenSSL::PKey::RSA.new(pem, "pass\0wd")
-    assert(key3.private?)
+    assert_equal(asn1.to_der, dup_public(RSA1024).to_der)
+    assert_equal(pem, dup_public(RSA1024).export)
   end
 
   def test_dup
@@ -303,29 +267,9 @@ AwEAAQ==
   end
 
   private
-
-  def check_PUBKEY(asn1, key)
-    assert_equal(OpenSSL::ASN1::SEQUENCE, asn1.tag)
-    assert_equal(2, asn1.value.size)
-    seq = asn1.value
-    assert_equal(OpenSSL::ASN1::SEQUENCE, seq[0].tag)
-    assert_equal(2, seq[0].value.size)
-    algo_id = seq[0].value
-    assert_equal(OpenSSL::ASN1::OBJECT, algo_id[0].tag)
-    assert_equal('rsaEncryption', algo_id[0].value)
-    assert_equal(OpenSSL::ASN1::NULL, algo_id[1].tag)
-    assert_equal(nil, algo_id[1].value)
-    assert_equal(OpenSSL::ASN1::BIT_STRING, seq[1].tag)
-    assert_equal(0, seq[1].unused_bits)
-    pub_key = OpenSSL::ASN1.decode(seq[1].value)
-    assert_equal(OpenSSL::ASN1::SEQUENCE, pub_key.tag)
-    assert_equal(2, pub_key.value.size)
-    assert_equal(OpenSSL::ASN1::INTEGER, pub_key.value[0].tag)
-    assert_equal(key.n, pub_key.value[0].value)
-    assert_equal(OpenSSL::ASN1::INTEGER, pub_key.value[1].tag)
-    assert_equal(key.e, pub_key.value[1].value)
+  def assert_same_rsa(expected, key)
+    check_component(expected, key, [:n, :e, :d, :p, :q, :dmp1, :dmq1, :iqmp])
   end
-
 end
 
 end

--- a/test/utils.rb
+++ b/test/utils.rb
@@ -349,5 +349,39 @@ AQjjxMXhwULlmuR/K+WwlaZPiLIBYalLAZQ7ZbOPeVkJ8ePao0eLAgEC
     end
   end
 
+  class OpenSSL::PKeyTestCase < OpenSSL::TestCase
+    def check_component(base, test, keys)
+      keys.each { |comp|
+        assert_equal(base.send(comp), test.send(comp))
+      }
+    end
+
+    def dup_public(key)
+      case key
+      when OpenSSL::PKey::RSA
+        rsa = OpenSSL::PKey::RSA.new
+        rsa.set_key(key.n, key.e, nil)
+        rsa
+      when OpenSSL::PKey::DSA
+        dsa = OpenSSL::PKey::DSA.new
+        dsa.set_pqg(key.p, key.q, key.g)
+        dsa.set_key(key.pub_key, nil)
+        dsa
+      when OpenSSL::PKey::DH
+        dh = OpenSSL::PKey::DH.new
+        dh.set_pqg(key.p, nil, key.g)
+        dh
+      else
+        if defined?(OpenSSL::PKey::EC) && OpenSSL::PKey::EC === key
+          ec = OpenSSL::PKey::EC.new(key.group)
+          ec.public_key = key.public_key
+          ec
+        else
+          raise "bug"
+        end
+      end
+    end
+  end
+
 end if defined?(OpenSSL::OPENSSL_LIBRARY_VERSION) and
   /\AOpenSSL +0\./ !~ OpenSSL::OPENSSL_LIBRARY_VERSION


### PR DESCRIPTION
Add format keyword argument to allow users to specify the encoding
format. The value can be either :{RSA,DSA,EC}PrivateKey or
SubjectPublicKeyInfo.

Currently they don't have such option, and choose the format depending
on whether if the PKey contains the private key or not.
