### PR TITLE
Openssl cms wrapper

### DIFF
--- a/ext/openssl/extconf.rb
+++ b/ext/openssl/extconf.rb
@@ -165,6 +165,7 @@ have_func("SSL_CTX_get_security_level")
 have_func("X509_get0_notBefore")
 have_func("SSL_SESSION_get_protocol_version")
 have_func("EVP_PBE_scrypt")
+have_func("CMS_sign")
 
 Logging::message "=== Checking done. ===\n"
 

--- a/ext/openssl/ossl.c
+++ b/ext/openssl/ossl.c
@@ -1202,6 +1202,7 @@ Init_openssl(void)
     Init_ossl_ns_spki();
     Init_ossl_pkcs12();
     Init_ossl_pkcs7();
+    Init_ossl_cms();
     Init_ossl_pkey();
     Init_ossl_rand();
     Init_ossl_ssl();

--- a/ext/openssl/ossl.c
+++ b/ext/openssl/ossl.c
@@ -1202,7 +1202,9 @@ Init_openssl(void)
     Init_ossl_ns_spki();
     Init_ossl_pkcs12();
     Init_ossl_pkcs7();
+#if defined(HAVE_CMS_SIGN)
     Init_ossl_cms();
+#endif
     Init_ossl_pkey();
     Init_ossl_rand();
     Init_ossl_ssl();

--- a/ext/openssl/ossl.h
+++ b/ext/openssl/ossl.h
@@ -24,7 +24,9 @@
 #include <openssl/ssl.h>
 #include <openssl/pkcs12.h>
 #include <openssl/pkcs7.h>
+#if defined(HAVE_CMS_SIGN)
 #include <openssl/cms.h>
+#endif
 #include <openssl/hmac.h>
 #include <openssl/rand.h>
 #include <openssl/conf.h>

--- a/ext/openssl/ossl.h
+++ b/ext/openssl/ossl.h
@@ -24,6 +24,7 @@
 #include <openssl/ssl.h>
 #include <openssl/pkcs12.h>
 #include <openssl/pkcs7.h>
+#include <openssl/cms.h>
 #include <openssl/hmac.h>
 #include <openssl/rand.h>
 #include <openssl/conf.h>
@@ -165,6 +166,7 @@ void ossl_debug(const char *, ...);
 #include "ossl_ocsp.h"
 #include "ossl_pkcs12.h"
 #include "ossl_pkcs7.h"
+#include "ossl_cms.h"
 #include "ossl_pkey.h"
 #include "ossl_rand.h"
 #include "ossl_ssl.h"

