### PR TITLE
Allow multiple certs & keys for SSLContext

### DIFF
--- a/ext/openssl/ossl_ssl.c
+++ b/ext/openssl/ossl_ssl.c
@@ -38,7 +38,7 @@ static VALUE sym_exception, sym_wait_readable, sym_wait_writable;
 
 static ID id_i_cert_store, id_i_ca_file, id_i_ca_path, id_i_verify_mode,
 	  id_i_verify_depth, id_i_verify_callback, id_i_client_ca,
-	  id_i_renegotiation_cb, id_i_cert, id_i_key, id_i_extra_chain_cert,
+	  id_i_renegotiation_cb, id_i_certs, id_i_keys, id_i_extra_chain_cert,
 	  id_i_client_cert_cb, id_i_tmp_ecdh_callback, id_i_timeout,
 	  id_i_session_id_context, id_i_session_get_cb, id_i_session_new_cb,
 	  id_i_session_remove_cb, id_i_npn_select_cb, id_i_npn_protocols,
@@ -780,7 +780,8 @@ ossl_sslctx_setup(VALUE self)
     char *ca_path = NULL, *ca_file = NULL;
     int verify_mode;
     long i;
-    VALUE val;
+    VALUE val, val2;
+    int cert_defined = 0, key_defined = 0;
 
     if(OBJ_FROZEN(self)) return Qnil;
     GetSSLCTX(self, ctx);
@@ -832,19 +833,38 @@ ossl_sslctx_setup(VALUE self)
     }
 
     /* private key may be bundled in certificate file. */
