### PR TITLE
Fix build failure against OpenSSL 1.1 built with no-deprecated

### DIFF
--- a/ext/openssl/openssl_missing.h
+++ b/ext/openssl/openssl_missing.h
@@ -209,6 +209,10 @@ IMPL_PKEY_GETTER(EC_KEY, ec)
 #  define X509_get0_notAfter(x) X509_get_notAfter(x)
 #  define X509_CRL_get0_lastUpdate(x) X509_CRL_get_lastUpdate(x)
 #  define X509_CRL_get0_nextUpdate(x) X509_CRL_get_nextUpdate(x)
+#  define X509_set1_notBefore(x, t) X509_set_notBefore(x, t)
+#  define X509_set1_notAfter(x, t) X509_set_notAfter(x, t)
+#  define X509_CRL_set1_lastUpdate(x, t) X509_CRL_set_lastUpdate(x, t)
+#  define X509_CRL_set1_nextUpdate(x, t) X509_CRL_set_nextUpdate(x, t)
 #endif
 
 #if !defined(HAVE_SSL_SESSION_GET_PROTOCOL_VERSION)

--- a/ext/openssl/ossl.c
+++ b/ext/openssl/ossl.c
@@ -1109,25 +1109,14 @@ Init_openssl(void)
     /*
      * Init all digests, ciphers
      */
-    /* CRYPTO_malloc_init(); */
-    /* ENGINE_load_builtin_engines(); */
+#if !defined(LIBRESSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x10100000
+    if (!OPENSSL_init_ssl(0, NULL))
+        rb_raise(rb_eRuntimeError, "OPENSSL_init_ssl");
+#else
     OpenSSL_add_ssl_algorithms();
     OpenSSL_add_all_algorithms();
     ERR_load_crypto_strings();
     SSL_load_error_strings();
-
-    /*
-     * FIXME:
-     * On unload do:
-     */
-#if 0
-    CONF_modules_unload(1);
-    destroy_ui_method();
-    EVP_cleanup();
-    ENGINE_cleanup();
-    CRYPTO_cleanup_all_ex_data();
-    ERR_remove_state(0);
-    ERR_free_strings();
 #endif
 
     /*
@@ -1149,7 +1138,11 @@ Init_openssl(void)
     /*
      * Version of OpenSSL the ruby OpenSSL extension is running with
      */
+#if !defined(LIBRESSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x10100000
+    rb_define_const(mOSSL, "OPENSSL_LIBRARY_VERSION", rb_str_new2(OpenSSL_version(OPENSSL_VERSION)));
+#else
     rb_define_const(mOSSL, "OPENSSL_LIBRARY_VERSION", rb_str_new2(SSLeay_version(SSLEAY_VERSION)));
