### PR TITLE
test/test_ssl: explicitly accept TLS 1.1 in corresponding test

### DIFF
--- a/test/test_ssl.rb
+++ b/test/test_ssl.rb
@@ -779,7 +779,8 @@ if OpenSSL::SSL::SSLContext::METHODS.include?(:TLSv1_1) && OpenSSL::SSL::SSLCont
 
   def test_tls_v1_1
     start_server_version(:TLSv1_1) { |port|
-      server_connect(port) { |ssl| assert_equal("TLSv1.1", ssl.ssl_version) }
+      ctx = OpenSSL::SSL::SSLContext.new(:TLSv1_1)
+      server_connect(port, ctx) { |ssl| assert_equal("TLSv1.1", ssl.ssl_version) }
     }
   end
 


### PR DESCRIPTION
OpenSSL in Debian sid has recently disabled TLS < 1.2 by default, so in
order to test that TLS 1.1 works, we need to explicitly make our test
client accept it.