### PR TITLE
Add msys2 library dependency tag in gem metadata

### DIFF
--- a/openssl.gemspec
+++ b/openssl.gemspec
@@ -21,4 +21,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake-compiler"
   spec.add_development_dependency "test-unit", "~> 3.0"
   spec.add_development_dependency "rdoc"
+
+  spec.metadata["msys2_mingw_dependencies"] = "openssl"
 end


### PR DESCRIPTION
RubyInstaller2 supports metadata tags for installation of dependent
MSYS2/MINGW libraries. The openssl gem requires the mingw-openssl
package to be installed on the system, which the gem installer takes
care about, when this tag is set.

The feature is documented here:
https://github.com/oneclick/rubyinstaller2/wiki/For-gem-developers#msys2-library-dependency

This fixes issues like 
https://github.com/oneclick/rubyinstaller2/issues/54 and 
https://github.com/oneclick/rubyinstaller2/issues/53 .