### PR TITLE
Fix compile errors with mingw64 on msys2

### DIFF
--- a/ext/openssl/openssl_missing.c
+++ b/ext/openssl/openssl_missing.c
@@ -10,6 +10,9 @@
 #include RUBY_EXTCONF_H
 
 #include <string.h> /* memcpy() */
+#ifdef _WIN32
+# include <winsock2.h>
+#endif
 #if !defined(OPENSSL_NO_ENGINE)
 # include <openssl/engine.h>
 #endif


### PR DESCRIPTION
Compiling openssl_missing.c causes the following errors using
mingw-w64-x86_64-openssl 1.1.1-3 package on msys2.
X509_NAME is defined in windows headers.
Include winsock2.h early so that `#undef X509_NAME` in openssl
headers works fine.

```
compiling ../../../ruby/ext/openssl/openssl_missing.c
In file included from C:/msys64/mingw64/include/openssl/crypto.h:23,
                 from C:/msys64/mingw64/include/openssl/bn.h:20,
                 from C:/msys64/mingw64/include/openssl/engine.h:18,
                 from ../../../ruby/ext/openssl/openssl_missing.c:14:
C:/msys64/mingw64/include/openssl/x509.h:77:1: error: pasting "stack_st_" and "(" does not give a valid preprocessing token
 DEFINE_STACK_OF(X509_NAME)
 ^~~~~~~~~~~~~~~
C:/msys64/mingw64/include/openssl/x509.h:77:17: error: expected ')' before numeric constant
 DEFINE_STACK_OF(X509_NAME)
                 ^~~~~~~~~
C:/msys64/mingw64/include/openssl/x509.h:77:1: error: pasting "sk_" and "(" does not give a valid preprocessing token
 DEFINE_STACK_OF(X509_NAME)
 ^~~~~~~~~~~~~~~
C:/msys64/mingw64/include/openssl/x509.h:77:17: error: expected declaration specifiers or '...' before '(' token
 DEFINE_STACK_OF(X509_NAME)
                 ^~~~~~~~~
(snip)
```