### PR TITLE
WIP: deprecated declarations

### DIFF
--- a/ext/openssl/ossl_cipher.c
+++ b/ext/openssl/ossl_cipher.c
@@ -225,7 +225,7 @@ ossl_cipher_init(int argc, VALUE *argv, VALUE self, int mode)
 	    }
 	    else memcpy(iv, RSTRING_PTR(init_v), sizeof(iv));
 	}
-	EVP_BytesToKey(EVP_CIPHER_CTX_cipher(ctx), EVP_md5(), iv,
+	EVP_BytesToKey(EVP_CIPHER_CTX_cipher(ctx), EVP_sha256(), iv,
 		       (unsigned char *)RSTRING_PTR(pass), RSTRING_LENINT(pass), 1, key, NULL);
 	p_key = key;
 	p_iv = iv;
@@ -319,7 +319,7 @@ ossl_cipher_pkcs5_keyivgen(int argc, VALUE *argv, VALUE self)
     iter = NIL_P(viter) ? 2048 : NUM2INT(viter);
     if (iter <= 0)
 	rb_raise(rb_eArgError, "iterations must be a positive integer");
-    digest = NIL_P(vdigest) ? EVP_md5() : ossl_evp_get_digestbyname(vdigest);
+    digest = NIL_P(vdigest) ? EVP_sha256() : ossl_evp_get_digestbyname(vdigest);
     GetCipher(self, ctx);
     EVP_BytesToKey(EVP_CIPHER_CTX_cipher(ctx), digest, salt,
 		   (unsigned char *)RSTRING_PTR(vpass), RSTRING_LENINT(vpass), iter, key, iv);

--- a/ext/openssl/ossl_pkcs7.c
+++ b/ext/openssl/ossl_pkcs7.c
@@ -306,12 +306,12 @@ ossl_pkcs7_s_encrypt(int argc, VALUE *argv, VALUE klass)
 
     rb_scan_args(argc, argv, "22", &certs, &data, &cipher, &flags);
     if(NIL_P(cipher)){
-#if !defined(OPENSSL_NO_RC2)
-	ciph = EVP_rc2_40_cbc();
-#elif !defined(OPENSSL_NO_DES)
+//#if !defined(OPENSSL_NO_RC2)
+//	ciph = EVP_rc2_40_cbc();
+#if !defined(OPENSSL_NO_DES)
 	ciph = EVP_des_ede3_cbc();
-#elif !defined(OPENSSL_NO_RC2)
-	ciph = EVP_rc2_40_cbc();
+//#elif !defined(OPENSSL_NO_RC2)
+//	ciph = EVP_rc2_40_cbc();
 #elif !defined(OPENSSL_NO_AES)
 	ciph = EVP_EVP_aes_128_cbc();
 #else

--- a/ext/openssl/ossl_x509cert.c
+++ b/ext/openssl/ossl_x509cert.c
@@ -242,7 +242,7 @@ ossl_x509_to_req(VALUE self)
     VALUE obj;
 
     GetX509(self, x509);
-    if (!(req = X509_to_X509_REQ(x509, NULL, EVP_md5()))) {
+    if (!(req = X509_to_X509_REQ(x509, NULL, EVP_sha256()))) {
 	ossl_raise(eX509CertError, NULL);
     }
     obj = ossl_x509req_new(req);


### PR DESCRIPTION
these two functions are problematic
```
EVP_md5()
EVP_rc2_40_cbc()
```

the build failed because Werror=deprecated-declarations is enabled by default

OPENSSL_NO_RC2, OPENSSL_NO_MD5 are NOT defined, they're available, but deprecated

EVP_md5() shouldn't be used anyway, I think there could be also problem on FIPS enabled systems, that don't allow md5? Ruby openssl has no guard for it.

```
ossl_pkcs7.c: In function 'ossl_pkcs7_s_encrypt':
ossl_pkcs7.c:310:9: error: 'EVP_rc2_40_cbc' is deprecated [-Werror=deprecated-declarations]
ciph = EVP_rc2_40_cbc();

In file included from /usr/include/openssl/x509.h:73:0,
                 from /usr/include/openssl/x509v3.h:53,
                 from ossl.h:23,
                 from ossl_pkcs7.c:10:
/usr/include/openssl/evp.h:817:30: note: declared here
 DEPRECATED const EVP_CIPHER *EVP_rc2_40_cbc(void);
```

uname
```
SunOS 5.11 11.4.0.15.0 i86pc i386 i86pc
```

version
```
OpenSSL 1.0.2o  27 Mar 2018
built on: date not available
platform: information not available
options:  bn(64,64) rc4(8x,int) des(ptr,cisc,16,int) blowfish(ptr) 
compiler: information not available
OPENSSLDIR: "/etc/openssl"
```

ciphers
```
ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:SRP-DSS-AES-256-CBC-SHA:SRP-RSA-AES-256-CBC-SHA:SRP-AES-256-CBC-SHA:DH-DSS-AES256-GCM-SHA384:DHE-DSS-AES256-GCM-SHA384:DH-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA256:DH-RSA-AES256-SHA256:DH-DSS-AES256-SHA256:DHE-RSA-AES256-SHA:DHE-DSS-AES256-SHA:DH-RSA-AES256-SHA:DH-DSS-AES256-SHA:DHE-RSA-CAMELLIA256-SHA:DHE-DSS-CAMELLIA256-SHA:DH-RSA-CAMELLIA256-SHA:DH-DSS-CAMELLIA256-SHA:ECDH-RSA-AES256-GCM-SHA384:ECDH-ECDSA-AES256-GCM-SHA384:ECDH-RSA-AES256-SHA384:ECDH-ECDSA-AES256-SHA384:ECDH-RSA-AES256-SHA:ECDH-ECDSA-AES256-SHA:AES256-GCM-SHA384:AES256-SHA256:AES256-SHA:CAMELLIA256-SHA:PSK-AES256-CBC-SHA:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:SRP-DSS-AES-128-CBC-SHA:SRP-RSA-AES-128-CBC-SHA:SRP-AES-128-CBC-SHA:DH-DSS-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:DH-RSA-AES128-GCM-SHA256:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES128-SHA256:DHE-DSS-AES128-SHA256:DH-RSA-AES128-SHA256:DH-DSS-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA:DH-RSA-AES128-SHA:DH-DSS-AES128-SHA:DHE-RSA-CAMELLIA128-SHA:DHE-DSS-CAMELLIA128-SHA:DH-RSA-CAMELLIA128-SHA:DH-DSS-CAMELLIA128-SHA:ECDH-RSA-AES128-GCM-SHA256:ECDH-ECDSA-AES128-GCM-SHA256:ECDH-RSA-AES128-SHA256:ECDH-ECDSA-AES128-SHA256:ECDH-RSA-AES128-SHA:ECDH-ECDSA-AES128-SHA:AES128-GCM-SHA256:AES128-SHA256:AES128-SHA:CAMELLIA128-SHA:PSK-AES128-CBC-SHA:ECDHE-RSA-RC4-SHA:ECDHE-ECDSA-RC4-SHA:ECDH-RSA-RC4-SHA:ECDH-ECDSA-RC4-SHA:RC4-SHA:RC4-MD5:PSK-RC4-SHA:ECDHE-RSA-DES-CBC3-SHA:ECDHE-ECDSA-DES-CBC3-SHA:SRP-DSS-3DES-EDE-CBC-SHA:SRP-RSA-3DES-EDE-CBC-SHA:SRP-3DES-EDE-CBC-SHA:EDH-RSA-DES-CBC3-SHA:EDH-DSS-DES-CBC3-SHA:DH-RSA-DES-CBC3-SHA:DH-DSS-DES-CBC3-SHA:ECDH-RSA-DES-CBC3-SHA:ECDH-ECDSA-DES-CBC3-SHA:DES-CBC3-SHA:PSK-3DES-EDE-CBC-SHA
```