### PR TITLE
remove unneeded gem require for ipaddr

### DIFF
--- a/openssl.gemspec
+++ b/openssl.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.3.0"
 
-  spec.add_runtime_dependency "ipaddr"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rake-compiler"
   spec.add_development_dependency "test-unit", "~> 3.0"


### PR DESCRIPTION
ipaddr is a builtin class for ruby, that is occasionally merged. If the version isn't specified by the runtime dependency, then it will default to needing the latest gem rather than the version that ships with that version of ruby. That will lead to all kinds of potential dependency fails that are most likely unneeded since this gem already requires ruby > 2.3.0