### PR TITLE
x509name: Correct inverted return for #eql?

### DIFF
--- a/ext/openssl/ossl_x509name.c
+++ b/ext/openssl/ossl_x509name.c
@@ -375,7 +375,7 @@ ossl_x509name_eql(VALUE self, VALUE other)
     if (!rb_obj_is_kind_of(other, cX509Name))
 	return Qfalse;
 
-    return ossl_x509name_cmp0(self, other) ? Qtrue : Qfalse;
+    return ossl_x509name_cmp0(self, other) == 0 ? Qtrue : Qfalse;
 }
 
 /*

--- a/test/test_x509name.rb
+++ b/test/test_x509name.rb
@@ -358,4 +358,10 @@ class OpenSSL::TestX509Name < OpenSSL::TestCase
     name = OpenSSL::X509::Name.parse("/CN=ruby-lang.org")
     assert_equal(name.to_der, name.dup.to_der)
   end
+
+  def test_eql
+    n1 = OpenSSL::X509::Name.new([['CN', 'ruby-lang.org']])
+    n2 = OpenSSL::X509::Name.new([['CN', 'ruby-lang.org']])
+    assert(n1.eql?(n2), "[Bug #13170]")
+  end
 end


### PR DESCRIPTION
Commit 34e7fe34e introduced a regression that inverted the return value
of OpenSSL::X509::Name#eql?; this commit fixes Bug #13170 and restores the
original semantics.

Reference: https://bugs.ruby-lang.org/issues/13170