### PR TITLE
Fix segfaults in OpenSSL::PKey::RSA#private_{en,de}crypt when private exp not set

### DIFF
--- a/ext/openssl/ossl_pkey_rsa.c
+++ b/ext/openssl/ossl_pkey_rsa.c
@@ -488,13 +488,13 @@ static VALUE
 ossl_rsa_private_encrypt(int argc, VALUE *argv, VALUE self)
 {
     RSA *rsa;
-    const BIGNUM *rsa_n;
+    const BIGNUM *rsa_n, *rsa_d;
     int buf_len, pad;
     VALUE str, buffer, padding;
 
     GetRSA(self, rsa);
-    RSA_get0_key(rsa, &rsa_n, NULL, NULL);
-    if (!rsa_n)
+    RSA_get0_key(rsa, &rsa_n, NULL, &rsa_d);
+    if (!rsa_n || !rsa_d)
 	ossl_raise(eRSAError, "incomplete RSA");
     if (!RSA_PRIVATE(self, rsa))
 	ossl_raise(eRSAError, "private key needed.");
@@ -522,13 +522,13 @@ static VALUE
 ossl_rsa_private_decrypt(int argc, VALUE *argv, VALUE self)
 {
     RSA *rsa;
-    const BIGNUM *rsa_n;
+    const BIGNUM *rsa_n, *rsa_d;
     int buf_len, pad;
     VALUE str, buffer, padding;
 
     GetRSA(self, rsa);
-    RSA_get0_key(rsa, &rsa_n, NULL, NULL);
-    if (!rsa_n)
+    RSA_get0_key(rsa, &rsa_n, NULL, &rsa_d);
+    if (!rsa_n || !rsa_d)
 	ossl_raise(eRSAError, "incomplete RSA");
     if (!RSA_PRIVATE(self, rsa))
 	ossl_raise(eRSAError, "private key needed.");

--- a/test/test_pkey_rsa.rb
+++ b/test/test_pkey_rsa.rb
@@ -4,6 +4,15 @@ require_relative "utils"
 if defined?(OpenSSL)
 
 class OpenSSL::TestPKeyRSA < OpenSSL::PKeyTestCase
+  def test_no_private_exp
+    key = OpenSSL::PKey::RSA.new
+    rsa = Fixtures.pkey("rsa2048")
+    key.set_key(rsa.n, rsa.e, nil) 
+    key.set_factors(rsa.p, rsa.q)
+    assert_raise(OpenSSL::PKey::RSAError){ key.private_encrypt("foo") }
+    assert_raise(OpenSSL::PKey::RSAError){ key.private_decrypt("foo") }
+  end
+
   def test_padding
     key = OpenSSL::PKey::RSA.new(512, 3)
 


### PR DESCRIPTION
The public exp not set would trigger this for #public_{en,de}crypt,
but OpenSSL::PKey::RSA#set does not allow setting a NULL public exp.

Fixes Ruby [Bug #15841]