### PR TITLE
Move rb_global_variable call to directly after assignment

### DIFF
--- a/ext/openssl/ossl_asn1.c
+++ b/ext/openssl/ossl_asn1.c
@@ -1823,6 +1823,7 @@ do{\
     rb_define_method(cASN1EndOfContent, "to_der", ossl_asn1eoc_to_der, 0);
 
     class_tag_map = rb_hash_new();
+    rb_global_variable(&class_tag_map);
     rb_hash_aset(class_tag_map, cASN1EndOfContent, INT2NUM(V_ASN1_EOC));
     rb_hash_aset(class_tag_map, cASN1Boolean, INT2NUM(V_ASN1_BOOLEAN));
     rb_hash_aset(class_tag_map, cASN1Integer, INT2NUM(V_ASN1_INTEGER));
@@ -1846,7 +1847,6 @@ do{\
     rb_hash_aset(class_tag_map, cASN1GeneralString, INT2NUM(V_ASN1_GENERALSTRING));
     rb_hash_aset(class_tag_map, cASN1UniversalString, INT2NUM(V_ASN1_UNIVERSALSTRING));
     rb_hash_aset(class_tag_map, cASN1BMPString, INT2NUM(V_ASN1_BMPSTRING));
-    rb_global_variable(&class_tag_map);
 
     id_each = rb_intern_const("each");
 }


### PR DESCRIPTION
While I'm guessing the `INT2NUM` calls all generate Fixnums and not Bignums,
it's unwise to rely on that.  Calling `rb_global_variable` directly after
assignment is the pattern used in `ossl.c`, and it's probably best to do
that here as well.