### PR TITLE
Reduce memory allocation when writing to SSLSocket

### DIFF
--- a/lib/openssl/buffering.rb
+++ b/lib/openssl/buffering.rb
@@ -316,8 +316,8 @@ module OpenSSL::Buffering
     @wbuffer << s
     @wbuffer.force_encoding(Encoding::BINARY)
     @sync ||= false
-    if @sync or @wbuffer.size > BLOCK_SIZE or idx = @wbuffer.rindex($/)
-      remain = idx ? idx + $/.size : @wbuffer.length
+    if @sync or @wbuffer.size > BLOCK_SIZE or idx = @wbuffer.rindex("\n")
+      remain = idx ? idx + 1 : @wbuffer.size
       nwritten = 0
       while remain > 0
         str = @wbuffer[nwritten,remain]
@@ -409,9 +409,7 @@ module OpenSSL::Buffering
     end
     args.each{|arg|
       s << arg.to_s
-      if $/ && /\n\z/ !~ s
-        s << "\n"
-      end
+      s.sub!(/(?<!\n)\z/, "\n")
     }
     do_write(s)
     nil

--- a/lib/openssl/buffering.rb
+++ b/lib/openssl/buffering.rb
@@ -316,20 +316,15 @@ module OpenSSL::Buffering
     @wbuffer << s
     @wbuffer.force_encoding(Encoding::BINARY)
     @sync ||= false
-    if @sync or @wbuffer.size > BLOCK_SIZE or idx = @wbuffer.rindex("\n")
-      remain = idx ? idx + 1 : @wbuffer.size
-      nwritten = 0
-      while remain > 0
-        str = @wbuffer[nwritten,remain]
+    if @sync or @wbuffer.size > BLOCK_SIZE
+      until @wbuffer.empty?
         begin
-          nwrote = syswrite(str)
+          nwrote = syswrite(@wbuffer)
         rescue Errno::EAGAIN
           retry
         end
-        remain -= nwrote
-        nwritten += nwrote
+        @wbuffer[0, nwrote] = ""
       end
-      @wbuffer[0,nwritten] = ""
     end
   end
 


### PR DESCRIPTION
At the moment OpenSSL::Buffering#do_write allocates some additional
strings, and in my profiling writing 5MB of data allocates additional
7.7MB of strings.

This patch greatly reduces memory allocations, and now writing 5MB of
data allocates only additional 0.2MB of strings. This means that large
file uploads would effectively not allocate additional memory anymore.

Reference: https://bugs.ruby-lang.org/issues/14426
Reference: https://github.com/ruby/ruby/pull/1924

Cc: @janko-m