### PR TITLE
test/test_ssl_session: skip tests for session_remove_cb

### DIFF
--- a/ext/openssl/ossl_ssl.c
+++ b/ext/openssl/ossl_ssl.c
@@ -2446,6 +2446,10 @@ Init_ossl_ssl(void)
      * A callback invoked when a session is removed from the internal cache.
      *
      * The callback is invoked with an SSLContext and a Session.
+     *
+     * IMPORTANT NOTE: It is currently not possible to use this safely in a
+     * multi-threaded application. The callback is called inside a global lock
+     * and it can randomly cause deadlock on Ruby thread switching.
      */
     rb_attr(cSSLContext, rb_intern("session_remove_cb"), 1, 1, Qfalse);
 


### PR DESCRIPTION
In OpenSSL < 1.1.0, the session_remove_cb callback is called inside the
global lock for CRYPTO_LOCK_SSL_CTX which is shared across the entire
process, not just for the specific SSL_CTX object. It is possible that
the callback releases GVL while the lock for CRYPTO_LOCK_SSL_CTX is
held, causing another thread calling an OpenSSL function that tries to
acquire the same lock stuck forever.

Add a note about the possible deadlock to the docs for
SSLContext#session_remove_cb=, and skip the relevant test cases unless
the OSSL_TEST_ALL environment variable is set to 1.

A deadlock due to this issue is observed:

  http://ci.rvm.jp/results/trunk-test@frontier/104428