### PR TITLE
pkcs7: allow recipient's certificate to be omitted for PKCS7#decrypt

### DIFF
--- a/ext/openssl/ossl_pkcs7.c
+++ b/ext/openssl/ossl_pkcs7.c
@@ -803,9 +803,9 @@ ossl_pkcs7_decrypt(int argc, VALUE *argv, VALUE self)
     BIO *out;
     VALUE str;
 
-    rb_scan_args(argc, argv, "21", &pkey, &cert, &flags);
+    rb_scan_args(argc, argv, "12", &pkey, &cert, &flags);
     key = GetPrivPKeyPtr(pkey); /* NO NEED TO DUP */
-    x509 = GetX509CertPtr(cert); /* NO NEED TO DUP */
+    x509 = NIL_P(cert) ? NULL : GetX509CertPtr(cert); /* NO NEED TO DUP */
     flg = NIL_P(flags) ? 0 : NUM2INT(flags);
     GetPKCS7(self, p7);
     if(!(out = BIO_new(BIO_s_mem())))

--- a/test/test_pkcs7.rb
+++ b/test/test_pkcs7.rb
@@ -133,6 +133,8 @@ class OpenSSL::TestPKCS7 < OpenSSL::TestCase
     assert_equal(@ca_cert.subject.to_s, recip[1].issuer.to_s)
     assert_equal(3, recip[1].serial)
     assert_equal(data, p7.decrypt(@rsa1024, @ee2_cert))
+
+    assert_equal(data, p7.decrypt(@rsa1024))
   end
 
   def test_graceful_parsing_failure #[ruby-core:43250]


### PR DESCRIPTION
The recipient's certificate is not mandatory for PKCS7_decrypt(). Make
it possible to call OpenSSL::PKCS7#decrypt with only the private key to
match the functionality with PKCS7_decrypt().

Reference: https://github.com/ruby/openssl/issues/182