--- a/ext/openssl/ossl_cms.c
+++ b/ext/openssl/ossl_cms.c
@@ -1,0 +1,498 @@
+/*
+ * 'OpenSSL for Ruby' project
+ * Copyright (C) 2018       Michael Richardson <mcr@sandelman.ca>
+ * copied from ossl_pkcs7.c:
+ *   Copyright (C) 2001-2002  Michal Rokos <m.rokos@sh.cvut.cz>
+ * All rights reserved.
+ */
+/*
+ * This program is licensed under the same licence as Ruby.
+ * (See the file 'LICENCE'.)
+ */
+#include "ossl.h"
+
+/*
+ * The CMS_ContentInfo is the primary data structure which this module creates and maintains
+ * Is is called OpenSSL::CMS::ContentInfo in ruby.
+ *
+ */
+
+#define NewCMSContentInfo(klass) \
+    TypedData_Wrap_Struct((klass), &ossl_cms_content_info_type, 0)
+#define SetCMSContentInfo(obj, cmsci) do { \
+    if (!(cmsci)) { \
+	ossl_raise(rb_eRuntimeError, "CMS wasn't initialized."); \
+    } \
+    RTYPEDDATA_DATA(obj) = (cmsci); \
+} while (0)
+#define GetCMSContentInfo(obj, cmsci) do { \
+    TypedData_Get_Struct((obj), CMS_ContentInfo, &ossl_cms_content_info_type, (cmsci)); \
+    if (!(cmsci)) {                                                \
+	ossl_raise(rb_eRuntimeError, "CMS wasn't initialized."); \
+    } \
+} while (0)
+
+#define NewCMSsi(klass) \
+    TypedData_Wrap_Struct((klass), &ossl_cms_signer_info_type, 0)
+#define SetCMSsi(obj, cmssi) do { \
+    if (!(cmssi)) { \
+	ossl_raise(rb_eRuntimeError, "CMSsi wasn't initialized."); \
+    } \
+    RTYPEDDATA_DATA(obj) = (cmssi); \
+} while (0)
+#define GetCMSsi(obj, cmssi) do { \
+    TypedData_Get_Struct((obj), CMS_SignerInfo, &ossl_cms_signer_info_type, (cmssi)); \
+    if (!(cmssi)) { \
+	ossl_raise(rb_eRuntimeError, "CMSsi wasn't initialized."); \
+    } \
+} while (0)
+
+
+#define ossl_cmsci_set_data(o,v)       rb_iv_set((o), "@data", (v))
+#define ossl_cmsci_get_data(o)         rb_iv_get((o), "@data")
+#define ossl_cmsci_set_err_string(o,v) rb_iv_set((o), "@error_string", (v))
+#define ossl_cmsci_get_err_string(o)   rb_iv_get((o), "@error_string")
+
+VALUE cCMS;
+VALUE cCMSContentInfo;
+VALUE cCMSSignerInfo;
+VALUE cCMSRecipient;
+VALUE eCMSError;
+
+
+static void
+ossl_cms_content_info_free(void *ptr)
+{
+    CMS_ContentInfo_free(ptr);
+}
+
+static const rb_data_type_t ossl_cms_content_info_type = {
+    "OpenSSL/CMS/ContentInfo",
+    {
+	0, ossl_cms_content_info_free,
+    },
+    0, 0, RUBY_TYPED_FREE_IMMEDIATELY,
+};
+
+static void
+ossl_cms_signer_info_free(void *ptr)
+{
+  /* nothing, only internal pointers are ever returned */
+}
+
+static const rb_data_type_t ossl_cms_signer_info_type = {
+    "OpenSSL/CMS/SignerInfo",
+    {
+	0, ossl_cms_signer_info_free,
+    },
+    0, 0, RUBY_TYPED_FREE_IMMEDIATELY,
+};
+
+
+
+static VALUE
+ossl_cmsci_to_pem(VALUE self)
+{
+    CMS_ContentInfo *cmsci;
+    BIO *out;
+    VALUE str;
+
+    GetCMSContentInfo(self, cmsci);
+    if (!(out = BIO_new(BIO_s_mem()))) {
+	ossl_raise(eCMSError, NULL);
+    }
+    if (!PEM_write_bio_CMS(out, cmsci)) {
+	BIO_free(out);
+	ossl_raise(ePKCS7Error, NULL);
+    }
+    str = ossl_membio2str(out);
+
+    return str;
+}
+
+/*
+ * call-seq:
+ *    cmsci.to_der => binary
+ */
+static VALUE
+ossl_cmsci_to_der(VALUE self)
+{
+    CMS_ContentInfo *cmsci;
+    VALUE str;
+    long len;
+    unsigned char *p;
+
+    GetCMSContentInfo(self, cmsci);
+    if((len = i2d_CMS_ContentInfo(cmsci, NULL)) <= 0)
+	ossl_raise(eCMSError, NULL);
+    str = rb_str_new(0, len);
+    p = (unsigned char *)RSTRING_PTR(str);
+    if(i2d_CMS_ContentInfo(cmsci, &p) <= 0)
+	ossl_raise(eCMSError, NULL);
+    ossl_str_adjust(str, p);
+
+    return str;
+}
+
+
+static VALUE
+ossl_cmsci_alloc(VALUE klass)
+{
+    CMS_ContentInfo *cms;
+    VALUE obj;
+
+    obj = NewCMSContentInfo(klass);
+    if (!(cms = CMS_ContentInfo_new())) {
+	ossl_raise(eCMSError, NULL);
+    }
+    SetCMSContentInfo(obj, cms);
+
+    return obj;
+}
+
+/*
+ * call-seq:
+ *    CMS::ContentInfo.new => cmsci
+ *    CMS::ContentInfo.new(string) => cmsi
+ *
+ * Create a new ContentInfo object. With argument decode from PEM or DER
+ * format CMS object.
+ *
+ */
+static VALUE
+ossl_cmsci_initialize(int argc, VALUE *argv, VALUE self)
+{
+    CMS_ContentInfo *c1, *cms = DATA_PTR(self);
+    BIO *in;
+    VALUE arg;
+
+    //GetCMSContentInfo(self, cms);
+    if(rb_scan_args(argc, argv, "01", &arg) == 0)
+	return self;
+    arg = ossl_to_der_if_possible(arg);
+    in = ossl_obj2bio(&arg);
+    c1 = PEM_read_bio_CMS(in, &cms, NULL, NULL);
+    if (!c1) {
+	OSSL_BIO_reset(in);
+        c1 = d2i_CMS_bio(in, &cms);
+	if (!c1) {
+	    BIO_free(in);
+	    CMS_ContentInfo_free(cms);
+	    DATA_PTR(self) = NULL;
+	    ossl_raise(rb_eArgError, "Could not parse the CMS");
+	}
+    }
+    SetCMSContentInfo(self, cms);
+    BIO_free(in);
+    ossl_cmsci_set_data(self, Qnil);
+    ossl_cmsci_set_err_string(self, Qnil);
+
+    return self;
+}
+
+static VALUE
+ossl_cmsci_verify(int argc, VALUE *argv, VALUE self)
+{
+    VALUE certs, store, indata, flags;
+    STACK_OF(X509) *x509s;
+    X509_STORE *x509st;
+    int flg, ok, status = 0;
+    BIO *in, *out;
+    CMS_ContentInfo *cmsci;
+    VALUE data;
+    const char *msg;
+
+    GetCMSContentInfo(self, cmsci);
+    rb_scan_args(argc, argv, "22", &certs, &store, &indata, &flags);
+    x509st = GetX509StorePtr(store);
+    flg = NIL_P(flags) ? 0 : NUM2INT(flags);
+    if(NIL_P(indata)) indata = ossl_cmsci_get_data(self);
+    in = NIL_P(indata) ? NULL : ossl_obj2bio(&indata);
+    if(NIL_P(certs)) x509s = NULL;
+    else{
+	x509s = ossl_protect_x509_ary2sk(certs, &status);
+	if(status){
+	    BIO_free(in);
+	    rb_jump_tag(status);
+	}
+    }
+    if(!(out = BIO_new(BIO_s_mem()))){
+	BIO_free(in);
+	sk_X509_pop_free(x509s, X509_free);
+	ossl_raise(eCMSError, NULL);
+    }
+    ok = CMS_verify(cmsci, x509s, x509st, in, out, flg);
+    BIO_free(in);
+    sk_X509_pop_free(x509s, X509_free);
+    if (ok < 0) ossl_raise(eCMSError, "CMS_verify");
+    msg = ERR_reason_error_string(ERR_peek_error());
+    ossl_cmsci_set_err_string(self, msg ? rb_str_new2(msg) : Qnil);
+    ossl_clear_error();
+    data = ossl_membio2str(out);
+    ossl_cmsci_set_data(self, data);
+
+    return (ok == 1) ? Qtrue : Qfalse;
+}
+
+
+static STACK_OF(X509) *
+cmsci_get_certs(VALUE self)
+{
+    CMS_ContentInfo *cms;
+    STACK_OF(X509) *certs;
+
+    GetCMSContentInfo(self, cms);
+    certs = CMS_get1_certs(cms);
+    return certs;
+}
+
+static VALUE
+ossl_cmsci_add_certificate(VALUE self, VALUE cert)
+{
+    CMS_ContentInfo *cms;
+    X509 *x509;
+
+    GetCMSContentInfo(self, cms);
+    x509 = GetX509CertPtr(cert);    /* NO NEED TO DUP */
+    if (!CMS_add1_cert(cms, x509)){ /* add1() takes reference */
+	ossl_raise(eCMSError, NULL);
+    }
+
+    return self;
+}
+
+static VALUE
+ossl_cmsci_set_certs_i(RB_BLOCK_CALL_FUNC_ARGLIST(i, arg))
+{
+    return ossl_cmsci_add_certificate(arg, i);
+}
+
+static VALUE
+ossl_cmsci_set_certificates(VALUE self, VALUE ary)
+{
+    STACK_OF(X509) *certs;
+    X509 *cert;
+
+    certs = cmsci_get_certs(self);
+    while((cert = sk_X509_pop(certs))) X509_free(cert);
+    rb_block_call(ary, rb_intern("each"), 0, 0, ossl_cmsci_set_certs_i, self);
+
+    return ary;
+}
+
+static VALUE
+ossl_cmsci_get_certificates(VALUE self)
+{
+    return ossl_x509_sk2ary(cmsci_get_certs(self));
+}
+
+/*
+ * CMS SignerInfo is not a first class object, but part of the
+ * CMS ContentInfo.  It can be wrapped in a ruby object, but it can
+ * not be created or freed directly.
+ */
+static VALUE
+ossl_cmssi_new(CMS_SignerInfo *cmssi)
+{
+    VALUE obj;
+
+    obj = NewCMSsi(cCMSSignerInfo);
+    SetCMSsi(obj, cmssi);
+
+    return obj;
+}
+
+static VALUE
+ossl_cmssi_get_issuer(VALUE self)
+{
+    CMS_SignerInfo *cmssi;
+    ASN1_OCTET_STRING *keyid;
+    X509_NAME *issuer;
+    ASN1_INTEGER *sno;
+
+    GetCMSsi(self, cmssi);
+
+    if(CMS_SignerInfo_get0_signer_id(cmssi,&keyid,&issuer, &sno)!=1) {
+      ossl_raise(eCMSError, "get0_signer_id failed");
+    }
+
+    /* XXX keyid may be set instead */
+    if(issuer) {
+      return ossl_x509name_new(issuer);
+    } else {
+      return Qnil;
+    }
+}
+
+static VALUE
+ossl_cmssi_get_serial(VALUE self)
+{
+    CMS_SignerInfo *cmssi;
+    ASN1_OCTET_STRING *keyid;
+    X509_NAME *issuer;
+    ASN1_INTEGER *sno;
+
+    GetCMSsi(self, cmssi);
+
+    if(CMS_SignerInfo_get0_signer_id(cmssi,&keyid,&issuer, &sno)!=1) {
+      ossl_raise(eCMSError, "get0_signer_id failed");
+    }
+
+    /* XXX keyid may be set */
+    if(sno) {
+      return asn1integer_to_num(sno);
+    } else {
+      return Qnil;
+    }
+}
+
+static VALUE
+ossl_cmsci_get_signers(VALUE self)
+{
+    CMS_ContentInfo *cms;
+    STACK_OF(CMS_SignerInfo) *sk;
+    CMS_SignerInfo *si;
+    int num, i;
+    VALUE ary;
+
+    GetCMSContentInfo(self, cms);
+    if (!(sk = CMS_get0_SignerInfos(cms))) {
+	OSSL_Debug("OpenSSL::CMS#get_signer_info == NULL!");
+	return rb_ary_new();
+    }
+    if ((num = sk_CMS_SignerInfo_num(sk)) < 0) {
+	ossl_raise(eCMSError, "Negative number of signers!");
+    }
+    ary = rb_ary_new2(num);
+    for (i=0; i<num; i++) {
+	si = sk_CMS_SignerInfo_value(sk, i);
+	rb_ary_push(ary, ossl_cmssi_new(si));
+    }
+
+    return ary;
+}
+
+/*
+ * call-seq:
+ *    CMS.sign(signcert, key, data, [certs, flags]) => cms
+ *
+ * CMS.sign creates and returns a CMS SignedData structure.
+ * The data will be signed with *key* (An OpenSSL::PKey instance), and the list of
+ * certs (if any) will be included in the structure as additional
+ * anchors.
+ *
+ * The flags come from the set of XYZ.
+ *
+ */
+static VALUE
+ossl_cms_s_sign(int argc, VALUE *argv, VALUE klass)
+{
+    VALUE cert, key, data, certs, flags;
+    X509 *x509;
+    EVP_PKEY *pkey;
+    BIO *in;
+    STACK_OF(X509) *x509s;
+    int flg, status = 0;
+    CMS_ContentInfo *cms_cinfo;
+    VALUE ret;
+
+    rb_scan_args(argc, argv, "32", &cert, &key, &data, &certs, &flags);
+    x509 = GetX509CertPtr(cert); /* NO NEED TO DUP */
+    pkey = GetPrivPKeyPtr(key);  /* NO NEED TO DUP */
+    flg = NIL_P(flags) ? 0 : NUM2INT(flags);
+    ret = NewCMSContentInfo(cCMSContentInfo);
+    in  = ossl_obj2bio(&data);
+    if(NIL_P(certs)) x509s = NULL;
+    else{
+	x509s = ossl_protect_x509_ary2sk(certs, &status);
+	if(status){
+	    BIO_free(in);
+	    rb_jump_tag(status);
+	}
+    }
+    if(!(cms_cinfo = CMS_sign(x509, pkey, x509s, in, flg))){
+	BIO_free(in);
+	sk_X509_pop_free(x509s, X509_free);
+	ossl_raise(ePKCS7Error, NULL);
+    }
+    SetCMSContentInfo(ret, cms_cinfo);
+    ossl_cmsci_set_data(ret, data);
+    ossl_cmsci_set_err_string(ret, Qnil);
+    BIO_free(in);
+    sk_X509_pop_free(x509s, X509_free);
+
+    return ret;
+}
+
+/*
+ * INIT
+ */
+void
+Init_ossl_cms(void)
+{
+    cCMS = rb_define_class_under(mOSSL, "CMS", rb_cObject);
+    rb_define_singleton_method(cCMS, "sign",  ossl_cms_s_sign, -1);
+
+    eCMSError = rb_define_class_under(cCMS, "CMSError", eOSSLError);
+
+    cCMSContentInfo = rb_define_class_under(cCMS, "ContentInfo", rb_cObject);
+    rb_define_alloc_func(cCMSContentInfo, ossl_cmsci_alloc);
+    rb_define_method(cCMSContentInfo, "to_pem", ossl_cmsci_to_pem, 0);
+    rb_define_alias(cCMSContentInfo,  "to_s", "to_pem");
+    rb_define_method(cCMSContentInfo, "to_der", ossl_cmsci_to_der, 0);
+    rb_define_method(cCMSContentInfo, "initialize", ossl_cmsci_initialize, -1);
+
+    rb_define_method(cCMSContentInfo, "certificates=", ossl_cmsci_set_certificates, 1);
+    rb_define_method(cCMSContentInfo, "certificates", ossl_cmsci_get_certificates, 0);
+    rb_define_method(cCMSContentInfo, "signers", ossl_cmsci_get_signers, 0);
+    rb_define_method(cCMSContentInfo, "verify", ossl_cmsci_verify, -1);
+    rb_attr(cCMSContentInfo, rb_intern("data"), 1, 0, Qfalse);
+    rb_attr(cCMSContentInfo, rb_intern("error_string"), 1, 1, Qfalse);
+#if 0
+    rb_define_method(cCMSContentInfo, "add_signer", ossl_cmsci_add_signer, 1);
+#endif
+
+    cCMSSignerInfo = rb_define_class_under(cCMS, "SignerInfo", rb_cObject);
+    rb_define_method(cCMSSignerInfo,"issuer", ossl_cmssi_get_issuer, 0);
+    rb_define_alias(cCMSSignerInfo, "name", "issuer");
+    rb_define_method(cCMSSignerInfo,"serial", ossl_cmssi_get_serial,0);
+
+#if 0
+    rb_define_singleton_method(cCMS, "read_smime", ossl_cms_s_read_smime, 1);
+    rb_define_singleton_method(cCMS, "write_smime", ossl_cms_s_write_smime, -1);
+    rb_define_singleton_method(cCMS, "encrypt", ossl_cms_s_encrypt, -1);
+    rb_define_method(cCMS, "initialize_copy", ossl_cms_copy, 1);
+    rb_define_method(cCMS, "detached=", ossl_cms_set_detached, 1);
+    rb_define_method(cCMS, "detached", ossl_cms_get_detached, 0);
+    rb_define_method(cCMS, "detached?", ossl_cms_detached_p, 0);
+    rb_define_method(cCMS, "cipher=", ossl_cms_set_cipher, 1);
+    rb_define_method(cCMS, "add_recipient", ossl_cms_add_recipient, 1);
+    rb_define_method(cCMS, "recipients", ossl_cms_get_recipient, 0);
+    rb_define_method(cCMS, "add_certificate", ossl_cms_add_certificate, 1);
+    rb_define_method(cCMS, "add_crl", ossl_cms_add_crl, 1);
+    rb_define_method(cCMS, "crls=", ossl_cms_set_crls, 1);
+    rb_define_method(cCMS, "crls", ossl_cms_get_crls, 0);
+    rb_define_method(cCMS, "add_data", ossl_cms_add_data, 1);
+    rb_define_alias(cCMS,  "data=", "add_data");
+    rb_define_method(cCMS, "decrypt", ossl_cms_decrypt, -1);
+
+    cCMSRecipient = rb_define_class_under(cCMS,"RecipientInfo",rb_cObject);
+    rb_define_alloc_func(cCMSRecipient, ossl_cmsri_alloc);
+    rb_define_method(cCMSRecipient, "initialize", ossl_cmsri_initialize,1);
+    rb_define_method(cCMSRecipient, "issuer", ossl_cmsri_get_issuer,0);
+    rb_define_method(cCMSRecipient, "serial", ossl_cmsri_get_serial,0);
+    rb_define_method(cCMSRecipient, "enc_key", ossl_cmsri_get_enc_key,0);
+#endif
+
+#define DefCMSConst(x) rb_define_const(cCMS, #x, INT2NUM(CMS_##x))
+
+    DefCMSConst(TEXT);
+    DefCMSConst(NOCERTS);
+    DefCMSConst(DETACHED);
+    DefCMSConst(BINARY);
+    DefCMSConst(NOATTR);
+    DefCMSConst(NOSMIMECAP);
+    DefCMSConst(USE_KEYID);
+    DefCMSConst(STREAM);
+    DefCMSConst(PARTIAL);
+}

