### PR TITLE
Fix incorrect documentation for SSLContext#verify_mode

### DIFF
--- a/ext/openssl/ossl_ssl.c
+++ b/ext/openssl/ossl_ssl.c
@@ -2490,8 +2490,8 @@ Init_ossl_ssl(void)
      * Valid modes are VERIFY_NONE, VERIFY_PEER, VERIFY_CLIENT_ONCE,
      * VERIFY_FAIL_IF_NO_PEER_CERT and defined on OpenSSL::SSL
      *
-     * The default mode is VERIFY_NONE, which does not perform any verification
-     * at all.
+     * The default mode is VERIFY_PEER, which verifies the authenticity
+     * of the peer's certificate.
      *
      * See SSL_CTX_set_verify(3) for details.
      */


### PR DESCRIPTION
The documentation claimed that the default value for `#verify_mode` is `VERIFY_NONE`, however at least as far as I can tell this is not true: it has been `VERIFY_PEER` since at least 2007:

https://github.com/ruby/ruby/commit/2c038353963843b8dfa7850b0b34023437b2174d

It continues to be so today:

https://github.com/ruby/openssl/blob/master/lib/openssl/ssl.rb#L21

This change updates the documentation to match what is configured in `OpenSSL::SSL::SSLContext::DEFAULT_PARAMS`.