### PR TITLE
Add "for Ruby" to the README title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# OpenSSL
+# OpenSSL for Ruby
 
 [![Build Status](https://travis-ci.org/ruby/openssl.svg?branch=master)](https://travis-ci.org/ruby/openssl)
 [![Build status](https://ci.appveyor.com/api/projects/status/b8djtmwo7l26f88y/branch/master?svg=true)](https://ci.appveyor.com/project/ruby/openssl/branch/master)


### PR DESCRIPTION
It's not immediately clear from the README exactly what this project is