### PR TITLE
x509name: update regexp in OpenSSL::X509::Name.parse

### DIFF
--- a/lib/openssl/x509.rb
+++ b/lib/openssl/x509.rb
@@ -139,7 +139,13 @@ module OpenSSL
         end
 
         def parse_openssl(str, template=OBJECT_TYPE_TEMPLATE)
-          ary = str.scan(/\s*([^\/,]+)\s*/).collect{|i| i[0].split("=", 2) }
+          if str.start_with?("/")
+            # /A=B/C=D format
+            ary = str[1..-1].split("/").map { |i| i.split("=", 2) }
+          else
+            # Comma-separated
+            ary = str.split(",").map { |i| i.strip.split("=", 2) }
+          end
           self.new(ary, template)
         end
 

--- a/test/test_x509name.rb
+++ b/test/test_x509name.rb
@@ -148,33 +148,28 @@ class OpenSSL::TestX509Name < OpenSSL::TestCase
   end
 
   def test_s_parse
-    dn = "/DC=org/DC=ruby-lang/CN=www.ruby-lang.org"
+    dn = "/DC=org/DC=ruby-lang/CN=www.ruby-lang.org/1.2.3.4.5.6=A=BCD"
     name = OpenSSL::X509::Name.parse(dn)
     assert_equal(dn, name.to_s)
     ary = name.to_a
-    assert_equal("DC", ary[0][0])
-    assert_equal("DC", ary[1][0])
-    assert_equal("CN", ary[2][0])
-    assert_equal("org", ary[0][1])
-    assert_equal("ruby-lang", ary[1][1])
-    assert_equal("www.ruby-lang.org", ary[2][1])
-    assert_equal(OpenSSL::ASN1::IA5STRING, ary[0][2])
-    assert_equal(OpenSSL::ASN1::IA5STRING, ary[1][2])
-    assert_equal(OpenSSL::ASN1::UTF8STRING, ary[2][2])
+    assert_equal [
+      ["DC", "org", OpenSSL::ASN1::IA5STRING],
+      ["DC", "ruby-lang", OpenSSL::ASN1::IA5STRING],
+      ["CN", "www.ruby-lang.org", OpenSSL::ASN1::UTF8STRING],
+      ["1.2.3.4.5.6", "A=BCD", OpenSSL::ASN1::UTF8STRING],
+    ], ary
 
-    dn2 = "DC=org, DC=ruby-lang, CN=www.ruby-lang.org"
+    dn2 = "DC=org, DC=ruby-lang, CN=www.ruby-lang.org, 1.2.3.4.5.6=A=BCD"
     name = OpenSSL::X509::Name.parse(dn2)
-    ary = name.to_a
     assert_equal(dn, name.to_s)
-    assert_equal("org", ary[0][1])
-    assert_equal("ruby-lang", ary[1][1])
-    assert_equal("www.ruby-lang.org", ary[2][1])
+    assert_equal ary, name.to_a
 
     name = OpenSSL::X509::Name.parse(dn2, @obj_type_tmpl)
     ary = name.to_a
     assert_equal(OpenSSL::ASN1::IA5STRING, ary[0][2])
     assert_equal(OpenSSL::ASN1::IA5STRING, ary[1][2])
     assert_equal(OpenSSL::ASN1::PRINTABLESTRING, ary[2][2])
+    assert_equal(OpenSSL::ASN1::PRINTABLESTRING, ary[3][2])
   end
 
   def test_s_parse_rfc2253
@@ -357,15 +352,15 @@ class OpenSSL::TestX509Name < OpenSSL::TestCase
   end
 
   def test_equals2
-    n1 = OpenSSL::X509::Name.parse 'CN=a'
-    n2 = OpenSSL::X509::Name.parse 'CN=a'
+    n1 = OpenSSL::X509::Name.parse_rfc2253 'CN=a'
+    n2 = OpenSSL::X509::Name.parse_rfc2253 'CN=a'
 
     assert_equal n1, n2
   end
 
   def test_spaceship
-    n1 = OpenSSL::X509::Name.parse 'CN=a'
-    n2 = OpenSSL::X509::Name.parse 'CN=b'
+    n1 = OpenSSL::X509::Name.parse_rfc2253 'CN=a'
+    n2 = OpenSSL::X509::Name.parse_rfc2253 'CN=b'
 
     assert_equal(-1, n1 <=> n2)
   end


### PR DESCRIPTION
Allow the attribute value to contain ',', just as the openssl utility's
parse_name() function does.

Fixes: https://github.com/ruby/openssl/issues/39