### PR TITLE
Drop support for LibreSSL < 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,6 @@ matrix:
     - env: RUBY_VERSION=ruby-2.3 OPENSSL_VERSION=openssl-1.0.1 OSSL_MDEBUG=1
     - env: RUBY_VERSION=ruby-2.3 OPENSSL_VERSION=openssl-1.0.2 OSSL_MDEBUG=1
     - env: RUBY_VERSION=ruby-2.3 OPENSSL_VERSION=openssl-1.1.0 OSSL_MDEBUG=1
-    - env: RUBY_VERSION=ruby-2.3 OPENSSL_VERSION=libressl-2.1
-    - env: RUBY_VERSION=ruby-2.3 OPENSSL_VERSION=libressl-2.2
     - env: RUBY_VERSION=ruby-2.3 OPENSSL_VERSION=libressl-2.3
     - env: RUBY_VERSION=ruby-2.3 OPENSSL_VERSION=libressl-2.4
     - env: RUBY_VERSION=ruby-2.3 OPENSSL_VERSION=libressl-2.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,4 +25,5 @@ matrix:
     - env: RUBY_VERSION=ruby-2.3 OPENSSL_VERSION=libressl-2.2
     - env: RUBY_VERSION=ruby-2.3 OPENSSL_VERSION=libressl-2.3
     - env: RUBY_VERSION=ruby-2.3 OPENSSL_VERSION=libressl-2.4
+    - env: RUBY_VERSION=ruby-2.3 OPENSSL_VERSION=libressl-2.5
   allow_failures:

--- a/History.md
+++ b/History.md
@@ -17,7 +17,7 @@ Supported platforms
 
 * OpenSSL 1.0.0, 1.0.1, 1.0.2, 1.1.0
 * OpenSSL < 0.9.8 is no longer supported.
-* LibreSSL 2.1, 2.2, 2.3, 2.4
+* LibreSSL 2.3, 2.4, 2.5
 * Ruby 2.3, 2.4
 
 Notable changes

--- a/tool/ruby-openssl-docker/Dockerfile
+++ b/tool/ruby-openssl-docker/Dockerfile
@@ -50,19 +50,7 @@ RUN curl -s https://www.openssl.org/source/openssl-1.1.0b.tar.gz | tar -C /build
       debug-linux-x86_64 && \
     make && make install_sw
 
-# Supported libressl versions: 2.1, 2.2, 2.3, 2.4, 2.5
-RUN curl -s http://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.1.10.tar.gz | tar -C /build/openssl -xzf -
-RUN cd /build/openssl/libressl-2.1.10 && \
-    ./configure \
-      --prefix=/opt/openssl/libressl-2.1 && \
-    make && make install
-
-RUN curl -s http://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.2.9.tar.gz | tar -C /build/openssl -xzf -
-RUN cd /build/openssl/libressl-2.2.9 && \
-    ./configure \
-      --prefix=/opt/openssl/libressl-2.2 && \
-    make && make install
-
+# Supported libressl versions: 2.3, 2.4, 2.5
 RUN curl -s http://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.3.8.tar.gz | tar -C /build/openssl -xzf -
 RUN cd /build/openssl/libressl-2.3.8 && \
     ./configure \

--- a/tool/ruby-openssl-docker/Dockerfile
+++ b/tool/ruby-openssl-docker/Dockerfile
@@ -28,29 +28,29 @@ RUN curl -s https://www.openssl.org/source/openssl-1.0.0t.tar.gz | tar -C /build
       shared debug-linux-x86_64 && \
     make && make install_sw
 
-RUN curl -s https://www.openssl.org/source/openssl-1.0.1t.tar.gz | tar -C /build/openssl -xzf - && \
-    cd /build/openssl/openssl-1.0.1t && \
+RUN curl -s https://www.openssl.org/source/openssl-1.0.1u.tar.gz | tar -C /build/openssl -xzf - && \
+    cd /build/openssl/openssl-1.0.1u && \
     ./Configure \
       --openssldir=/opt/openssl/openssl-1.0.1 \
       shared debug-linux-x86_64 && \
     make && make install_sw
 
