### PR TITLE
Define equality method for ASN1::ObjectId

### DIFF
--- a/ext/openssl/ossl_asn1.c
+++ b/ext/openssl/ossl_asn1.c
@@ -1285,6 +1285,30 @@ ossl_asn1obj_get_ln(VALUE self)
     return ret;
 }
 
+/*
+ *  call-seq:
+ *     oid == other_oid => true or false
+ *
+ *  Returns +true+ if _other_oid_ is the same as _oid_
+ */
+static VALUE
+ossl_asn1obj_eq(VALUE self, VALUE other)
+{
+    VALUE valSelf, valOther;
+    int nidSelf, nidOther;
+
+    valSelf = ossl_asn1_get_value(self);
+    valOther = ossl_asn1_get_value(other);
+
+    if ((nidSelf = OBJ_txt2nid(StringValueCStr(valSelf))) == NID_undef)
+	ossl_raise(eASN1Error, "OBJ_txt2nid");
+
+    if ((nidOther = OBJ_txt2nid(StringValueCStr(valOther))) == NID_undef)
+	ossl_raise(eASN1Error, "OBJ_txt2nid");
+
+    return nidSelf == nidOther ? Qtrue : Qfalse;
+}
+
 static VALUE
 asn1obj_get_oid_i(VALUE vobj)
 {
@@ -1818,6 +1842,8 @@ do{\
     rb_define_method(cASN1ObjectId, "oid", ossl_asn1obj_get_oid, 0);
     rb_define_alias(cASN1ObjectId, "short_name", "sn");
     rb_define_alias(cASN1ObjectId, "long_name", "ln");
+    rb_define_method(cASN1ObjectId, "==", ossl_asn1obj_eq, 1);
+    rb_define_alias(cASN1ObjectId, "===", "==");
     rb_attr(cASN1BitString, rb_intern("unused_bits"), 1, 1, 0);
 
     rb_define_method(cASN1EndOfContent, "initialize", ossl_asn1eoc_initialize, 0);

--- a/ext/openssl/ossl_asn1.c
+++ b/ext/openssl/ossl_asn1.c
@@ -1843,7 +1843,6 @@ do{\
     rb_define_alias(cASN1ObjectId, "short_name", "sn");
     rb_define_alias(cASN1ObjectId, "long_name", "ln");
     rb_define_method(cASN1ObjectId, "==", ossl_asn1obj_eq, 1);
-    rb_define_alias(cASN1ObjectId, "===", "==");
     rb_attr(cASN1BitString, rb_intern("unused_bits"), 1, 1, 0);
 
     rb_define_method(cASN1EndOfContent, "initialize", ossl_asn1eoc_initialize, 0);

--- a/test/test_asn1.rb
+++ b/test/test_asn1.rb
@@ -332,6 +332,32 @@ class  OpenSSL::TestASN1 < OpenSSL::TestCase
       pend "OBJ_obj2txt() not working (LibreSSL?)" if $!.message =~ /OBJ_obj2txt/
       raise
     end
+
+    aki = [
+      OpenSSL::ASN1::ObjectId.new("authorityKeyIdentifier"),
+      OpenSSL::ASN1::ObjectId.new("X509v3 Authority Key Identifier"),
+      OpenSSL::ASN1::ObjectId.new("2.5.29.35")
+    ]
+
+    ski = [
+      OpenSSL::ASN1::ObjectId.new("subjectKeyIdentifier"),
+      OpenSSL::ASN1::ObjectId.new("X509v3 Subject Key Identifier"),
+      OpenSSL::ASN1::ObjectId.new("2.5.29.14")
+    ]
+
+    aki.each do |a|
+      aki.each do |b|
+        assert a == b
+      end
+
+      ski.each do |b|
+        refute a == b
+      end
+    end
+
+    assert_raise(TypeError) {
+      OpenSSL::ASN1::ObjectId.new("authorityKeyIdentifier") == nil
+    }
   end
 
   def test_sequence


### PR DESCRIPTION
This makes it easier to compare OIDs.