### PR TITLE
ossl.c: make legacy locking callbacks reentrant

### DIFF
--- a/ext/openssl/ossl.c
+++ b/ext/openssl/ossl.c
@@ -484,40 +484,41 @@ print_mem_leaks(VALUE self)
 /**
  * Stores locks needed for OpenSSL thread safety
  */
-static rb_nativethread_lock_t *ossl_locks;
-
-static void
-ossl_lock_unlock(int mode, rb_nativethread_lock_t *lock)
-{
-    if (mode & CRYPTO_LOCK) {
-	rb_nativethread_lock_lock(lock);
-    } else {
-	rb_nativethread_lock_unlock(lock);
-    }
-}
-
-static void
-ossl_lock_callback(int mode, int type, const char *file, int line)
-{
-    ossl_lock_unlock(mode, &ossl_locks[type]);
-}
-
 struct CRYPTO_dynlock_value {
     rb_nativethread_lock_t lock;
 };
 
+static void
+ossl_lock_init(struct CRYPTO_dynlock_value *l)
+{
+    rb_nativethread_lock_initialize(&l->lock);
+}
+
+static void
+ossl_lock_unlock(int mode, struct CRYPTO_dynlock_value *l)
+{
+    if (mode & CRYPTO_LOCK) {
+	rb_nativethread_lock_lock(&l->lock);
+    } else {
+	rb_nativethread_lock_unlock(&l->lock);
+    }
+}
+
 static struct CRYPTO_dynlock_value *
 ossl_dyn_create_callback(const char *file, int line)
 {
-    struct CRYPTO_dynlock_value *dynlock = (struct CRYPTO_dynlock_value *)OPENSSL_malloc((int)sizeof(struct CRYPTO_dynlock_value));
-    rb_nativethread_lock_initialize(&dynlock->lock);
+    /* Do not use xmalloc() here, since it may raise NoMemoryError */
+    struct CRYPTO_dynlock_value *dynlock =
+	OPENSSL_malloc(sizeof(struct CRYPTO_dynlock_value));
+    if (dynlock)
+	ossl_lock_init(dynlock);
     return dynlock;
 }
 
 static void
 ossl_dyn_lock_callback(int mode, struct CRYPTO_dynlock_value *l, const char *file, int line)
 {
-    ossl_lock_unlock(mode, &l->lock);
+    ossl_lock_unlock(mode, l);
 }
 
 static void
@@ -541,21 +542,22 @@ static unsigned long ossl_thread_id(void)
 }
 #endif
 
+static struct CRYPTO_dynlock_value *ossl_locks;
+
+static void
+ossl_lock_callback(int mode, int type, const char *file, int line)
+{
+    ossl_lock_unlock(mode, &ossl_locks[type]);
+}
+
 static void Init_ossl_locks(void)
 {
     int i;
     int num_locks = CRYPTO_num_locks();
 
-    if ((unsigned)num_locks >= INT_MAX / (int)sizeof(VALUE)) {
-	rb_raise(rb_eRuntimeError, "CRYPTO_num_locks() is too big: %d", num_locks);
-    }
-    ossl_locks = (rb_nativethread_lock_t *) OPENSSL_malloc(num_locks * (int)sizeof(rb_nativethread_lock_t));
-    if (!ossl_locks) {
-	rb_raise(rb_eNoMemError, "CRYPTO_num_locks() is too big: %d", num_locks);
-    }
-    for (i = 0; i < num_locks; i++) {
-	rb_nativethread_lock_initialize(&ossl_locks[i]);
-    }
+    ossl_locks = ALLOC_N(struct CRYPTO_dynlock_value, num_locks);
+    for (i = 0; i < num_locks; i++)
+	ossl_lock_init(&ossl_locks[i]);
 
 #ifdef HAVE_CRYPTO_THREADID_PTR
     CRYPTO_THREADID_set_callback(ossl_threadid_func);


### PR DESCRIPTION
Although it's not documented explicitly that the locking callbacks must
provide reentrant mutexes, it seems to be required.

Specifically, the session_remove_cb callback function of an SSL_CTX is
called in a critical section for CRYPTO_LOCK_SSL_CTX, which is shared
across the library. This leads, if the callback function calls another
OpenSSL function that will attempt to lock CRYPTO_LOCK_SSL_CTX, to
deadlock. SSL_CTX_free() is one example of such a function.

http://ci.rvm.jp/results/trunk@P895/64001