### PR TITLE
Add fips_mode_get to return fips_mode

### DIFF
--- a/ext/openssl/ossl.c
+++ b/ext/openssl/ossl.c
@@ -410,6 +410,23 @@ ossl_debug_set(VALUE self, VALUE val)
 }
 
 /*
+ * call-seq
+ *   OpenSSL.fips_mode -> true | false
+ */
+static VALUE
+ossl_fips_mode_get(VALUE self)
+{
+
+#ifdef OPENSSL_FIPS
+    VALUE enabled;
+    enabled = FIPS_mode() ? Qtrue : Qfalse;
+    return enabled;
+#else
+    return Qfalse;
+#endif
+}
+
+/*
  * call-seq:
  *   OpenSSL.fips_mode = boolean -> boolean
  *
@@ -1139,7 +1156,7 @@ Init_openssl(void)
     rb_define_const(mOSSL, "OPENSSL_VERSION_NUMBER", INT2NUM(OPENSSL_VERSION_NUMBER));
 
     /*
-     * Boolean indicating whether OpenSSL is FIPS-enabled or not
+     * Boolean indicating whether OpenSSL is FIPS-capable or not
      */
     rb_define_const(mOSSL, "OPENSSL_FIPS",
 #ifdef OPENSSL_FIPS
@@ -1149,6 +1166,7 @@ Init_openssl(void)
 #endif
 		   );
 
+    rb_define_module_function(mOSSL, "fips_mode", ossl_fips_mode_get, 0);
     rb_define_module_function(mOSSL, "fips_mode=", ossl_fips_mode_set, 1);
 
     /*

--- a/test/test_fips.rb
+++ b/test/test_fips.rb
@@ -8,4 +8,13 @@ class OpenSSL::TestFIPS < OpenSSL::TestCase
     OpenSSL.fips_mode = false
   end
 
+  def test_fips_mode_get
+    if OpenSSL::OPENSSL_FIPS
+      OpenSSL.fips_mode = true
+      assert OpenSSL.fips_mode == true, ".fips_mode returns true when .fips_mode=true"
+
+      OpenSSL.fips_mode = false
+      assert OpenSSL.fips_mode == false, ".fips_mode returns false when .fips_mode=false"
+    end
+  end
 end


### PR DESCRIPTION
`OpenSSL::OPENSSL_FIPS` causes confusion as the doc states it returns a boolean based on if FIPS is 'enabled' which isn't true. It is dependent on whether the openssl installed was built with FOM (fips object module). If it was then it will always returns true (even when `fips_mode = false`), thus it is more accurate to say FIPS-capable.

Adding `OpenSSL.fips_mode` to return whether or not fips_mode is currently set. This allows for better handling around fips mode.