### PR TITLE
asn1: handle GENERALIZEDTIME without seconds

### DIFF
--- a/ext/openssl/ossl_asn1.c
+++ b/ext/openssl/ossl_asn1.c
@@ -47,8 +47,13 @@ asn1time_to_time(const ASN1_TIME *time)
 	}
 	break;
     case V_ASN1_GENERALIZEDTIME:
-	if (sscanf((const char *)time->data, "%4d%2d%2d%2d%2d%2dZ", &tm.tm_year, &tm.tm_mon,
-    		&tm.tm_mday, &tm.tm_hour, &tm.tm_min, &tm.tm_sec) != 6) {
+	count = sscanf((const char *)time->data, "%4d%2d%2d%2d%2d%2dZ",
+		&tm.tm_year, &tm.tm_mon, &tm.tm_mday, &tm.tm_hour, &tm.tm_min,
+		&tm.tm_sec);
+	if (count == 5) {
+		tm.tm_sec = 0;
+	}
+	else if (count != 6) {
 	    ossl_raise(rb_eTypeError, "bad GENERALIZEDTIME format" );
 	}
 	break;

--- a/ext/openssl/ossl_asn1.c
+++ b/ext/openssl/ossl_asn1.c
@@ -54,7 +54,8 @@ asn1time_to_time(const ASN1_TIME *time)
 		tm.tm_sec = 0;
 	}
 	else if (count != 6) {
-	    ossl_raise(rb_eTypeError, "bad GENERALIZEDTIME format" );
+		ossl_raise(rb_eTypeError, "bad GENERALIZEDTIME format: \"%s\"",
+			time->data);
 	}
 	break;
     default:

--- a/test/test_asn1.rb
+++ b/test/test_asn1.rb
@@ -275,6 +275,14 @@ rEzBQ0F9dUyqQ9gyRg8KHhDfv9HzT1d/rnUZMkoombwYBRIUChGCYV0GnJcan2Zm
     assert_equal 2 ** 31, OpenSSL::ASN1.decode(encoded).value.to_i
   end
 
+  def test_decode_generalisedtime
+    expected = Time.at 1481225640
+    assert_equal expected, OpenSSL::ASN1.decode("\x18\x0D201612081934Z").value
+
+    expected += 29
+    assert_equal expected, OpenSSL::ASN1.decode("\x18\x0F20161208193429Z").value
+  end
+
   def test_decode_enumerated
     encoded = OpenSSL::ASN1.Enumerated(0).to_der
     assert_equal "\x0a\x01\x00".b, encoded


### PR DESCRIPTION
encountered this error using a certificate that is accepted by other clients:
```
OpenSSL::X509::Certificate.new File.read ("openssl_test.crt")
TypeError: bad GENERALIZEDTIME format
```
this is from asn1parse:
```
  147:d=2  hl=2 l=  30 cons:   SEQUENCE          
  149:d=3  hl=2 l=  13 prim:    GENERALIZEDTIME   :201401010000Z
  164:d=3  hl=2 l=  13 prim:    UTCTIME           :390512144609Z
```