### PR TITLE
Add install_dependencies rake task that installs testing dependencies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ Test cases are located under the
 You can run it with the following three commands:
 
 ```
-$ gem install rake-compiler test-unit
+$ rake install_dependencies # installs rake-compiler, test-unit, ...
 $ rake compile
 $ rake test
 ```

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ install:
   - appveyor DownloadFile http://dl.bintray.com/oneclick/OpenKnapsack/x64/openssl-1.0.1m-x64-windows.tar.lzma
   - 7z e openssl-1.0.1m-x64-windows.tar.lzma
   - 7z x -y -oC:\Ruby%ruby_version% openssl-1.0.1m-x64-windows.tar
-  - gem install rake-compiler
+  - ruby -S rake install_dependencies
 build_script:
   - rake -rdevkit compile -- --with-openssl-dir=C:\Ruby%ruby_version%
 test_script:

--- a/tool/ruby-openssl-docker/init.sh
+++ b/tool/ruby-openssl-docker/init.sh
@@ -15,15 +15,6 @@ export PATH="/opt/ruby/${RUBY_VERSION}/bin:$PATH"
 export LD_LIBRARY_PATH="/opt/openssl/${OPENSSL_VERSION}/lib"
 export PKG_CONFIG_PATH="/opt/openssl/${OPENSSL_VERSION}/lib/pkgconfig"
 
-ruby -e '
-  newsource = Gem::Source.new("http://rubygems.org")
-  Gem.sources.replace([newsource])
-  Gem.configuration.write
-
-  spec = eval(File.read("openssl.gemspec"))
-  spec.development_dependencies.each do |dep|
-    Gem.install(dep.name, dep.requirement, force: true)
-  end
-'
+rake install_dependencies USE_HTTP_RUBYGEMS_ORG=1
 
 exec $*


### PR DESCRIPTION
Follow up for #80. Seeing if Travis and AppVeyor are happy with this.

---

Parse the dependency gems from openssl.gemspec and install them. This is
extracted from tool/ruby-openssl-docker/init.sh.

.travis.yml, appveyor.yml and CONTRIBUTING.md are also updated to use
the new task.