### PR TITLE
ssl: conditionally set explicit cipher suite list

### DIFF
--- a/lib/openssl/ssl.rb
+++ b/lib/openssl/ssl.rb
@@ -20,38 +20,6 @@ module OpenSSL
         :ssl_version => "SSLv23",
         :verify_mode => OpenSSL::SSL::VERIFY_PEER,
         :verify_hostname => true,
-        :ciphers => %w{
-          ECDHE-ECDSA-AES128-GCM-SHA256
-          ECDHE-RSA-AES128-GCM-SHA256
-          ECDHE-ECDSA-AES256-GCM-SHA384
-          ECDHE-RSA-AES256-GCM-SHA384
-          DHE-RSA-AES128-GCM-SHA256
-          DHE-DSS-AES128-GCM-SHA256
-          DHE-RSA-AES256-GCM-SHA384
-          DHE-DSS-AES256-GCM-SHA384
-          ECDHE-ECDSA-AES128-SHA256
-          ECDHE-RSA-AES128-SHA256
-          ECDHE-ECDSA-AES128-SHA
-          ECDHE-RSA-AES128-SHA
-          ECDHE-ECDSA-AES256-SHA384
-          ECDHE-RSA-AES256-SHA384
-          ECDHE-ECDSA-AES256-SHA
-          ECDHE-RSA-AES256-SHA
-          DHE-RSA-AES128-SHA256
-          DHE-RSA-AES256-SHA256
-          DHE-RSA-AES128-SHA
-          DHE-RSA-AES256-SHA
-          DHE-DSS-AES128-SHA256
-          DHE-DSS-AES256-SHA256
-          DHE-DSS-AES128-SHA
-          DHE-DSS-AES256-SHA
-          AES128-GCM-SHA256
-          AES256-GCM-SHA384
-          AES128-SHA256
-          AES256-SHA256
-          AES128-SHA
-          AES256-SHA
-        }.join(":"),
         :options => -> {
           opts = OpenSSL::SSL::OP_ALL
           opts &= ~OpenSSL::SSL::OP_DONT_INSERT_EMPTY_FRAGMENTS
@@ -60,6 +28,44 @@ module OpenSSL
           opts
         }.call
       }
+
+      if !(OpenSSL::OPENSSL_VERSION.start_with?("OpenSSL") &&
+           OpenSSL::OPENSSL_VERSION_NUMBER >= 0x10100000)
+        DEFAULT_PARAMS.merge!(
+          ciphers: %w{
+            ECDHE-ECDSA-AES128-GCM-SHA256
+            ECDHE-RSA-AES128-GCM-SHA256
+            ECDHE-ECDSA-AES256-GCM-SHA384
+            ECDHE-RSA-AES256-GCM-SHA384
+            DHE-RSA-AES128-GCM-SHA256
+            DHE-DSS-AES128-GCM-SHA256
+            DHE-RSA-AES256-GCM-SHA384
+            DHE-DSS-AES256-GCM-SHA384
+            ECDHE-ECDSA-AES128-SHA256
+            ECDHE-RSA-AES128-SHA256
+            ECDHE-ECDSA-AES128-SHA
+            ECDHE-RSA-AES128-SHA
+            ECDHE-ECDSA-AES256-SHA384
+            ECDHE-RSA-AES256-SHA384
+            ECDHE-ECDSA-AES256-SHA
+            ECDHE-RSA-AES256-SHA
+            DHE-RSA-AES128-SHA256
+            DHE-RSA-AES256-SHA256
+            DHE-RSA-AES128-SHA
+            DHE-RSA-AES256-SHA
+            DHE-DSS-AES128-SHA256
+            DHE-DSS-AES256-SHA256
+            DHE-DSS-AES128-SHA
+            DHE-DSS-AES256-SHA
+            AES128-GCM-SHA256
+            AES256-GCM-SHA384
+            AES128-SHA256
+            AES256-SHA256
+            AES128-SHA
+            AES256-SHA
+          }.join(":"),
+        )
+      end
 
       DEFAULT_CERT_STORE = OpenSSL::X509::Store.new
       DEFAULT_CERT_STORE.set_default_paths

--- a/test/test_ssl.rb
+++ b/test/test_ssl.rb
@@ -413,26 +413,15 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
   end
 
   def test_sslctx_set_params
