### PR TITLE
cipher: validate iterations argument for Cipher#pkcs5_keyivgen

### DIFF
--- a/ext/openssl/ossl_cipher.c
+++ b/ext/openssl/ossl_cipher.c
@@ -321,6 +321,8 @@ ossl_cipher_pkcs5_keyivgen(int argc, VALUE *argv, VALUE self)
 	salt = (unsigned char *)RSTRING_PTR(vsalt);
     }
     iter = NIL_P(viter) ? 2048 : NUM2INT(viter);
+    if (iter <= 0)
+	rb_raise(rb_eArgError, "iterations must be a positive integer");
     digest = NIL_P(vdigest) ? EVP_md5() : GetDigestPtr(vdigest);
     GetCipher(self, ctx);
     EVP_BytesToKey(EVP_CIPHER_CTX_cipher(ctx), digest, salt,

--- a/test/test_cipher.rb
+++ b/test/test_cipher.rb
@@ -44,6 +44,9 @@ class OpenSSL::TestCipher < OpenSSL::TestCase
     s2 = cipher.update(pt) << cipher.final
 
     assert_equal s1, s2
+
+    cipher2 = OpenSSL::Cipher.new("DES-EDE3-CBC").encrypt
+    assert_raise(ArgumentError) { cipher2.pkcs5_keyivgen(pass, salt, -1, "MD5") }
   end
 
   def test_info


### PR DESCRIPTION
EVP_BytesToKey() internally converts the iteration count given as an
"int" into an "unsigned int". Calling that with a negative integer will
result in a hang. This is surprising, so let's validate the value by
ourselves and raise ArgumentError as necessary.

The issue was reported by finixbit at https://hackerone.com/reports/304115 (not public yet)