--- a/ext/openssl/ossl_cms.c
+++ b/ext/openssl/ossl_cms.c
@@ -11,6 +11,7 @@
  */
 #include "ossl.h"
 
+#if defined(HAVE_CMS_SIGN)
 /*
  * The CMS_ContentInfo is the primary data structure which this module creates and maintains
  * Is is called OpenSSL::CMS::ContentInfo in ruby.
@@ -496,3 +497,5 @@ Init_ossl_cms(void)
     DefCMSConst(STREAM);
     DefCMSConst(PARTIAL);
 }
+
+#endif /* HAVE_CMS_SIGN */

--- a/ext/openssl/ossl_cms.h
+++ b/ext/openssl/ossl_cms.h
@@ -1,0 +1,21 @@
+/*
+ * 'OpenSSL for Ruby' project
+ * Copyright (C) 2001-2002  Michal Rokos <m.rokos@sh.cvut.cz>
+ * All rights reserved.
+ */
+/*
+ * This program is licensed under the same licence as Ruby.
+ * (See the file 'LICENCE'.)
+ */
+#if !defined(_OSSL_CMS_H_)
+#define _OSSL_CMS_H_
+
+extern VALUE cCMS;
+extern VALUE cCMSContentInfo;
+extern VALUE cCMSSigner;
+extern VALUE cCMSRecipient;
+extern VALUE eCMSError;
+
+void Init_ossl_cms(void);
+
+#endif /* _OSSL_CMS_H_ */

