### PR TITLE
ssl: add SSLContext#min_version= and #max_version=

### DIFF
--- a/ext/openssl/extconf.rb
+++ b/ext/openssl/extconf.rb
@@ -104,11 +104,6 @@ end
 
 Logging::message "=== Checking for OpenSSL features... ===\n"
 # compile options
-
-# SSLv2 and SSLv3 may be removed in future versions of OpenSSL, and even macros
-# like OPENSSL_NO_SSL2 may not be defined.
-have_func("SSLv2_method")
-have_func("SSLv3_method")
 have_func("RAND_egd")
 engines = %w{builtin_engines openbsd_dev_crypto dynamic 4758cca aep atalla chil
              cswift nuron sureware ubsec padlock capi gmp gost cryptodev aesni}

--- a/ext/openssl/ossl_ssl.c
+++ b/ext/openssl/ossl_ssl.c
@@ -121,7 +121,11 @@ ossl_sslctx_s_alloc(VALUE klass)
     VALUE obj;
 
     obj = TypedData_Wrap_Struct(klass, &ossl_sslctx_type, 0);
+#if OPENSSL_VERSION_NUMBER >= 0x10100000 && !defined(LIBRESSL_VERSION_NUMBER)
+    ctx = SSL_CTX_new(TLS_method());
+#else
     ctx = SSL_CTX_new(SSLv23_method());
+#endif
     if (!ctx) {
         ossl_raise(eSSLError, "SSL_CTX_new");
     }

--- a/ext/openssl/ossl_ssl.c
+++ b/ext/openssl/ossl_ssl.c
@@ -2665,44 +2665,87 @@ Init_ossl_ssl(void)
 # endif
 #endif
 
-#define ossl_ssl_def_const(x) rb_define_const(mSSL, #x, ULONG2NUM(SSL_##x))
+    rb_define_const(mSSL, "VERIFY_NONE", INT2NUM(SSL_VERIFY_NONE));
+    rb_define_const(mSSL, "VERIFY_PEER", INT2NUM(SSL_VERIFY_PEER));
+    rb_define_const(mSSL, "VERIFY_FAIL_IF_NO_PEER_CERT", INT2NUM(SSL_VERIFY_FAIL_IF_NO_PEER_CERT));
+    rb_define_const(mSSL, "VERIFY_CLIENT_ONCE", INT2NUM(SSL_VERIFY_CLIENT_ONCE));
 