+#endif
 
     /*
      * Version number of OpenSSL the ruby OpenSSL extension was built with

--- a/ext/openssl/ossl.h
+++ b/ext/openssl/ossl.h
@@ -35,6 +35,11 @@
 #if !defined(OPENSSL_NO_OCSP)
 #  include <openssl/ocsp.h>
 #endif
+#include <openssl/bn.h>
+#include <openssl/rsa.h>
+#include <openssl/dsa.h>
+#include <openssl/evp.h>
+#include <openssl/dh.h>
 
 /*
  * Common Module

--- a/ext/openssl/ossl_cipher.c
+++ b/ext/openssl/ossl_cipher.c
@@ -508,7 +508,7 @@ ossl_cipher_set_iv(VALUE self, VALUE iv)
     StringValue(iv);
     GetCipher(self, ctx);
 
-    if (EVP_CIPHER_CTX_flags(ctx) & EVP_CIPH_FLAG_AEAD_CIPHER)
+    if (EVP_CIPHER_flags(EVP_CIPHER_CTX_cipher(ctx)) & EVP_CIPH_FLAG_AEAD_CIPHER)
 	iv_len = (int)(VALUE)EVP_CIPHER_CTX_get_app_data(ctx);
     if (!iv_len)
 	iv_len = EVP_CIPHER_CTX_iv_length(ctx);
@@ -535,7 +535,7 @@ ossl_cipher_is_authenticated(VALUE self)
 
     GetCipher(self, ctx);
 
-    return (EVP_CIPHER_CTX_flags(ctx) & EVP_CIPH_FLAG_AEAD_CIPHER) ? Qtrue : Qfalse;
+    return (EVP_CIPHER_flags(EVP_CIPHER_CTX_cipher(ctx)) & EVP_CIPH_FLAG_AEAD_CIPHER) ? Qtrue : Qfalse;
 }
 
 /*
@@ -606,7 +606,7 @@ ossl_cipher_get_auth_tag(int argc, VALUE *argv, VALUE self)
 
     GetCipher(self, ctx);
 
-    if (!(EVP_CIPHER_CTX_flags(ctx) & EVP_CIPH_FLAG_AEAD_CIPHER))
+    if (!(EVP_CIPHER_flags(EVP_CIPHER_CTX_cipher(ctx)) & EVP_CIPH_FLAG_AEAD_CIPHER))
 	ossl_raise(eCipherError, "authentication tag not supported by this cipher");
 
     ret = rb_str_new(NULL, tag_len);
@@ -641,7 +641,7 @@ ossl_cipher_set_auth_tag(VALUE self, VALUE vtag)
     tag_len = RSTRING_LENINT(vtag);
 
     GetCipher(self, ctx);
-    if (!(EVP_CIPHER_CTX_flags(ctx) & EVP_CIPH_FLAG_AEAD_CIPHER))
+    if (!(EVP_CIPHER_flags(EVP_CIPHER_CTX_cipher(ctx)) & EVP_CIPH_FLAG_AEAD_CIPHER))
 	ossl_raise(eCipherError, "authentication tag not supported by this cipher");
 
     if (!EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_SET_TAG, tag_len, tag))
@@ -668,7 +668,7 @@ ossl_cipher_set_auth_tag_len(VALUE self, VALUE vlen)
     EVP_CIPHER_CTX *ctx;
 
     GetCipher(self, ctx);
-    if (!(EVP_CIPHER_CTX_flags(ctx) & EVP_CIPH_FLAG_AEAD_CIPHER))
+    if (!(EVP_CIPHER_flags(EVP_CIPHER_CTX_cipher(ctx)) & EVP_CIPH_FLAG_AEAD_CIPHER))
 	ossl_raise(eCipherError, "AEAD not supported by this cipher");
 
     if (!EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_SET_TAG, tag_len, NULL))
@@ -695,7 +695,7 @@ ossl_cipher_set_iv_length(VALUE self, VALUE iv_length)
     EVP_CIPHER_CTX *ctx;
 
     GetCipher(self, ctx);
-    if (!(EVP_CIPHER_CTX_flags(ctx) & EVP_CIPH_FLAG_AEAD_CIPHER))
+    if (!(EVP_CIPHER_flags(EVP_CIPHER_CTX_cipher(ctx)) & EVP_CIPH_FLAG_AEAD_CIPHER))
 	ossl_raise(eCipherError, "cipher does not support AEAD");
 
     if (!EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_SET_IVLEN, len, NULL))
@@ -786,7 +786,7 @@ ossl_cipher_iv_length(VALUE self)
     int len = 0;
 
     GetCipher(self, ctx);
-    if (EVP_CIPHER_CTX_flags(ctx) & EVP_CIPH_FLAG_AEAD_CIPHER)
+    if (EVP_CIPHER_flags(EVP_CIPHER_CTX_cipher(ctx)) & EVP_CIPH_FLAG_AEAD_CIPHER)
 	len = (int)(VALUE)EVP_CIPHER_CTX_get_app_data(ctx);
     if (!len)
 	len = EVP_CIPHER_CTX_iv_length(ctx);

--- a/ext/openssl/ossl_ssl.c
+++ b/ext/openssl/ossl_ssl.c
@@ -379,7 +379,7 @@ ossl_call_session_get_cb(VALUE ary)
 
 /* this method is currently only called for servers (in OpenSSL <= 0.9.8e) */
 static SSL_SESSION *
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+#if OPENSSL_VERSION_NUMBER >= 0x10100000 && !defined(LIBRESSL_VERSION_NUMBER)
 ossl_sslctx_session_get_cb(SSL *ssl, const unsigned char *buf, int len, int *copy)
 #else
 ossl_sslctx_session_get_cb(SSL *ssl, unsigned char *buf, int len, int *copy)

--- a/ext/openssl/ossl_x509cert.c
+++ b/ext/openssl/ossl_x509cert.c
@@ -440,7 +440,7 @@ ossl_x509_set_not_before(VALUE self, VALUE time)
 
     GetX509(self, x509);
     asn1time = ossl_x509_time_adjust(NULL, time);