--- a/test/test_cms.rb
+++ b/test/test_cms.rb
@@ -1,0 +1,263 @@
+# frozen_string_literal: false
+require_relative 'utils'
+
+if defined?(OpenSSL)
+
+class OpenSSL::TestCMS < OpenSSL::TestCase
+  def setup
+    super
+    @rsa1024 = Fixtures.pkey("rsa1024")
+    @rsa2048 = Fixtures.pkey("rsa2048")
+    ca = OpenSSL::X509::Name.parse("/DC=org/DC=ruby-lang/CN=CA")
+    ee1 = OpenSSL::X509::Name.parse("/DC=org/DC=ruby-lang/CN=EE1")
+    ee2 = OpenSSL::X509::Name.parse("/DC=org/DC=ruby-lang/CN=EE2")
+
+    ca_exts = [
+      ["basicConstraints","CA:TRUE",true],
+      ["keyUsage","keyCertSign, cRLSign",true],
+      ["subjectKeyIdentifier","hash",false],
+      ["authorityKeyIdentifier","keyid:always",false],
+    ]
+    @ca_cert = issue_cert(ca, @rsa2048, 1, ca_exts, nil, nil)
+    ee_exts = [
+      ["keyUsage","Non Repudiation, Digital Signature, Key Encipherment",true],
+      ["authorityKeyIdentifier","keyid:always",false],
+      ["extendedKeyUsage","clientAuth, emailProtection, codeSigning",false],
+    ]
+    @ee1_cert = issue_cert(ee1, @rsa1024, 2, ee_exts, @ca_cert, @rsa2048)
+    @ee2_cert = issue_cert(ee2, @rsa1024, 3, ee_exts, @ca_cert, @rsa2048)
+  end
+
+  def test_signed
+    store = OpenSSL::X509::Store.new
+    store.add_cert(@ca_cert)
+    ca_certs = [@ca_cert]
+
+    data = "aaaaa\r\nbbbbb\r\nccccc\r\n"
+    tmp = OpenSSL::CMS.sign(@ee1_cert, @rsa1024, data, ca_certs)
+    byebug
+    cms = OpenSSL::CMS::ContentInfo.new(tmp.to_der)
+    certs = cms.certificates
+    signers = cms.signers
+    assert(cms.verify([], store))
+    assert_equal(data, cms.data)
+    assert_equal(2, certs.size)
+    assert_equal(@ee1_cert.subject.to_s, certs[0].subject.to_s)
+    assert_equal(@ca_cert.subject.to_s, certs[1].subject.to_s)
+    assert_equal(1, signers.size)
+    assert_equal(@ee1_cert.serial, signers[0].serial)
+    assert_equal(@ee1_cert.issuer.to_s, signers[0].issuer.to_s)
+
+    # Normally OpenSSL tries to translate the supplied content into canonical
+    # MIME format (e.g. a newline character is converted into CR+LF).
+    # If the content is a binary, CMS::BINARY flag should be used.
+
+    data = "aaaaa\nbbbbb\nccccc\n"
+    flag = OpenSSL::CMS::BINARY
+    tmp = OpenSSL::CMS.sign(@ee1_cert, @rsa1024, data, ca_certs, flag)
+    cms = OpenSSL::CMS::ContentInfo.new(tmp.to_der)
+    certs = cms.certificates
+    signers = cms.signers
+    assert(cms.verify([], store))
+    assert_equal(data, cms.data)
+    assert_equal(2, certs.size)
+    assert_equal(@ee1_cert.subject.to_s, certs[0].subject.to_s)
+    assert_equal(@ca_cert.subject.to_s, certs[1].subject.to_s)
+    assert_equal(1, signers.size)
+    assert_equal(@ee1_cert.serial, signers[0].serial)
+    assert_equal(@ee1_cert.issuer.to_s, signers[0].issuer.to_s)
+
+    # A signed-data which have multiple signatures can be created
+    # through the following steps.
+    #   1. create two signed-data
+    #   2. copy signerInfo and certificate from one to another
+
+    tmp1 = OpenSSL::CMS.sign(@ee1_cert, @rsa1024, data, [], flag)
+    tmp2 = OpenSSL::CMS.sign(@ee2_cert, @rsa1024, data, [], flag)
+    tmp1.add_signer(tmp2.signers[0])
+    tmp1.add_certificate(@ee2_cert)
+
+    cms = OpenSSL::CMS.ContentInfo.new(tmp1.to_der)
+    certs = cms.certificates
+    signers = cms.signers
+    assert(cms.verify([], store))
+    assert_equal(data, cms.data)
+    assert_equal(2, certs.size)
+    assert_equal(2, signers.size)
+    assert_equal(@ee1_cert.serial, signers[0].serial)
+    assert_equal(@ee1_cert.issuer.to_s, signers[0].issuer.to_s)
+    assert_equal(@ee2_cert.serial, signers[1].serial)
+    assert_equal(@ee2_cert.issuer.to_s, signers[1].issuer.to_s)
+  end
+
+  def test_detached_sign
+    pend "not yet"
+    store = OpenSSL::X509::Store.new
+    store.add_cert(@ca_cert)
+    ca_certs = [@ca_cert]
+
+    data = "aaaaa\nbbbbb\nccccc\n"
+    flag = OpenSSL::PKCS7::BINARY|OpenSSL::PKCS7::DETACHED
+    tmp = OpenSSL::PKCS7.sign(@ee1_cert, @rsa1024, data, ca_certs, flag)
+    p7 = OpenSSL::PKCS7.new(tmp.to_der)
+    assert_nothing_raised do
+      OpenSSL::ASN1.decode(p7)
+    end
+
+    certs = p7.certificates
+    signers = p7.signers
+    assert(!p7.verify([], store))
+    assert(p7.verify([], store, data))
+    assert_equal(data, p7.data)
+    assert_equal(2, certs.size)
+    assert_equal(@ee1_cert.subject.to_s, certs[0].subject.to_s)
+    assert_equal(@ca_cert.subject.to_s, certs[1].subject.to_s)
+    assert_equal(1, signers.size)
+    assert_equal(@ee1_cert.serial, signers[0].serial)
+    assert_equal(@ee1_cert.issuer.to_s, signers[0].issuer.to_s)
+  end
+
+  def test_enveloped
+    pend "not yet"
+    certs = [@ee1_cert, @ee2_cert]
+    cipher = OpenSSL::Cipher::AES.new("128-CBC")
+    data = "aaaaa\nbbbbb\nccccc\n"
+
+    tmp = OpenSSL::PKCS7.encrypt(certs, data, cipher, OpenSSL::PKCS7::BINARY)
+    p7 = OpenSSL::PKCS7.new(tmp.to_der)
+    recip = p7.recipients
+    assert_equal(:enveloped, p7.type)
+    assert_equal(2, recip.size)
+
+    assert_equal(@ca_cert.subject.to_s, recip[0].issuer.to_s)
+    assert_equal(2, recip[0].serial)
+    assert_equal(data, p7.decrypt(@rsa1024, @ee1_cert))
+
+    assert_equal(@ca_cert.subject.to_s, recip[1].issuer.to_s)
+    assert_equal(3, recip[1].serial)
+    assert_equal(data, p7.decrypt(@rsa1024, @ee2_cert))
+
+    assert_equal(data, p7.decrypt(@rsa1024))
+  end
+
+  def test_graceful_parsing_failure #[ruby-core:43250]
+    pend "not yet"
+    contents = File.read(__FILE__)
+    assert_raise(ArgumentError) { OpenSSL::PKCS7.new(contents) }
+  end
+
+  def test_degenerate_cms
+    pend "not yet"
+    ca_cert_pem = <<END
+-----BEGIN CERTIFICATE-----
+MIID4DCCAsigAwIBAgIJAL1oVI72wmQwMA0GCSqGSIb3DQEBBQUAMFMxCzAJBgNV
+BAYTAkFVMQ4wDAYDVQQIEwVTdGF0ZTENMAsGA1UEBxMEQ2l0eTEQMA4GA1UEChMH
+RXhhbXBsZTETMBEGA1UEAxMKRXhhbXBsZSBDQTAeFw0xMjEwMTgwOTE2NTBaFw0y
+MjEwMTYwOTE2NTBaMFMxCzAJBgNVBAYTAkFVMQ4wDAYDVQQIEwVTdGF0ZTENMAsG
+A1UEBxMEQ2l0eTEQMA4GA1UEChMHRXhhbXBsZTETMBEGA1UEAxMKRXhhbXBsZSBD
+QTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMTSPNxOkd5NN19XO0fJ
+tGVlWN4DWuvVL9WbWnXJXX9rU6X8sSOL9RrRA64eEZf2UBFjz9fMHZj/OGcxZpus
+4YtzfSrMU6xfvsIHeqX+mT60ms2RfX4UXab50MQArBin3JVKHGnOi25uyAOylVFU
+TuzzQJvKyB67vjuRPMlVAgVAZAP07ru9gW0ajt/ODxvUfvXxp5SFF68mVP2ipMBr
+4fujUwQC6cVHmnuL6p87VFoo9uk87TSQVDOQGL8MK4moMFtEW9oUTU22CgnxnCsS
+sCCELYhy9BdaTWQH26LzMfhnwSuIRHZyprW4WZtU0akrYXNiCj8o92rZmQWXJDbl
+qNECAwEAAaOBtjCBszAdBgNVHQ4EFgQUNtVw4jvkZZbkdQbkYi2/F4QN79owgYMG
+A1UdIwR8MHqAFDbVcOI75GWW5HUG5GItvxeEDe/aoVekVTBTMQswCQYDVQQGEwJB
+VTEOMAwGA1UECBMFU3RhdGUxDTALBgNVBAcTBENpdHkxEDAOBgNVBAoTB0V4YW1w
+bGUxEzARBgNVBAMTCkV4YW1wbGUgQ0GCCQC9aFSO9sJkMDAMBgNVHRMEBTADAQH/
+MA0GCSqGSIb3DQEBBQUAA4IBAQBvJIsY9bIqliZ3WD1KoN4cvAQeRAPsoLXQkkHg
+P6Nrcw9rJ5JvoHfYbo5aNlwbnkbt/B2xlVEXUYpJoBZFXafgxG2gJleioIgnaDS4
+FPPwZf1C5ZrOgUBfxTGjHex4ghSAoNGOd35jQzin5NGKOvZclPjZ2vQ++LP3aA2l
+9Fn2qASS46IzMGJlC75mlTOTQwDM16UunMAK26lNG9J6q02o4d/oU2a7x0fD80yF
+64kNA1wDAwaVCYiUH541qKp+b4iDqer8nf8HqzYDFlpje18xYZMEd1hj8dVOharM
+pISJ+D52hV/BGEYF8r5k3hpC5d76gSP2oCcaY0XvLBf97qik
+-----END CERTIFICATE-----
+END
+    cms = OpenSSL::CMS.new
+    cms.type = "signed"
+    ca_cert = OpenSSL::X509::Certificate.new(ca_cert_pem)
+    cms.add_certificate ca_cert
+    cms.add_data ""
+
+    assert_nothing_raised do
+      cms.to_pem
+    end
+  end
+
+  def test_split_content
+    pend "not yet"
+     pki_message_pem = <<END
+-----BEGIN PKCS7-----
+MIIHSwYJKoZIhvcNAQcCoIIHPDCCBzgCAQExCzAJBgUrDgMCGgUAMIIDiAYJKoZI
+hvcNAQcBoIIDeQSCA3UwgAYJKoZIhvcNAQcDoIAwgAIBADGCARAwggEMAgEAMHUw
+cDEQMA4GA1UECgwHZXhhbXBsZTEXMBUGA1UEAwwOVEFSTUFDIFJPT1QgQ0ExIjAg
+BgkqhkiG9w0BCQEWE3NvbWVvbmVAZXhhbXBsZS5vcmcxCzAJBgNVBAYTAlVTMRIw
+EAYDVQQHDAlUb3duIEhhbGwCAWYwDQYJKoZIhvcNAQEBBQAEgYBspXXse8ZhG1FE
+E3PVAulbvrdR52FWPkpeLvSjgEkYzTiUi0CC3poUL1Ku5mOlavWAJgoJpFICDbvc
+N4ZNDCwOhnzoI9fMGmm1gvPQy15BdhhZRo9lP7Ga/Hg2APKT0/0yhPsmJ+w+u1e7
+OoJEVeEZ27x3+u745bGEcu8of5th6TCABgkqhkiG9w0BBwEwFAYIKoZIhvcNAwcE
+CBNs2U5mMsd/oIAEggIQU6cur8QBz02/4eMpHdlU9IkyrRMiaMZ/ky9zecOAjnvY
+d2jZqS7RhczpaNJaSli3GmDsKrF+XqE9J58s9ScGqUigzapusTsxIoRUPr7Ztb0a
+pg8VWDipAsuw7GfEkgx868sV93uC4v6Isfjbhd+JRTFp/wR1kTi7YgSXhES+RLUW
+gQbDIDgEQYxJ5U951AJtnSpjs9za2ZkTdd8RSEizJK0bQ1vqLoApwAVgZqluATqQ
+AHSDCxhweVYw6+y90B9xOrqPC0eU7Wzryq2+Raq5ND2Wlf5/N11RQ3EQdKq/l5Te
+ijp9PdWPlkUhWVoDlOFkysjk+BE+7AkzgYvz9UvBjmZsMsWqf+KsZ4S8/30ndLzu
+iucsu6eOnFLLX8DKZxV6nYffZOPzZZL8hFBcE7PPgSdBEkazMrEBXq1j5mN7exbJ
+NOA5uGWyJNBMOCe+1JbxG9UeoqvCCTHESxEeDu7xR3NnSOD47n7cXwHr81YzK2zQ
+5oWpP3C8jzI7tUjLd1S0Z3Psd17oaCn+JOfUtuB0nc3wfPF/WPo0xZQodWxp2/Cl
+EltR6qr1zf5C7GwmLzBZ6bHFAIT60/JzV0/56Pn8ztsRFtI4cwaBfTfvnwi8/sD9
+/LYOMY+/b6UDCUSR7RTN7XfrtAqDEzSdzdJkOWm1jvM8gkLmxpZdvxG3ZvDYnEQE
+5Nq+un5nAny1wf3rWierBAjE5ntiAmgs5AAAAAAAAAAAAACgggHqMIIB5jCCAU+g
+AwIBAgIBATANBgkqhkiG9w0BAQUFADAvMS0wKwYDVQQDEyQwQUM5RjAyNi1EQ0VB
+LTRDMTItOTEyNy1DMEZEN0QyQThCNUEwHhcNMTIxMDE5MDk0NTQ3WhcNMTMxMDE5
+MDk0NTQ3WjAvMS0wKwYDVQQDEyQwQUM5RjAyNi1EQ0VBLTRDMTItOTEyNy1DMEZE
+N0QyQThCNUEwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBALTsTNyGIsKvyw56
+WI3Gll/RmjsupkrdEtPbx7OjS9MEgyhOAf9+u6CV0LJGHpy7HUeROykF6xpbSdCm
+Mr6kNObl5N0ljOb8OmV4atKjmGg1rWawDLyDQ9Dtuby+dzfHtzAzP+J/3ZoOtSqq
+AHVTnCclU1pm/uHN0HZ5nL5iLJTvAgMBAAGjEjAQMA4GA1UdDwEB/wQEAwIFoDAN
+BgkqhkiG9w0BAQUFAAOBgQA8K+BouEV04HRTdMZd3akjTQOm6aEGW4nIRnYIf8ZV
+mvUpLirVlX/unKtJinhGisFGpuYLMpemx17cnGkBeLCQRvHQjC+ho7l8/LOGheMS
+nvu0XHhvmJtRbm8MKHhogwZqHFDnXonvjyqhnhEtK5F2Fimcce3MoF2QtEe0UWv/
+8DGCAaowggGmAgEBMDQwLzEtMCsGA1UEAxMkMEFDOUYwMjYtRENFQS00QzEyLTkx
+MjctQzBGRDdEMkE4QjVBAgEBMAkGBSsOAwIaBQCggc0wEgYKYIZIAYb4RQEJAjEE
+EwIxOTAYBgkqhkiG9w0BCQMxCwYJKoZIhvcNAQcBMBwGCSqGSIb3DQEJBTEPFw0x
+MjEwMTkwOTQ1NDdaMCAGCmCGSAGG+EUBCQUxEgQQ2EFUJdQNwQDxclIQ8qNyYzAj
+BgkqhkiG9w0BCQQxFgQUy8GFXPpAwRJUT3rdvNC9Pn+4eoswOAYKYIZIAYb4RQEJ
+BzEqEygwRkU3QzJEQTVEMDc2NzFFOTcxNDlCNUE3MDRCMERDNkM4MDYwRDJBMA0G
+CSqGSIb3DQEBAQUABIGAWUNdzvU2iiQOtihBwF0h48Nnw/2qX8uRjg6CVTOMcGji
+BxjUMifEbT//KJwljshl4y3yBLqeVYLOd04k6aKSdjgdZnrnUPI6p5tL5PfJkTAE
+L6qflZ9YCU5erE4T5U98hCQBMh4nOYxgaTjnZzhpkKQuEiKq/755cjzTzlI/eok=
+-----END PKCS7-----
+END
+    pki_message_content_pem = <<END
+-----BEGIN PKCS7-----
+MIIDawYJKoZIhvcNAQcDoIIDXDCCA1gCAQAxggEQMIIBDAIBADB1MHAxEDAOBgNV
+BAoMB2V4YW1wbGUxFzAVBgNVBAMMDlRBUk1BQyBST09UIENBMSIwIAYJKoZIhvcN
+AQkBFhNzb21lb25lQGV4YW1wbGUub3JnMQswCQYDVQQGEwJVUzESMBAGA1UEBwwJ
+VG93biBIYWxsAgFmMA0GCSqGSIb3DQEBAQUABIGAbKV17HvGYRtRRBNz1QLpW763
+UedhVj5KXi70o4BJGM04lItAgt6aFC9SruZjpWr1gCYKCaRSAg273DeGTQwsDoZ8
+6CPXzBpptYLz0MteQXYYWUaPZT+xmvx4NgDyk9P9MoT7JifsPrtXuzqCRFXhGdu8
+d/ru+OWxhHLvKH+bYekwggI9BgkqhkiG9w0BBwEwFAYIKoZIhvcNAwcECBNs2U5m
+Msd/gIICGFOnLq/EAc9Nv+HjKR3ZVPSJMq0TImjGf5Mvc3nDgI572Hdo2aku0YXM
+6WjSWkpYtxpg7Cqxfl6hPSefLPUnBqlIoM2qbrE7MSKEVD6+2bW9GqYPFVg4qQLL
+sOxnxJIMfOvLFfd7guL+iLH424XfiUUxaf8EdZE4u2IEl4REvkS1FoEGwyA4BEGM
+SeVPedQCbZ0qY7Pc2tmZE3XfEUhIsyStG0Nb6i6AKcAFYGapbgE6kAB0gwsYcHlW
+MOvsvdAfcTq6jwtHlO1s68qtvkWquTQ9lpX+fzddUUNxEHSqv5eU3oo6fT3Vj5ZF
+IVlaA5ThZMrI5PgRPuwJM4GL8/VLwY5mbDLFqn/irGeEvP99J3S87ornLLunjpxS
+y1/AymcVep2H32Tj82WS/IRQXBOzz4EnQRJGszKxAV6tY+Zje3sWyTTgObhlsiTQ
+TDgnvtSW8RvVHqKrwgkxxEsRHg7u8UdzZ0jg+O5+3F8B6/NWMyts0OaFqT9wvI8y
+O7VIy3dUtGdz7Hde6Ggp/iTn1LbgdJ3N8Hzxf1j6NMWUKHVsadvwpRJbUeqq9c3+
+QuxsJi8wWemxxQCE+tPyc1dP+ej5/M7bERbSOHMGgX03758IvP7A/fy2DjGPv2+l
+AwlEke0Uze1367QKgxM0nc3SZDlptY7zPIJC5saWXb8Rt2bw2JxEBOTavrp+ZwJ8
+tcH961onq8Tme2ICaCzk
+-----END PKCS7-----
+END
+    pki_msg = OpenSSL::CMS.new(pki_message_pem)
+    store = OpenSSL::X509::Store.new
+    pki_msg.verify(nil, store, nil, OpenSSL::CMS::NOVERIFY)
+    cmsenc = OpenSSL::CMS.new(pki_msg.data)
+    assert_equal(pki_message_content_pem, cmsenc.to_pem)
+  end
+end
+
+end