-    ossl_ssl_def_const(VERIFY_NONE);
-    ossl_ssl_def_const(VERIFY_PEER);
-    ossl_ssl_def_const(VERIFY_FAIL_IF_NO_PEER_CERT);
-    ossl_ssl_def_const(VERIFY_CLIENT_ONCE);
-    /* Introduce constants included in OP_ALL.  These constants are mostly for
-     * unset some bits in OP_ALL such as;
-     *   ctx.options = OP_ALL & ~OP_DONT_INSERT_EMPTY_FRAGMENTS
-     */
-    ossl_ssl_def_const(OP_MICROSOFT_SESS_ID_BUG);
-    ossl_ssl_def_const(OP_NETSCAPE_CHALLENGE_BUG);
-    ossl_ssl_def_const(OP_NETSCAPE_REUSE_CIPHER_CHANGE_BUG);
-    ossl_ssl_def_const(OP_SSLREF2_REUSE_CERT_TYPE_BUG);
-    ossl_ssl_def_const(OP_MICROSOFT_BIG_SSLV3_BUFFER);
-    ossl_ssl_def_const(OP_MSIE_SSLV2_RSA_PADDING);
-    ossl_ssl_def_const(OP_SSLEAY_080_CLIENT_DH_BUG);
-    ossl_ssl_def_const(OP_TLS_D5_BUG);
-    ossl_ssl_def_const(OP_TLS_BLOCK_PADDING_BUG);
-    ossl_ssl_def_const(OP_DONT_INSERT_EMPTY_FRAGMENTS);
-    ossl_ssl_def_const(OP_ALL);
-    ossl_ssl_def_const(OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION);
-    ossl_ssl_def_const(OP_SINGLE_ECDH_USE);
-    ossl_ssl_def_const(OP_SINGLE_DH_USE);
-    ossl_ssl_def_const(OP_EPHEMERAL_RSA);
-    ossl_ssl_def_const(OP_CIPHER_SERVER_PREFERENCE);
-    ossl_ssl_def_const(OP_TLS_ROLLBACK_BUG);
-    ossl_ssl_def_const(OP_NO_SSLv2);
-    ossl_ssl_def_const(OP_NO_SSLv3);
-    ossl_ssl_def_const(OP_NO_TLSv1);
-    ossl_ssl_def_const(OP_NO_TLSv1_1);
-    ossl_ssl_def_const(OP_NO_TLSv1_2);
-    ossl_ssl_def_const(OP_NO_TICKET);
-    ossl_ssl_def_const(OP_NO_COMPRESSION);
-    ossl_ssl_def_const(OP_PKCS1_CHECK_1);
-    ossl_ssl_def_const(OP_PKCS1_CHECK_2);
-    ossl_ssl_def_const(OP_NETSCAPE_CA_DN_BUG);
-    ossl_ssl_def_const(OP_NETSCAPE_DEMO_CIPHER_CHANGE_BUG);
+    rb_define_const(mSSL, "OP_ALL", ULONG2NUM(SSL_OP_ALL));
+    rb_define_const(mSSL, "OP_LEGACY_SERVER_CONNECT", ULONG2NUM(SSL_OP_LEGACY_SERVER_CONNECT));
+#ifdef SSL_OP_TLSEXT_PADDING /* OpenSSL 1.0.1h and OpenSSL 1.0.2 */
+    rb_define_const(mSSL, "OP_TLSEXT_PADDING", ULONG2NUM(SSL_OP_TLSEXT_PADDING));
+#endif
+#ifdef SSL_OP_SAFARI_ECDHE_ECDSA_BUG /* OpenSSL 1.0.1f and OpenSSL 1.0.2 */
+    rb_define_const(mSSL, "OP_SAFARI_ECDHE_ECDSA_BUG", ULONG2NUM(SSL_OP_SAFARI_ECDHE_ECDSA_BUG));
+#endif
+#ifdef SSL_OP_ALLOW_NO_DHE_KEX /* OpenSSL 1.1.1 */
+    rb_define_const(mSSL, "OP_ALLOW_NO_DHE_KEX", ULONG2NUM(SSL_OP_ALLOW_NO_DHE_KEX));
+#endif
+    rb_define_const(mSSL, "OP_DONT_INSERT_EMPTY_FRAGMENTS", ULONG2NUM(SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS));
+    rb_define_const(mSSL, "OP_NO_TICKET", ULONG2NUM(SSL_OP_NO_TICKET));
+    rb_define_const(mSSL, "OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION", ULONG2NUM(SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION));
+    rb_define_const(mSSL, "OP_NO_COMPRESSION", ULONG2NUM(SSL_OP_NO_COMPRESSION));
+    rb_define_const(mSSL, "OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION", ULONG2NUM(SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION));
+#ifdef SSL_OP_NO_ENCRYPT_THEN_MAC /* OpenSSL 1.1.1 */
+    rb_define_const(mSSL, "OP_NO_ENCRYPT_THEN_MAC", ULONG2NUM(SSL_OP_NO_ENCRYPT_THEN_MAC));
+#endif
+    rb_define_const(mSSL, "OP_CIPHER_SERVER_PREFERENCE", ULONG2NUM(SSL_OP_CIPHER_SERVER_PREFERENCE));
+    rb_define_const(mSSL, "OP_TLS_ROLLBACK_BUG", ULONG2NUM(SSL_OP_TLS_ROLLBACK_BUG));
+#ifdef SSL_OP_NO_RENEGOTIATION /* OpenSSL 1.1.1 */
+    rb_define_const(mSSL, "OP_NO_RENEGOTIATION", ULONG2NUM(SSL_OP_NO_RENEGOTIATION));
+#endif
+    rb_define_const(mSSL, "OP_CRYPTOPRO_TLSEXT_BUG", ULONG2NUM(SSL_OP_CRYPTOPRO_TLSEXT_BUG));
+
+    rb_define_const(mSSL, "OP_NO_SSLv3", ULONG2NUM(SSL_OP_NO_SSLv3));
+    rb_define_const(mSSL, "OP_NO_TLSv1", ULONG2NUM(SSL_OP_NO_TLSv1));
+    rb_define_const(mSSL, "OP_NO_TLSv1_1", ULONG2NUM(SSL_OP_NO_TLSv1_1));
+    rb_define_const(mSSL, "OP_NO_TLSv1_2", ULONG2NUM(SSL_OP_NO_TLSv1_2));
+#ifdef SSL_OP_NO_TLSv1_3 /* OpenSSL 1.1.1 */
+    rb_define_const(mSSL, "OP_NO_TLSv1_3", ULONG2NUM(SSL_OP_NO_TLSv1_3));
+#endif
+
+    /* SSL_OP_* flags for DTLS */
+#if 0
+    rb_define_const(mSSL, "OP_NO_QUERY_MTU", ULONG2NUM(SSL_OP_NO_QUERY_MTU));
+    rb_define_const(mSSL, "OP_COOKIE_EXCHANGE", ULONG2NUM(SSL_OP_COOKIE_EXCHANGE));
+    rb_define_const(mSSL, "OP_CISCO_ANYCONNECT", ULONG2NUM(SSL_OP_CISCO_ANYCONNECT));
+#endif
+
+    /* Deprecated in OpenSSL 1.1.0. */
+    rb_define_const(mSSL, "OP_MICROSOFT_SESS_ID_BUG", ULONG2NUM(SSL_OP_MICROSOFT_SESS_ID_BUG));
+    /* Deprecated in OpenSSL 1.1.0. */
+    rb_define_const(mSSL, "OP_NETSCAPE_CHALLENGE_BUG", ULONG2NUM(SSL_OP_NETSCAPE_CHALLENGE_BUG));
+    /* Deprecated in OpenSSL 0.9.8q and 1.0.0c. */
+    rb_define_const(mSSL, "OP_NETSCAPE_REUSE_CIPHER_CHANGE_BUG", ULONG2NUM(SSL_OP_NETSCAPE_REUSE_CIPHER_CHANGE_BUG));
+    /* Deprecated in OpenSSL 1.0.1h and 1.0.2. */
+    rb_define_const(mSSL, "OP_SSLREF2_REUSE_CERT_TYPE_BUG", ULONG2NUM(SSL_OP_SSLREF2_REUSE_CERT_TYPE_BUG));
+    /* Deprecated in OpenSSL 1.1.0. */
+    rb_define_const(mSSL, "OP_MICROSOFT_BIG_SSLV3_BUFFER", ULONG2NUM(SSL_OP_MICROSOFT_BIG_SSLV3_BUFFER));
+    /* Deprecated in OpenSSL 0.9.7h and 0.9.8b. */
+    rb_define_const(mSSL, "OP_MSIE_SSLV2_RSA_PADDING", ULONG2NUM(SSL_OP_MSIE_SSLV2_RSA_PADDING));
+    /* Deprecated in OpenSSL 1.1.0. */
+    rb_define_const(mSSL, "OP_SSLEAY_080_CLIENT_DH_BUG", ULONG2NUM(SSL_OP_SSLEAY_080_CLIENT_DH_BUG));
+    /* Deprecated in OpenSSL 1.1.0. */
+    rb_define_const(mSSL, "OP_TLS_D5_BUG", ULONG2NUM(SSL_OP_TLS_D5_BUG));
+    /* Deprecated in OpenSSL 1.1.0. */
+    rb_define_const(mSSL, "OP_TLS_BLOCK_PADDING_BUG", ULONG2NUM(SSL_OP_TLS_BLOCK_PADDING_BUG));
+    /* Deprecated in OpenSSL 1.1.0. */
+    rb_define_const(mSSL, "OP_SINGLE_ECDH_USE", ULONG2NUM(SSL_OP_SINGLE_ECDH_USE));
+    /* Deprecated in OpenSSL 1.1.0. */
+    rb_define_const(mSSL, "OP_SINGLE_DH_USE", ULONG2NUM(SSL_OP_SINGLE_DH_USE));
+    /* Deprecated in OpenSSL 1.0.1k and 1.0.2. */
+    rb_define_const(mSSL, "OP_EPHEMERAL_RSA", ULONG2NUM(SSL_OP_EPHEMERAL_RSA));
+    /* Deprecated in OpenSSL 1.1.0. */
+    rb_define_const(mSSL, "OP_NO_SSLv2", ULONG2NUM(SSL_OP_NO_SSLv2));
+    /* Deprecated in OpenSSL 1.0.1. */
+    rb_define_const(mSSL, "OP_PKCS1_CHECK_1", ULONG2NUM(SSL_OP_PKCS1_CHECK_1));
+    /* Deprecated in OpenSSL 1.0.1. */
+    rb_define_const(mSSL, "OP_PKCS1_CHECK_2", ULONG2NUM(SSL_OP_PKCS1_CHECK_2));
+    /* Deprecated in OpenSSL 1.1.0. */
+    rb_define_const(mSSL, "OP_NETSCAPE_CA_DN_BUG", ULONG2NUM(SSL_OP_NETSCAPE_CA_DN_BUG));
+    /* Deprecated in OpenSSL 1.1.0. */
+    rb_define_const(mSSL, "OP_NETSCAPE_DEMO_CIPHER_CHANGE_BUG", ULONG2NUM(SSL_OP_NETSCAPE_DEMO_CIPHER_CHANGE_BUG));
+
 
     sym_exception = ID2SYM(rb_intern("exception"));
     sym_wait_readable = ID2SYM(rb_intern("wait_readable"));