-RUN curl -s https://www.openssl.org/source/openssl-1.0.2h.tar.gz | tar -C /build/openssl -xzf - && \
-    cd /build/openssl/openssl-1.0.2h && \
+RUN curl -s https://www.openssl.org/source/openssl-1.0.2j.tar.gz | tar -C /build/openssl -xzf - && \
+    cd /build/openssl/openssl-1.0.2j && \
     ./Configure \
       --openssldir=/opt/openssl/openssl-1.0.2 \
       shared debug-linux-x86_64 && \
     make && make install_sw
 
-RUN curl -s https://www.openssl.org/source/openssl-1.1.0.tar.gz | tar -C /build/openssl -xzf - && \
-    cd /build/openssl/openssl-1.1.0 && \
+RUN curl -s https://www.openssl.org/source/openssl-1.1.0b.tar.gz | tar -C /build/openssl -xzf - && \
+    cd /build/openssl/openssl-1.1.0b && \
     ./Configure \
       --prefix=/opt/openssl/openssl-1.1.0 \
       enable-crypto-mdebug enable-crypto-mdebug-backtrace \
       debug-linux-x86_64 && \
     make && make install_sw
 
-# Supported libressl versions: 2.1, 2.2, 2.3, 2.4
+# Supported libressl versions: 2.1, 2.2, 2.3, 2.4, 2.5
 RUN curl -s http://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.1.10.tar.gz | tar -C /build/openssl -xzf -
 RUN cd /build/openssl/libressl-2.1.10 && \
     ./configure \
@@ -63,16 +63,22 @@ RUN cd /build/openssl/libressl-2.2.9 && \
       --prefix=/opt/openssl/libressl-2.2 && \
     make && make install
 
-RUN curl -s http://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.3.7.tar.gz | tar -C /build/openssl -xzf -
-RUN cd /build/openssl/libressl-2.3.7 && \
+RUN curl -s http://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.3.8.tar.gz | tar -C /build/openssl -xzf -
+RUN cd /build/openssl/libressl-2.3.8 && \
     ./configure \
       --prefix=/opt/openssl/libressl-2.3 && \
     make && make install
 
-RUN curl -s http://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.4.2.tar.gz | tar -C /build/openssl -xzf -
-RUN cd /build/openssl/libressl-2.4.2 && \
+RUN curl -s http://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.4.3.tar.gz | tar -C /build/openssl -xzf -
+RUN cd /build/openssl/libressl-2.4.3 && \
     ./configure \
       --prefix=/opt/openssl/libressl-2.4 && \
+    make && make install
+
+RUN curl -s http://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.5.0.tar.gz | tar -C /build/openssl -xzf -
+RUN cd /build/openssl/libressl-2.5.0 && \
+    ./configure \
+      --prefix=/opt/openssl/libressl-2.5 && \
     make && make install
 
 # Supported Ruby versions: 2.3

--- a/tool/ruby-openssl-docker/README.md
+++ b/tool/ruby-openssl-docker/README.md
@@ -1,5 +1,6 @@
 # ruby-openssl-docker
 
-Supports OpenSSL 1.0.0t, 1.0.1q, 1.0.2e and LibreSSL 2.1.9, 2.2.5 and 2.3.1.
+Docker image for testing. The image contains various binaries of supported
+versions of OpenSSL, LibreSSL, and Ruby.
 
-Currently only Ruby 2.3.0 is supported.
+CONTRIBUTING.md on the top directory describes how to use the image.


### PR DESCRIPTION
I'm thinking of dropping support for unmaintained versions of LibreSSL.

According to the support schedule described on libressl.org[1], a stable branch is maintained for 1 year after an OpenBSD release that ships with it is published. So, LibreSSL 2.2, which was the version on OpenBSD 5.8 released on 2015-08, is no longer supported officially.

Unlike OpenSSL, since there are no (at least I don't know) redisributions with extended support, I think it's completely safe to drop old versions.

@zzak @hsbt What do you think?

[1]: http://www.libressl.org/releases.html