### PR TITLE
Add OpenSSL::X509::Extension#value_der method

### DIFF
--- a/ext/openssl/ossl_x509ext.c
+++ b/ext/openssl/ossl_x509ext.c
@@ -403,6 +403,19 @@ ossl_x509ext_get_value(VALUE obj)
 }
 
 static VALUE
+ossl_x509ext_get_value_der(VALUE obj)
+{
+    X509_EXTENSION *ext;
+    ASN1_OCTET_STRING *value;
+
+    GetX509Ext(obj, ext);
+    if ((value = X509_EXTENSION_get_data(ext)) == NULL)
+	ossl_raise(eX509ExtError, NULL);
+
+    return rb_str_new((const char *)value->data, value->length);
+}
+
+static VALUE
 ossl_x509ext_get_critical(VALUE obj)
 {
     X509_EXTENSION *ext;
@@ -472,6 +485,7 @@ Init_ossl_x509ext(void)
     rb_define_method(cX509Ext, "critical=", ossl_x509ext_set_critical, 1);
     rb_define_method(cX509Ext, "oid", ossl_x509ext_get_oid, 0);
     rb_define_method(cX509Ext, "value", ossl_x509ext_get_value, 0);
+    rb_define_method(cX509Ext, "value_der", ossl_x509ext_get_value_der, 0);
     rb_define_method(cX509Ext, "critical?", ossl_x509ext_get_critical, 0);
     rb_define_method(cX509Ext, "to_der", ossl_x509ext_to_der, 0);
 }

--- a/test/test_x509ext.rb
+++ b/test/test_x509ext.rb
@@ -86,6 +86,11 @@ class OpenSSL::TestX509Extension < OpenSSL::TestCase
     assert_equal true, ext1 == ext2
     assert_equal false, ext1 == ext3
   end
+
+  def test_value_der
+    ext = OpenSSL::X509::Extension.new(@basic_constraints.to_der)
+    assert_equal @basic_constraints_value.to_der, ext.value_der
+  end
 end
 
 end


### PR DESCRIPTION
The `#value` method provides a weird stringification of the extension value that can't be parsed and isn't very useful. The new `#value_der` method provides the raw value, allowing users to decode the value and use it as needed.

For example, I'm wanting to use the Authority Key Identifier extension from a certificate. To do this currently, I do

```ruby
ext = cert.extensions.find { |c| c.oid == "authorityKeyIdentifier" }
if ext.nil?
  raise "missing extension"
end

# OpenSSL's weird stringification of the extension value
ext.value
#=> "keyid:E7:02:23:80:00:4F:D8:D7:BC:94:0B:D9:3F:74:39:49:32:3C:8A:79\n"

ext_asn1 = OpenSSL::ASN1.decode(ext.to_der)
unless ext_asn1.tag == OpenSSL::ASN1::SEQUENCE && [2, 3].include?(ext_asn1.value.length)
  raise GitSigning::OCSPError, "invalid x.509 extension"
end

ext_value = ext_asn1.value.last
unless ext_value.tag == OpenSSL::ASN1::OCTET_STRING
  raise "bad extension value"
end

aki_asn1 = OpenSSL::ASN1.decode(ext_value.value)
unless aki_asn1.tag == OpenSSL::ASN1::SEQUENCE
  raise "bad aki value"
end

key_id_value = ak1_asn1.value.find { |v| v.tag_class == :CONTEXT_SPECIFIC &&  v.tag == 0 }

# The actual AKI digest value we care about
key_id_value.value
#=> "\xE7\x02#\x80\x00O\xD8\xD7\xBC\x94\v\xD9?t9I2<\x8Ay"
```

The change in this PR lets us simplify this to

```ruby
ext = cert.extensions.find { |c| c.oid == "authorityKeyIdentifier" }
if ext.nil?
  raise "missing extension"
end

aki_asn1 = OpenSSL::ASN1.decode(ext.value_der)
unless aki_asn1.tag == OpenSSL::ASN1::SEQUENCE
  raise "bad aki value"
end

key_id_value = ak1_asn1.value.find { |v| v.tag_class == :CONTEXT_SPECIFIC &&  v.tag == 0 }

key_id_value.value
```

While this still isn't great, I think it's as good as we can get. Since each extension has a different ASN.1 profile, we can't do much to parse the actual extension value for the user unless we wanted to add a bunch of logic for several popular extensions. 