--- a/ext/openssl/ossl_ssl.c
+++ b/ext/openssl/ossl_ssl.c
@@ -727,7 +727,11 @@ ossl_sslctx_get_options(VALUE self)
 {
     SSL_CTX *ctx;
     GetSSLCTX(self, ctx);
-    return LONG2NUM(SSL_CTX_get_options(ctx));
+    /*
+     * Do explicit cast because SSL_CTX_get_options() returned (signed) long in
+     * OpenSSL before 1.1.0.
+     */
+    return ULONG2NUM((unsigned long)SSL_CTX_get_options(ctx));
 }
 
 /*
@@ -746,7 +750,7 @@ ossl_sslctx_set_options(VALUE self, VALUE options)
     if (NIL_P(options)) {
 	SSL_CTX_set_options(ctx, SSL_OP_ALL);
     } else {
-	SSL_CTX_set_options(ctx, NUM2LONG(options));
+	SSL_CTX_set_options(ctx, NUM2ULONG(options));
     }
 
     return self;
@@ -2661,7 +2665,7 @@ Init_ossl_ssl(void)
 # endif
 #endif
 
-#define ossl_ssl_def_const(x) rb_define_const(mSSL, #x, LONG2NUM(SSL_##x))
+#define ossl_ssl_def_const(x) rb_define_const(mSSL, #x, ULONG2NUM(SSL_##x))
 
     ossl_ssl_def_const(VERIFY_NONE);
     ossl_ssl_def_const(VERIFY_PEER);

--- a/lib/openssl/ssl.rb
+++ b/lib/openssl/ssl.rb
@@ -17,14 +17,13 @@ module OpenSSL
   module SSL
     class SSLContext
       DEFAULT_PARAMS = { # :nodoc:
-        :ssl_version => "SSLv23",
+        :min_version => OpenSSL::SSL::TLS1_VERSION,
         :verify_mode => OpenSSL::SSL::VERIFY_PEER,
         :verify_hostname => true,
         :options => -> {
           opts = OpenSSL::SSL::OP_ALL
           opts &= ~OpenSSL::SSL::OP_DONT_INSERT_EMPTY_FRAGMENTS
           opts |= OpenSSL::SSL::OP_NO_COMPRESSION
-          opts |= OpenSSL::SSL::OP_NO_SSLv2 | OpenSSL::SSL::OP_NO_SSLv3
           opts
         }.call
       }
@@ -109,11 +108,15 @@ YoaOffgTf5qxiwkjnlVZQc3whgnEt9FpVMvQ9eknyeGB5KHfayAc3+hUAvI3/Cr3
       attr_accessor :servername_cb
 
       # call-seq:
-      #    SSLContext.new => ctx
-      #    SSLContext.new(:TLSv1) => ctx
-      #    SSLContext.new("SSLv23_client") => ctx
+      #    SSLContext.new           -> ctx
+      #    SSLContext.new(:TLSv1)   -> ctx
+      #    SSLContext.new("SSLv23") -> ctx
       #
-      # You can get a list of valid methods with OpenSSL::SSL::SSLContext::METHODS
+      # Creates a new SSL context.
+      #
+      # If an argument is given, #ssl_version= is called with the value. Note
+      # that this form is deprecated. New applications should use #min_version=
+      # and #max_version= as necessary.
       def initialize(version = nil)
         self.options |= OpenSSL::SSL::OP_ALL
         self.ssl_version = version if version
@@ -140,6 +143,43 @@ YoaOffgTf5qxiwkjnlVZQc3whgnEt9FpVMvQ9eknyeGB5KHfayAc3+hUAvI3/Cr3
           end
         end
         return params
+      end
+
+      # call-seq:
+      #    ctx.min_version = OpenSSL::SSL::TLS1_2_VERSION
+      #    ctx.min_version = :TLS1_2
+      #    ctx.min_version = nil
+      #
+      # Sets the lower bound on the supported SSL/TLS protocol version. The
+      # version may be specified by an integer constant named
+      # OpenSSL::SSL::*_VERSION, a Symbol, or +nil+ which means "any version".
+      #
+      # Be careful that you don't overwrite OpenSSL::SSL::OP_NO_{SSL,TLS}v*
+      # options by #options= once you have called #min_version= or
+      # #max_version=.
+      #
+      # === Example
+      #   ctx = OpenSSL::SSL::SSLContext.new
+      #   ctx.min_version = OpenSSL::SSL::TLS1_1_VERSION
+      #   ctx.max_version = OpenSSL::SSL::TLS1_2_VERSION
+      #
+      #   sock = OpenSSL::SSL::SSLSocket.new(tcp_sock, ctx)
+      #   sock.connect # Initiates a connection using either TLS 1.1 or TLS 1.2
+      def min_version=(version)
+        set_minmax_proto_version(version, @max_proto_version ||= nil)
+        @min_proto_version = version
+      end
+
+      # call-seq:
+      #    ctx.max_version = OpenSSL::SSL::TLS1_2_VERSION
+      #    ctx.max_version = :TLS1_2
+      #    ctx.max_version = nil
+      #
+      # Sets the upper bound of the supported SSL/TLS protocol version. See
+      # #min_version= for the possible values.
+      def max_version=(version)
+        set_minmax_proto_version(@min_proto_version ||= nil, version)
+        @max_proto_version = version
       end
     end
 

--- a/test/test_ssl.rb
+++ b/test/test_ssl.rb
@@ -969,6 +969,17 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
     end
   end
 
+  def test_ssl_methods_constant
+    EnvUtil.suppress_warning { # Deprecated in v2.1.0
+      base = [:TLSv1_2, :TLSv1_1, :TLSv1, :SSLv3, :SSLv2, :SSLv23]
+      base.each do |name|
+        assert_include OpenSSL::SSL::SSLContext::METHODS, name
+        assert_include OpenSSL::SSL::SSLContext::METHODS, :"#{name}_client"
+        assert_include OpenSSL::SSL::SSLContext::METHODS, :"#{name}_server"
+      end
+    }
+  end
+
   def test_renegotiation_cb
     num_handshakes = 0
     renegotiation_cb = Proc.new { |ssl| num_handshakes += 1 }

--- a/test/utils.rb
+++ b/test/utils.rb
@@ -177,7 +177,10 @@ class OpenSSL::SSLTestCase < OpenSSL::TestCase
   end
 
   def tls12_supported?
-    OpenSSL::SSL::SSLContext::METHODS.include?(:TLSv1_2)
+    ctx = OpenSSL::SSL::SSLContext.new
+    ctx.min_version = ctx.max_version = OpenSSL::SSL::TLS1_2_VERSION
+    true
+  rescue
   end
 
   def readwrite_loop(ctx, ssl)


### PR DESCRIPTION
Add methods that set the minimum and maximum supported protocol
versions for the SSL context. If the OpenSSL library supports, use
SSL_CTX_set_{min,max}_proto_version() that do the exact thing.
Otherwise, simulate by combining SSL_OP_NO_{SSL,TLS}v* flags.

The new methods are meant to replace the deprecated
SSLContext#ssl_version= that cannot support multiple protocol versions.

SSLContext::DEFAULT_PARAMS is also updated to use the new
SSLContext#min_version=.