--- a/test/test_cms.rb
+++ b/test/test_cms.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: false
 require_relative 'utils'
 
-if defined?(OpenSSL)
+if defined?(OpenSSL::CMS)
 
 class OpenSSL::TestCMS < OpenSSL::TestCase
   def setup
@@ -35,7 +35,6 @@ class OpenSSL::TestCMS < OpenSSL::TestCase
 
     data = "aaaaa\r\nbbbbb\r\nccccc\r\n"
     tmp = OpenSSL::CMS.sign(@ee1_cert, @rsa1024, data, ca_certs)
-    byebug
     cms = OpenSSL::CMS::ContentInfo.new(tmp.to_der)
     certs = cms.certificates
     signers = cms.signers
@@ -67,197 +66,31 @@ class OpenSSL::TestCMS < OpenSSL::TestCase
     assert_equal(@ee1_cert.serial, signers[0].serial)
     assert_equal(@ee1_cert.issuer.to_s, signers[0].issuer.to_s)
 
-    # A signed-data which have multiple signatures can be created
-    # through the following steps.
-    #   1. create two signed-data
-    #   2. copy signerInfo and certificate from one to another
+    if false
+      # multiple signers not yet supported.
+      # A signed-data which have multiple signatures can be created
+      # through the following steps.
+      #   1. create two signed-data
+      #   2. copy signerInfo and certificate from one to another
 
