### PR TITLE
Update .travis.yml and Dockerfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,4 +25,13 @@ matrix:
     - env: RUBY_VERSION=ruby-2.4 OPENSSL_VERSION=libressl-2.3
     - env: RUBY_VERSION=ruby-2.4 OPENSSL_VERSION=libressl-2.4
     - env: RUBY_VERSION=ruby-2.4 OPENSSL_VERSION=libressl-2.5
+    - language: ruby
+      rvm: ruby-head
+      before_install:
+        - "rake install_dependencies"
+      script:
+        - "rake compile -- --enable-debug"
+        - "rake test"
   allow_failures:
+    - language: ruby
+      rvm: ruby-head

--- a/tool/ruby-openssl-docker/Dockerfile
+++ b/tool/ruby-openssl-docker/Dockerfile
@@ -42,8 +42,8 @@ RUN curl -s https://www.openssl.org/source/openssl-1.0.2k.tar.gz | tar -C /build
       shared linux-x86_64 && \
     make && make install_sw
 
-RUN curl -s https://www.openssl.org/source/openssl-1.1.0d.tar.gz | tar -C /build/openssl -xzf - && \
-    cd /build/openssl/openssl-1.1.0d && \
+RUN curl -s https://www.openssl.org/source/openssl-1.1.0e.tar.gz | tar -C /build/openssl -xzf - && \
+    cd /build/openssl/openssl-1.1.0e && \
     ./Configure \
       --prefix=/opt/openssl/openssl-1.1.0 \
       enable-crypto-mdebug enable-crypto-mdebug-backtrace \
@@ -51,36 +51,36 @@ RUN curl -s https://www.openssl.org/source/openssl-1.1.0d.tar.gz | tar -C /build
     make && make install_sw
 
 # Supported libressl versions: 2.3-
-RUN curl -s http://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.3.9.tar.gz | tar -C /build/openssl -xzf -
-RUN cd /build/openssl/libressl-2.3.9 && \
+RUN curl -s http://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.3.10.tar.gz | tar -C /build/openssl -xzf -
+RUN cd /build/openssl/libressl-2.3.10 && \
     ./configure \
       --prefix=/opt/openssl/libressl-2.3 && \
     make && make install
 
-RUN curl -s http://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.4.4.tar.gz | tar -C /build/openssl -xzf -
-RUN cd /build/openssl/libressl-2.4.4 && \
+RUN curl -s http://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.4.5.tar.gz | tar -C /build/openssl -xzf -
+RUN cd /build/openssl/libressl-2.4.5 && \
     ./configure \
       --prefix=/opt/openssl/libressl-2.4 && \
     make && make install
 
-RUN curl -s http://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.5.0.tar.gz | tar -C /build/openssl -xzf -
-RUN cd /build/openssl/libressl-2.5.0 && \
+RUN curl -s http://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.5.4.tar.gz | tar -C /build/openssl -xzf -
+RUN cd /build/openssl/libressl-2.5.4 && \
     ./configure \
       --prefix=/opt/openssl/libressl-2.5 && \
     make && make install
 
 # Supported Ruby versions: 2.3-
 RUN mkdir -p /build/ruby
-RUN curl -s https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.3.tar.gz | tar -C /build/ruby -xzf - && \
-    cd /build/ruby/ruby-2.3.3 && \
+RUN curl -s https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.4.tar.gz | tar -C /build/ruby -xzf - && \
+    cd /build/ruby/ruby-2.3.4 && \
     autoconf && ./configure \
       --without-openssl \
       --prefix=/opt/ruby/ruby-2.3 \
       --disable-install-doc && \
     make && make install
 
-RUN curl -s https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.0.tar.gz | tar -C /build/ruby -xzf - && \
-    cd /build/ruby/ruby-2.4.0 && \
+RUN curl -s https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.1.tar.gz | tar -C /build/ruby -xzf - && \
+    cd /build/ruby/ruby-2.4.1 && \
     autoconf && ./configure \
       --without-openssl \
       --prefix=/opt/ruby/ruby-2.4 \


### PR DESCRIPTION
Hello,

I updated Rubies to latest version in `tool/ruby-openssl-docker/Dockerfile`
I also added `ruby-head` as allow_failures.

I think testing with `ruby-head` is useful.
Because we can support the next version Ruby as faster.

You can see that some Rubygem packages that are bundled in Ruby, also are testing on `ruby-head`.
https://github.com/yuki24/did_you_mean/blob/master/.travis.yml
https://github.com/ruby/bigdecimal/blob/master/.travis.yml

My concern is currently this `openssl` is tested on Docker.
It is hard to test `ruby-head` on Docker.
Because we have to get HEAD of the Ruby trunk branch, and do `docker build` regularly to create the container image.

I added `ruby-head` to `.travis.yml` directly due to that reason.
I takes longer time to finish tests.
But `fast_finish: true` option must help contributors to check the result faster regardless the result of `ruby-head` test.

My image that I built is here.
https://hub.docker.com/r/junaruga/ruby-openssl-docker/tags/

Thanks.


* Updated Rubies to latest version.
* Added ruby-head as allow_failures.
  * Because it's good to know new version Ruby's issue as faster before the release.