-    if (!X509_set_notBefore(x509, asn1time)) {
+    if (!X509_set1_notBefore(x509, asn1time)) {
 	ASN1_TIME_free(asn1time);
 	ossl_raise(eX509CertError, "X509_set_notBefore");
     }
@@ -479,7 +479,7 @@ ossl_x509_set_not_after(VALUE self, VALUE time)
 
     GetX509(self, x509);
     asn1time = ossl_x509_time_adjust(NULL, time);
-    if (!X509_set_notAfter(x509, asn1time)) {
+    if (!X509_set1_notAfter(x509, asn1time)) {
 	ASN1_TIME_free(asn1time);
 	ossl_raise(eX509CertError, "X509_set_notAfter");
     }

--- a/ext/openssl/ossl_x509crl.c
+++ b/ext/openssl/ossl_x509crl.c
@@ -226,7 +226,7 @@ ossl_x509crl_set_last_update(VALUE self, VALUE time)
 
     GetX509CRL(self, crl);
     asn1time = ossl_x509_time_adjust(NULL, time);
-    if (!X509_CRL_set_lastUpdate(crl, asn1time)) {
+    if (!X509_CRL_set1_lastUpdate(crl, asn1time)) {
 	ASN1_TIME_free(asn1time);
 	ossl_raise(eX509CRLError, "X509_CRL_set_lastUpdate");
     }
@@ -257,7 +257,7 @@ ossl_x509crl_set_next_update(VALUE self, VALUE time)
 
     GetX509CRL(self, crl);
     asn1time = ossl_x509_time_adjust(NULL, time);
-    if (!X509_CRL_set_nextUpdate(crl, asn1time)) {
+    if (!X509_CRL_set1_nextUpdate(crl, asn1time)) {
 	ASN1_TIME_free(asn1time);
 	ossl_raise(eX509CRLError, "X509_CRL_set_nextUpdate");
     }


### PR DESCRIPTION
The proposed changes remove the use of the OpenSSL 1.1.0 deprecated API.  Which fixes the following build errors that occur on Gentoo when building ruby 2.4.2 with openssl 1.1.0f built with no-deprecated:

compiling ossl.c
ossl.c: In function ‘Init_openssl’:
ossl.c:1014:5: warning: implicit declaration of function ‘OpenSSL_add_all_algorithms’; did you mean ‘OpenSSL_add_ssl_algorithms’? [-Wimplicit-function-declaration]
     OpenSSL_add_all_algorithms();
     ^~~~~~~~~~~~~~~~~~~~~~~~~~
     OpenSSL_add_ssl_algorithms
ossl.c:1015:5: warning: implicit declaration of function ‘ERR_load_crypto_strings’; did you mean ‘ERR_load_OCSP_strings’? [-Wimplicit-function-declaration]
     ERR_load_crypto_strings();
     ^~~~~~~~~~~~~~~~~~~~~~~
     ERR_load_OCSP_strings
ossl.c:1016:5: warning: implicit declaration of function ‘SSL_load_error_strings’; did you mean ‘ERR_lib_error_string’? [-Wimplicit-function-declaration]
     SSL_load_error_strings();
     ^~~~~~~~~~~~~~~~~~~~~~
     ERR_lib_error_string
In file included from ../.././include/ruby/ruby.h:36:0,
                 from ../.././include/ruby.h:33,
                 from ossl.h:17,
                 from ossl.c:10:
ossl.c:1051:67: warning: implicit declaration of function ‘SSLeay_version’; did you mean ‘SSL_version’? [-Wimplicit-function-declaration]
     rb_define_const(mOSSL, "OPENSSL_LIBRARY_VERSION", rb_str_new2(SSLeay_version(SSLEAY_VERSION)));
                                                                   ^
../.././include/ruby/defines.h:94:53: note: in definition of macro ‘RB_GNUC_EXTENSION_BLOCK’
 #define RB_GNUC_EXTENSION_BLOCK(x) __extension__ ({ x; })
                                                     ^
../.././include/ruby/intern.h:857:21: note: in expansion of macro ‘rb_str_new_cstr’
 #define rb_str_new2 rb_str_new_cstr
                     ^~~~~~~~~~~~~~~
ossl.c:1051:55: note: in expansion of macro ‘rb_str_new2’
     rb_define_const(mOSSL, "OPENSSL_LIBRARY_VERSION", rb_str_new2(SSLeay_version(SSLEAY_VERSION)));
                                                       ^~~~~~~~~~~
ossl.c:1051:82: error: ‘SSLEAY_VERSION’ undeclared (first use in this function); did you mean ‘SSL2_VERSION’?
     rb_define_const(mOSSL, "OPENSSL_LIBRARY_VERSION", rb_str_new2(SSLeay_version(SSLEAY_VERSION)));
                                                                                  ^
../.././include/ruby/defines.h:94:53: note: in definition of macro ‘RB_GNUC_EXTENSION_BLOCK’
 #define RB_GNUC_EXTENSION_BLOCK(x) __extension__ ({ x; })
                                                     ^
../.././include/ruby/intern.h:857:21: note: in expansion of macro ‘rb_str_new_cstr’
 #define rb_str_new2 rb_str_new_cstr
                     ^~~~~~~~~~~~~~~
ossl.c:1051:55: note: in expansion of macro ‘rb_str_new2’
     rb_define_const(mOSSL, "OPENSSL_LIBRARY_VERSION", rb_str_new2(SSLeay_version(SSLEAY_VERSION)));
                                                       ^~~~~~~~~~~
ossl.c:1051:82: note: each undeclared identifier is reported only once for each function it appears in
     rb_define_const(mOSSL, "OPENSSL_LIBRARY_VERSION", rb_str_new2(SSLeay_version(SSLEAY_VERSION)));
                                                                                  ^
../.././include/ruby/defines.h:94:53: note: in definition of macro ‘RB_GNUC_EXTENSION_BLOCK’
 #define RB_GNUC_EXTENSION_BLOCK(x) __extension__ ({ x; })
                                                     ^
../.././include/ruby/intern.h:857:21: note: in expansion of macro ‘rb_str_new_cstr’
 #define rb_str_new2 rb_str_new_cstr
                     ^~~~~~~~~~~~~~~
ossl.c:1051:55: note: in expansion of macro ‘rb_str_new2’
     rb_define_const(mOSSL, "OPENSSL_LIBRARY_VERSION", rb_str_new2(SSLeay_version(SSLEAY_VERSION)));
                                                       ^~~~~~~~~~~

The Gentoo bug is:
https://bugs.gentoo.org/614760