-    tmp1 = OpenSSL::CMS.sign(@ee1_cert, @rsa1024, data, [], flag)
-    tmp2 = OpenSSL::CMS.sign(@ee2_cert, @rsa1024, data, [], flag)
-    tmp1.add_signer(tmp2.signers[0])
-    tmp1.add_certificate(@ee2_cert)
+      tmp1 = OpenSSL::CMS.sign(@ee1_cert, @rsa1024, data, [], flag)
+      tmp2 = OpenSSL::CMS.sign(@ee2_cert, @rsa1024, data, [], flag)
+      tmp1.add_signer(tmp2.signers[0])
+      tmp1.add_certificate(@ee2_cert)
 
-    cms = OpenSSL::CMS.ContentInfo.new(tmp1.to_der)
-    certs = cms.certificates
-    signers = cms.signers
-    assert(cms.verify([], store))
-    assert_equal(data, cms.data)
-    assert_equal(2, certs.size)
-    assert_equal(2, signers.size)
-    assert_equal(@ee1_cert.serial, signers[0].serial)
-    assert_equal(@ee1_cert.issuer.to_s, signers[0].issuer.to_s)
-    assert_equal(@ee2_cert.serial, signers[1].serial)
-    assert_equal(@ee2_cert.issuer.to_s, signers[1].issuer.to_s)
-  end
-
-  def test_detached_sign
-    pend "not yet"
-    store = OpenSSL::X509::Store.new
-    store.add_cert(@ca_cert)
-    ca_certs = [@ca_cert]
-
-    data = "aaaaa\nbbbbb\nccccc\n"
-    flag = OpenSSL::PKCS7::BINARY|OpenSSL::PKCS7::DETACHED
-    tmp = OpenSSL::PKCS7.sign(@ee1_cert, @rsa1024, data, ca_certs, flag)
-    p7 = OpenSSL::PKCS7.new(tmp.to_der)
-    assert_nothing_raised do
-      OpenSSL::ASN1.decode(p7)
-    end
-
-    certs = p7.certificates
-    signers = p7.signers
-    assert(!p7.verify([], store))
-    assert(p7.verify([], store, data))
-    assert_equal(data, p7.data)
-    assert_equal(2, certs.size)
-    assert_equal(@ee1_cert.subject.to_s, certs[0].subject.to_s)
-    assert_equal(@ca_cert.subject.to_s, certs[1].subject.to_s)
-    assert_equal(1, signers.size)
-    assert_equal(@ee1_cert.serial, signers[0].serial)
-    assert_equal(@ee1_cert.issuer.to_s, signers[0].issuer.to_s)
-  end
-
-  def test_enveloped
-    pend "not yet"
-    certs = [@ee1_cert, @ee2_cert]
-    cipher = OpenSSL::Cipher::AES.new("128-CBC")
-    data = "aaaaa\nbbbbb\nccccc\n"
-
-    tmp = OpenSSL::PKCS7.encrypt(certs, data, cipher, OpenSSL::PKCS7::BINARY)
-    p7 = OpenSSL::PKCS7.new(tmp.to_der)
-    recip = p7.recipients
-    assert_equal(:enveloped, p7.type)
-    assert_equal(2, recip.size)
-
-    assert_equal(@ca_cert.subject.to_s, recip[0].issuer.to_s)
-    assert_equal(2, recip[0].serial)
-    assert_equal(data, p7.decrypt(@rsa1024, @ee1_cert))
-
-    assert_equal(@ca_cert.subject.to_s, recip[1].issuer.to_s)
-    assert_equal(3, recip[1].serial)
-    assert_equal(data, p7.decrypt(@rsa1024, @ee2_cert))
-
-    assert_equal(data, p7.decrypt(@rsa1024))
-  end
-
-  def test_graceful_parsing_failure #[ruby-core:43250]
-    pend "not yet"
-    contents = File.read(__FILE__)
-    assert_raise(ArgumentError) { OpenSSL::PKCS7.new(contents) }
-  end
-
-  def test_degenerate_cms
-    pend "not yet"
-    ca_cert_pem = <<END
------BEGIN CERTIFICATE-----
-MIID4DCCAsigAwIBAgIJAL1oVI72wmQwMA0GCSqGSIb3DQEBBQUAMFMxCzAJBgNV
-BAYTAkFVMQ4wDAYDVQQIEwVTdGF0ZTENMAsGA1UEBxMEQ2l0eTEQMA4GA1UEChMH
-RXhhbXBsZTETMBEGA1UEAxMKRXhhbXBsZSBDQTAeFw0xMjEwMTgwOTE2NTBaFw0y
-MjEwMTYwOTE2NTBaMFMxCzAJBgNVBAYTAkFVMQ4wDAYDVQQIEwVTdGF0ZTENMAsG
-A1UEBxMEQ2l0eTEQMA4GA1UEChMHRXhhbXBsZTETMBEGA1UEAxMKRXhhbXBsZSBD
-QTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMTSPNxOkd5NN19XO0fJ
-tGVlWN4DWuvVL9WbWnXJXX9rU6X8sSOL9RrRA64eEZf2UBFjz9fMHZj/OGcxZpus
-4YtzfSrMU6xfvsIHeqX+mT60ms2RfX4UXab50MQArBin3JVKHGnOi25uyAOylVFU
-TuzzQJvKyB67vjuRPMlVAgVAZAP07ru9gW0ajt/ODxvUfvXxp5SFF68mVP2ipMBr
-4fujUwQC6cVHmnuL6p87VFoo9uk87TSQVDOQGL8MK4moMFtEW9oUTU22CgnxnCsS
-sCCELYhy9BdaTWQH26LzMfhnwSuIRHZyprW4WZtU0akrYXNiCj8o92rZmQWXJDbl
-qNECAwEAAaOBtjCBszAdBgNVHQ4EFgQUNtVw4jvkZZbkdQbkYi2/F4QN79owgYMG
-A1UdIwR8MHqAFDbVcOI75GWW5HUG5GItvxeEDe/aoVekVTBTMQswCQYDVQQGEwJB
-VTEOMAwGA1UECBMFU3RhdGUxDTALBgNVBAcTBENpdHkxEDAOBgNVBAoTB0V4YW1w
-bGUxEzARBgNVBAMTCkV4YW1wbGUgQ0GCCQC9aFSO9sJkMDAMBgNVHRMEBTADAQH/
-MA0GCSqGSIb3DQEBBQUAA4IBAQBvJIsY9bIqliZ3WD1KoN4cvAQeRAPsoLXQkkHg
-P6Nrcw9rJ5JvoHfYbo5aNlwbnkbt/B2xlVEXUYpJoBZFXafgxG2gJleioIgnaDS4
-FPPwZf1C5ZrOgUBfxTGjHex4ghSAoNGOd35jQzin5NGKOvZclPjZ2vQ++LP3aA2l
-9Fn2qASS46IzMGJlC75mlTOTQwDM16UunMAK26lNG9J6q02o4d/oU2a7x0fD80yF
-64kNA1wDAwaVCYiUH541qKp+b4iDqer8nf8HqzYDFlpje18xYZMEd1hj8dVOharM
-pISJ+D52hV/BGEYF8r5k3hpC5d76gSP2oCcaY0XvLBf97qik
------END CERTIFICATE-----
-END
-    cms = OpenSSL::CMS.new
-    cms.type = "signed"
-    ca_cert = OpenSSL::X509::Certificate.new(ca_cert_pem)
-    cms.add_certificate ca_cert
-    cms.add_data ""
-
-    assert_nothing_raised do
-      cms.to_pem
+      cms = OpenSSL::CMS.ContentInfo.new(tmp1.to_der)
+      certs = cms.certificates
+      signers = cms.signers
+      assert(cms.verify([], store))
+      assert_equal(data, cms.data)
+      assert_equal(2, certs.size)
+      assert_equal(2, signers.size)
+      assert_equal(@ee1_cert.serial, signers[0].serial)
+      assert_equal(@ee1_cert.issuer.to_s, signers[0].issuer.to_s)
+      assert_equal(@ee2_cert.serial, signers[1].serial)
+      assert_equal(@ee2_cert.issuer.to_s, signers[1].issuer.to_s)
     end
   end
 
