### PR TITLE
Document using secure protocol to fetch git master

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Alternatively, you can install the gem with `bundler`:
 # Gemfile
 gem 'openssl'
 # or specify git master
-gem 'openssl', github: 'ruby/openssl'
+gem 'openssl', git: 'https://github.com/ruby/openssl'
 ```
 
 After doing `bundle install`, you should have the gem installed in your bundle.


### PR DESCRIPTION
Firstly, thank you for you're hard work.

I was browsing through the README and noticed that it's being documented that you can fetch master using git and bundler using:

    gem 'openssl', github: 'ruby/openssl'

The `github` gem option in Bundler uses the `git://` protocol to fetch the repository and this protocol is unfortunately not secure. I have changed the documentation to instead use the `git` option using `https` as the protocol.