-    val = rb_attr_get(self, id_i_cert);
-    cert = NIL_P(val) ? NULL : GetX509CertPtr(val); /* NO DUP NEEDED */
-    val = rb_attr_get(self, id_i_key);
-    key = NIL_P(val) ? NULL : GetPrivPKeyPtr(val); /* NO DUP NEEDED */
-    if (cert && key) {
-        if (!SSL_CTX_use_certificate(ctx, cert)) {
-            /* Adds a ref => Safe to FREE */
-            ossl_raise(eSSLError, "SSL_CTX_use_certificate");
+    val = rb_attr_get(self, id_i_certs);
+    if (!NIL_P(val)) {
+        Check_Type(val, T_ARRAY);
+        for (i = 0; i < RARRAY_LEN(val); i++) {
+            val2 = rb_ary_entry(val, i);
+            if (!NIL_P(val2)) {
+                cert_defined = 1;
+                cert = GetX509CertPtr(val2); /* NO DUP NEEDED */
+                if (!SSL_CTX_use_certificate(ctx, cert)) {
+                    /* Adds a ref => Safe to FREE */
+                    ossl_raise(eSSLError, "SSL_CTX_use_certificate");
+                }
+            }
         }
-        if (!SSL_CTX_use_PrivateKey(ctx, key)) {
-            /* Adds a ref => Safe to FREE */
-            ossl_raise(eSSLError, "SSL_CTX_use_PrivateKey");
+    }
+    val = rb_attr_get(self, id_i_keys);
+    if (!NIL_P(val)) {
+        Check_Type(val, T_ARRAY);
+        for (i = 0; i < RARRAY_LEN(val); i++) {
+            val2 = rb_ary_entry(val, i);
+            if (!NIL_P(val2)) {
+                key =  GetPrivPKeyPtr(val2); /* NO DUP NEEDED */
+                key_defined = 1;
+                if (!SSL_CTX_use_PrivateKey(ctx, key)) {
+                    /* Adds a ref => Safe to FREE */
+                    ossl_raise(eSSLError, "SSL_CTX_use_PrivateKey");
+                }
+            }
         }
+    }
+
+    if (cert_defined && key_defined) {
         if (!SSL_CTX_check_private_key(ctx)) {
             ossl_raise(eSSLError, "SSL_CTX_check_private_key");
         }
@@ -852,22 +872,21 @@ ossl_sslctx_setup(VALUE self)
 
     val = rb_attr_get(self, id_i_client_ca);
     if(!NIL_P(val)){
-	if (RB_TYPE_P(val, T_ARRAY)) {
-	    for(i = 0; i < RARRAY_LEN(val); i++){
-		client_ca = GetX509CertPtr(RARRAY_AREF(val, i));
-        	if (!SSL_CTX_add_client_CA(ctx, client_ca)){
-		    /* Copies X509_NAME => FREE it. */
-        	    ossl_raise(eSSLError, "SSL_CTX_add_client_CA");
-        	}
-	    }
-        }
-	else{
-	    client_ca = GetX509CertPtr(val); /* NO DUP NEEDED. */
-            if (!SSL_CTX_add_client_CA(ctx, client_ca)){
-		/* Copies X509_NAME => FREE it. */
-        	ossl_raise(eSSLError, "SSL_CTX_add_client_CA");
+        if (RB_TYPE_P(val, T_ARRAY)) {
+            for(i = 0; i < RARRAY_LEN(val); i++) {
+                client_ca = GetX509CertPtr(RARRAY_AREF(val, i));
+                if (!SSL_CTX_add_client_CA(ctx, client_ca)) {
+                    /* Copies X509_NAME => FREE it. */
+                    ossl_raise(eSSLError, "SSL_CTX_add_client_CA");
+                }
             }
-	}
+        } else {
+            client_ca = GetX509CertPtr(val); /* NO DUP NEEDED. */
+            if (!SSL_CTX_add_client_CA(ctx, client_ca)) {
+                /* Copies X509_NAME => FREE it. */
+                ossl_raise(eSSLError, "SSL_CTX_add_client_CA");
+            }
+        }
     }
 
     val = rb_attr_get(self, id_i_ca_file);
@@ -2326,12 +2345,12 @@ Init_ossl_ssl(void)
     /*
      * Context certificate
      */
-    rb_attr(cSSLContext, rb_intern("cert"), 1, 1, Qfalse);
+    rb_attr(cSSLContext, rb_intern("certs"), 1, 1, Qfalse);
 
     /*
      * Context private key
      */
-    rb_attr(cSSLContext, rb_intern("key"), 1, 1, Qfalse);
+    rb_attr(cSSLContext, rb_intern("keys"), 1, 1, Qfalse);
 
     /*
      * A certificate or Array of certificates that will be sent to the client.
@@ -2787,8 +2806,8 @@ Init_ossl_ssl(void)
     DefIVarID(verify_callback);
     DefIVarID(client_ca);
     DefIVarID(renegotiation_cb);
-    DefIVarID(cert);
-    DefIVarID(key);
+    DefIVarID(certs);
+    DefIVarID(keys);
     DefIVarID(extra_chain_cert);
     DefIVarID(client_cert_cb);
     DefIVarID(tmp_ecdh_callback);

--- a/lib/openssl/ssl.rb
+++ b/lib/openssl/ssl.rb
@@ -118,8 +118,25 @@ YoaOffgTf5qxiwkjnlVZQc3whgnEt9FpVMvQ9eknyeGB5KHfayAc3+hUAvI3/Cr3
       # that this form is deprecated. New applications should use #min_version=
       # and #max_version= as necessary.
       def initialize(version = nil)
+        @certs = []
+        @keys = []
         self.options |= OpenSSL::SSL::OP_ALL
         self.ssl_version = version if version
+      end
+
+      # Compatibility with previous version supporting a single certificate
+      def cert=(cert)
+        self.certs = [cert]
+      end
+      def cert
+        self.certs.first
+      end
+
+      def key=(key)
+        self.keys = [key]
+      end
+      def key
+        self.keys.first
       end
 
       ##

--- a/test/test_ssl.rb
+++ b/test/test_ssl.rb
@@ -1222,6 +1222,29 @@ end
     end
   end
 
+  def test_server_with_multiple_certificate
+    ctx_proc = proc { |ctx|
+      ctx.ssl_version = :TLSv1_2
+      ctx.ciphers = 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384'
+      ctx.keys = [@svr_key, @ec_key]
+      ctx.certs = [@svr_cert, @ec_cert]
+    }
+    start_server(ctx_proc: ctx_proc) do |port|
+      ctx = OpenSSL::SSL::SSLContext.new
+      ctx.ssl_version = :TLSv1_2
+      ctx.ciphers = 'ECDHE-RSA-AES256-GCM-SHA384'
+      server_connect(port, ctx) { |ssl|
+        assert_instance_of OpenSSL::PKey::RSA, ssl.peer_cert.public_key
+      }
+
+      ctx = OpenSSL::SSL::SSLContext.new
+      ctx.ciphers = 'ECDHE-ECDSA-AES256-GCM-SHA384'
+      server_connect(port, ctx) { |ssl|
+        assert_instance_of OpenSSL::PKey::EC, ssl.peer_cert.public_key
+      }
+    end
+  end
+
   def test_dh_callback
     pend "TLS 1.2 is not supported" unless tls12_supported?
 


### PR DESCRIPTION
This allow to serve both RSA & ECDSA in same time on a single TLS server
Compatibility is kept for single cert & key configuration.