-  def test_split_content
-    pend "not yet"
-     pki_message_pem = <<END
------BEGIN PKCS7-----
-MIIHSwYJKoZIhvcNAQcCoIIHPDCCBzgCAQExCzAJBgUrDgMCGgUAMIIDiAYJKoZI
-hvcNAQcBoIIDeQSCA3UwgAYJKoZIhvcNAQcDoIAwgAIBADGCARAwggEMAgEAMHUw
-cDEQMA4GA1UECgwHZXhhbXBsZTEXMBUGA1UEAwwOVEFSTUFDIFJPT1QgQ0ExIjAg
-BgkqhkiG9w0BCQEWE3NvbWVvbmVAZXhhbXBsZS5vcmcxCzAJBgNVBAYTAlVTMRIw
-EAYDVQQHDAlUb3duIEhhbGwCAWYwDQYJKoZIhvcNAQEBBQAEgYBspXXse8ZhG1FE
-E3PVAulbvrdR52FWPkpeLvSjgEkYzTiUi0CC3poUL1Ku5mOlavWAJgoJpFICDbvc
-N4ZNDCwOhnzoI9fMGmm1gvPQy15BdhhZRo9lP7Ga/Hg2APKT0/0yhPsmJ+w+u1e7
-OoJEVeEZ27x3+u745bGEcu8of5th6TCABgkqhkiG9w0BBwEwFAYIKoZIhvcNAwcE
-CBNs2U5mMsd/oIAEggIQU6cur8QBz02/4eMpHdlU9IkyrRMiaMZ/ky9zecOAjnvY
-d2jZqS7RhczpaNJaSli3GmDsKrF+XqE9J58s9ScGqUigzapusTsxIoRUPr7Ztb0a
-pg8VWDipAsuw7GfEkgx868sV93uC4v6Isfjbhd+JRTFp/wR1kTi7YgSXhES+RLUW
-gQbDIDgEQYxJ5U951AJtnSpjs9za2ZkTdd8RSEizJK0bQ1vqLoApwAVgZqluATqQ
-AHSDCxhweVYw6+y90B9xOrqPC0eU7Wzryq2+Raq5ND2Wlf5/N11RQ3EQdKq/l5Te
-ijp9PdWPlkUhWVoDlOFkysjk+BE+7AkzgYvz9UvBjmZsMsWqf+KsZ4S8/30ndLzu
-iucsu6eOnFLLX8DKZxV6nYffZOPzZZL8hFBcE7PPgSdBEkazMrEBXq1j5mN7exbJ
-NOA5uGWyJNBMOCe+1JbxG9UeoqvCCTHESxEeDu7xR3NnSOD47n7cXwHr81YzK2zQ
-5oWpP3C8jzI7tUjLd1S0Z3Psd17oaCn+JOfUtuB0nc3wfPF/WPo0xZQodWxp2/Cl
-EltR6qr1zf5C7GwmLzBZ6bHFAIT60/JzV0/56Pn8ztsRFtI4cwaBfTfvnwi8/sD9
-/LYOMY+/b6UDCUSR7RTN7XfrtAqDEzSdzdJkOWm1jvM8gkLmxpZdvxG3ZvDYnEQE
-5Nq+un5nAny1wf3rWierBAjE5ntiAmgs5AAAAAAAAAAAAACgggHqMIIB5jCCAU+g
-AwIBAgIBATANBgkqhkiG9w0BAQUFADAvMS0wKwYDVQQDEyQwQUM5RjAyNi1EQ0VB
-LTRDMTItOTEyNy1DMEZEN0QyQThCNUEwHhcNMTIxMDE5MDk0NTQ3WhcNMTMxMDE5
-MDk0NTQ3WjAvMS0wKwYDVQQDEyQwQUM5RjAyNi1EQ0VBLTRDMTItOTEyNy1DMEZE
-N0QyQThCNUEwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBALTsTNyGIsKvyw56
-WI3Gll/RmjsupkrdEtPbx7OjS9MEgyhOAf9+u6CV0LJGHpy7HUeROykF6xpbSdCm
-Mr6kNObl5N0ljOb8OmV4atKjmGg1rWawDLyDQ9Dtuby+dzfHtzAzP+J/3ZoOtSqq
-AHVTnCclU1pm/uHN0HZ5nL5iLJTvAgMBAAGjEjAQMA4GA1UdDwEB/wQEAwIFoDAN
-BgkqhkiG9w0BAQUFAAOBgQA8K+BouEV04HRTdMZd3akjTQOm6aEGW4nIRnYIf8ZV
-mvUpLirVlX/unKtJinhGisFGpuYLMpemx17cnGkBeLCQRvHQjC+ho7l8/LOGheMS
-nvu0XHhvmJtRbm8MKHhogwZqHFDnXonvjyqhnhEtK5F2Fimcce3MoF2QtEe0UWv/
-8DGCAaowggGmAgEBMDQwLzEtMCsGA1UEAxMkMEFDOUYwMjYtRENFQS00QzEyLTkx
-MjctQzBGRDdEMkE4QjVBAgEBMAkGBSsOAwIaBQCggc0wEgYKYIZIAYb4RQEJAjEE
-EwIxOTAYBgkqhkiG9w0BCQMxCwYJKoZIhvcNAQcBMBwGCSqGSIb3DQEJBTEPFw0x
-MjEwMTkwOTQ1NDdaMCAGCmCGSAGG+EUBCQUxEgQQ2EFUJdQNwQDxclIQ8qNyYzAj
-BgkqhkiG9w0BCQQxFgQUy8GFXPpAwRJUT3rdvNC9Pn+4eoswOAYKYIZIAYb4RQEJ
-BzEqEygwRkU3QzJEQTVEMDc2NzFFOTcxNDlCNUE3MDRCMERDNkM4MDYwRDJBMA0G
-CSqGSIb3DQEBAQUABIGAWUNdzvU2iiQOtihBwF0h48Nnw/2qX8uRjg6CVTOMcGji
-BxjUMifEbT//KJwljshl4y3yBLqeVYLOd04k6aKSdjgdZnrnUPI6p5tL5PfJkTAE
-L6qflZ9YCU5erE4T5U98hCQBMh4nOYxgaTjnZzhpkKQuEiKq/755cjzTzlI/eok=
------END PKCS7-----
-END
-    pki_message_content_pem = <<END
------BEGIN PKCS7-----
-MIIDawYJKoZIhvcNAQcDoIIDXDCCA1gCAQAxggEQMIIBDAIBADB1MHAxEDAOBgNV
-BAoMB2V4YW1wbGUxFzAVBgNVBAMMDlRBUk1BQyBST09UIENBMSIwIAYJKoZIhvcN
-AQkBFhNzb21lb25lQGV4YW1wbGUub3JnMQswCQYDVQQGEwJVUzESMBAGA1UEBwwJ
-VG93biBIYWxsAgFmMA0GCSqGSIb3DQEBAQUABIGAbKV17HvGYRtRRBNz1QLpW763
-UedhVj5KXi70o4BJGM04lItAgt6aFC9SruZjpWr1gCYKCaRSAg273DeGTQwsDoZ8
-6CPXzBpptYLz0MteQXYYWUaPZT+xmvx4NgDyk9P9MoT7JifsPrtXuzqCRFXhGdu8
-d/ru+OWxhHLvKH+bYekwggI9BgkqhkiG9w0BBwEwFAYIKoZIhvcNAwcECBNs2U5m
-Msd/gIICGFOnLq/EAc9Nv+HjKR3ZVPSJMq0TImjGf5Mvc3nDgI572Hdo2aku0YXM
-6WjSWkpYtxpg7Cqxfl6hPSefLPUnBqlIoM2qbrE7MSKEVD6+2bW9GqYPFVg4qQLL
-sOxnxJIMfOvLFfd7guL+iLH424XfiUUxaf8EdZE4u2IEl4REvkS1FoEGwyA4BEGM
-SeVPedQCbZ0qY7Pc2tmZE3XfEUhIsyStG0Nb6i6AKcAFYGapbgE6kAB0gwsYcHlW
-MOvsvdAfcTq6jwtHlO1s68qtvkWquTQ9lpX+fzddUUNxEHSqv5eU3oo6fT3Vj5ZF
-IVlaA5ThZMrI5PgRPuwJM4GL8/VLwY5mbDLFqn/irGeEvP99J3S87ornLLunjpxS
-y1/AymcVep2H32Tj82WS/IRQXBOzz4EnQRJGszKxAV6tY+Zje3sWyTTgObhlsiTQ
-TDgnvtSW8RvVHqKrwgkxxEsRHg7u8UdzZ0jg+O5+3F8B6/NWMyts0OaFqT9wvI8y
-O7VIy3dUtGdz7Hde6Ggp/iTn1LbgdJ3N8Hzxf1j6NMWUKHVsadvwpRJbUeqq9c3+
-QuxsJi8wWemxxQCE+tPyc1dP+ej5/M7bERbSOHMGgX03758IvP7A/fy2DjGPv2+l
-AwlEke0Uze1367QKgxM0nc3SZDlptY7zPIJC5saWXb8Rt2bw2JxEBOTavrp+ZwJ8
-tcH961onq8Tme2ICaCzk
------END PKCS7-----
-END
-    pki_msg = OpenSSL::CMS.new(pki_message_pem)
-    store = OpenSSL::X509::Store.new
-    pki_msg.verify(nil, store, nil, OpenSSL::CMS::NOVERIFY)
-    cmsenc = OpenSSL::CMS.new(pki_msg.data)
-    assert_equal(pki_message_content_pem, cmsenc.to_pem)
-  end
 end
-
-end
+end # if(OpenSSL)


### PR DESCRIPTION
This is the beginnings of support for CMS signatures and verification, in the spirit of the PKCS7 work.
I don't need encrypt/decrypt, so I will leave them for last. I will be adding eContentType settings, which are new since PKCS7.  The OpenSSL CMS SignerInfo code works differently than the PKCS7_SIGNER_INFO, and as I don't need multiple signatures for the moment, I will leave that until later as well.
