### PR TITLE
Fix for ASN1::Constructive 'each' implementation

### DIFF
--- a/ext/openssl/ossl_asn1.c
+++ b/ext/openssl/ossl_asn1.c
@@ -1291,7 +1291,7 @@ ossl_asn1cons_to_der(VALUE self)
 static VALUE
 ossl_asn1cons_each(VALUE self)
 {
-    rb_funcall(ossl_asn1_get_value(self), id_each, 0);
+    rb_block_call(ossl_asn1_get_value(self), id_each, 0, 0, 0, 0);
 
     return self;
 }

--- a/test/test_asn1.rb
+++ b/test/test_asn1.rb
@@ -566,6 +566,13 @@ rEzBQ0F9dUyqQ9gyRg8KHhDfv9HzT1d/rnUZMkoombwYBRIUChGCYV0GnJcan2Zm
     assert_equal 17, ret[0][6]
   end
 
+  def test_constructive_each
+    data = [OpenSSL::ASN1::Integer.new(0), OpenSSL::ASN1::Integer.new(1)]
+    seq = OpenSSL::ASN1::Sequence.new data
+
+    assert_equal data, seq.entries
+  end
+
   private
 
   def assert_universal(tag, asn1)


### PR DESCRIPTION
This change fixes the `ASN1::Constructive.each` implementation that was broken with commit 36bf7f403ebb6cefcaa1e7af9d8ec99e6b4bc1ed (see @tidoublemy's comment on that commit for code to reproduce the issue).

Included are two small tests to test for correct behavior of the `each` implementation and that an appropriate exception will be raised (instead of SIGSEGV'ing) when non-array data is specified in Ruby for the `value` attribute.