### PR TITLE
buffering: let #write accept multiple arguments

### DIFF
--- a/lib/openssl/buffering.rb
+++ b/lib/openssl/buffering.rb
@@ -339,9 +339,11 @@ module OpenSSL::Buffering
   # Writes _s_ to the stream.  If the argument is not a String it will be
   # converted using +.to_s+ method.  Returns the number of bytes written.
 
-  def write(s)
-    do_write(s)
-    s.bytesize
+  def write(*s)
+    s.inject(0) do |written, str|
+      do_write(str)
+      written + str.bytesize
+    end
   end
 
   ##

--- a/test/test_pair.rb
+++ b/test/test_pair.rb
@@ -362,6 +362,15 @@ module OpenSSL::TestPairM
     }
   end
 
+  def test_write_multiple_arguments
+    ssl_pair {|s1, s2|
+      str1 = "foo"; str2 = "bar"
+      assert_equal 6, s1.write(str1, str2)
+      s1.close
+      assert_equal "foobar", s2.read
+    }
+  end
+
   def test_partial_tls_record_read_nonblock
     ssl_pair { |s1, s2|
       # the beginning of a TLS record


### PR DESCRIPTION
As of Ruby 2.5, IO#write accepts multiple input strings and writes them
at once[1]. Follow that.

[1] https://bugs.ruby-lang.org/issues/9323