-    start_server(OpenSSL::SSL::VERIFY_NONE, true, :ignore_listener_error => true){|server, port|
-      sock = TCPSocket.new("127.0.0.1", port)
-      ctx = OpenSSL::SSL::SSLContext.new
-      ctx.set_params
-      assert_equal(OpenSSL::SSL::VERIFY_PEER, ctx.verify_mode)
-      assert_equal(OpenSSL::SSL::SSLContext::DEFAULT_PARAMS[:options], ctx.options)
-      ciphers = ctx.ciphers
-      ciphers_versions = ciphers.collect{|_, v, _, _| v }
-      ciphers_names = ciphers.collect{|v, _, _, _| v }
-      assert(ciphers_names.all?{|v| /A(EC)?DH/ !~ v })
-      assert(ciphers_versions.all?{|v| /SSLv2/ !~ v })
-      ssl = OpenSSL::SSL::SSLSocket.new(sock, ctx)
-      ssl.sync_close = true
-      begin
-        assert_raise(OpenSSL::SSL::SSLError){ ssl.connect }
-        assert_equal(OpenSSL::X509::V_ERR_SELF_SIGNED_CERT_IN_CHAIN, ssl.verify_result)
-      ensure
-        ssl.close
-      end
-    }
+    ctx = OpenSSL::SSL::SSLContext.new
+    ctx.set_params
+    assert_equal(OpenSSL::SSL::VERIFY_PEER, ctx.verify_mode)
+    ciphers = ctx.ciphers
+    ciphers_versions = ciphers.collect{|_, v, _, _| v }
+    ciphers_names = ciphers.collect{|v, _, _, _| v }
+    assert(ciphers_names.all?{|v| /A(EC)?DH/ !~ v })
+    assert(ciphers_names.all?{|v| /(RC4|MD5|EXP)/ !~ v })
+    assert(ciphers_versions.all?{|v| /SSLv2/ !~ v })
   end
 
   def test_post_connect_check_with_anon_ciphers


### PR DESCRIPTION
Don't set in SSLContext#set_params when built with OpenSSL 1.1.0 or
newer.

The list was added as a workaround to exclude known weak cipher suites
([Bug #9424]). In OpenSSL <= 1.0.2, the default list (DEFAULT) included
even cipher suites using MD5. Now, OpenSSL 1.1.0 has better DEFAULT. So
make SSLContext#set_params just use it.

Here is the diff between our current explicit list and DEFAULT of
OpenSSL 1.1.0-pre6 (with sorted):

~~~
$ list_ruby=$(openssl ciphers -v $(ruby -ropenssl -e'puts OpenSSL::SSL::SSLContext::DEFAULT_PARAMS[:ciphers]') | sort)
$ list_default=$(openssl ciphers -v 'DEAFULT:!PSK:!SRP' | sort)
$ diff <(echo "$list_ruby") <(echo "$list_default")
7,12c7
< DHE-DSS-AES128-GCM-SHA256 TLSv1.2 Kx=DH       Au=DSS  Enc=AESGCM(128) Mac=AEAD
< DHE-DSS-AES128-SHA256   TLSv1.2 Kx=DH       Au=DSS  Enc=AES(128)  Mac=SHA256
< DHE-DSS-AES128-SHA      SSLv3 Kx=DH       Au=DSS  Enc=AES(128)  Mac=SHA1
< DHE-DSS-AES256-GCM-SHA384 TLSv1.2 Kx=DH       Au=DSS  Enc=AESGCM(256) Mac=AEAD
< DHE-DSS-AES256-SHA256   TLSv1.2 Kx=DH       Au=DSS  Enc=AES(256)  Mac=SHA256
< DHE-DSS-AES256-SHA      SSLv3 Kx=DH       Au=DSS  Enc=AES(256)  Mac=SHA1
---
> DES-CBC3-SHA            SSLv3 Kx=RSA      Au=RSA  Enc=3DES(168) Mac=SHA1
18a14,15
> DHE-RSA-CHACHA20-POLY1305 TLSv1.2 Kx=DH       Au=RSA  Enc=CHACHA20/POLY1305(256) Mac=AEAD
> DHE-RSA-DES-CBC3-SHA    SSLv3 Kx=DH       Au=RSA  Enc=3DES(168) Mac=SHA1
24a22,23
> ECDHE-ECDSA-CHACHA20-POLY1305 TLSv1.2 Kx=ECDH     Au=ECDSA Enc=CHACHA20/POLY1305(256) Mac=AEAD
> ECDHE-ECDSA-DES-CBC3-SHA SSLv3 Kx=ECDH     Au=ECDSA Enc=3DES(168) Mac=SHA1
30a30,31
> ECDHE-RSA-CHACHA20-POLY1305 TLSv1.2 Kx=ECDH     Au=RSA  Enc=CHACHA20/POLY1305(256) Mac=AEAD
> ECDHE-RSA-DES-CBC3-SHA  SSLv3 Kx=ECDH     Au=RSA  Enc=3DES(168) Mac=SHA1
~~~
