### PR TITLE
Fix rdoc for core Integer class

### DIFF
--- a/lib/openssl/bn.rb
+++ b/lib/openssl/bn.rb
@@ -27,8 +27,9 @@ module OpenSSL
 end # OpenSSL
 
 ##
+#--
 # Add double dispatch to Integer
-#
+#++
 class Integer
   # Casts an Integer as an OpenSSL::BN
   #


### PR DESCRIPTION
The comment "Add double dispatch to Integer" should not leak into the class documentation for Integer:

```
$ ri Integer
Integer < Numeric

(from ruby site)
------------------------------------------------------------------------------
[snip other stuff that doesn't belong here]

Add double dispatch to Integer

[snip]

Holds Integer values.  You cannot add a singleton method to an Integer. Any
attempt to add a singleton method to an Integer object will raise a TypeError.
```

See also https://docs.ruby-lang.org/en/2.4.0/Integer.html.