### PR TITLE
OpenSSL::BN.new nil guard

### DIFF
--- a/ext/openssl/ossl_bn.c
+++ b/ext/openssl/ossl_bn.c
@@ -173,7 +173,6 @@ ossl_bn_alloc(VALUE klass)
 
 /*
  * call-seq:
- *    OpenSSL::BN.new => aBN
  *    OpenSSL::BN.new(bn) => aBN
  *    OpenSSL::BN.new(integer) => aBN
  *    OpenSSL::BN.new(string) => aBN

--- a/ext/openssl/ossl_bn.c
+++ b/ext/openssl/ossl_bn.c
@@ -192,6 +192,10 @@ ossl_bn_initialize(int argc, VALUE *argv, VALUE self)
 	base = NUM2INT(bs);
     }
 
+    if (NIL_P(str)) {
+        ossl_raise(rb_eArgError, "invalid argument");
+    }
+
     if (RB_INTEGER_TYPE_P(str)) {
 	GetBN(self, bn);
 	integer_to_bnptr(str, bn);

--- a/test/test_bn.rb
+++ b/test/test_bn.rb
@@ -15,6 +15,9 @@ class OpenSSL::TestBN < OpenSSL::TestCase
   end
 
   def test_new
+    assert_raise(ArgumentError) { OpenSSL::BN.new(nil) }
+    assert_raise(ArgumentError) { OpenSSL::BN.new(nil, 2) }
+
     assert_equal(@e1, OpenSSL::BN.new("999"))
     assert_equal(@e1, OpenSSL::BN.new("999", 10))
     assert_equal(@e1, OpenSSL::BN.new("\x03\xE7", 2))

--- a/test/test_bn.rb
+++ b/test/test_bn.rb
@@ -15,6 +15,7 @@ class OpenSSL::TestBN < OpenSSL::TestCase
   end
 
   def test_new
+    assert_raise(ArgumentError) { OpenSSL::BN.new }
     assert_raise(ArgumentError) { OpenSSL::BN.new(nil) }
     assert_raise(ArgumentError) { OpenSSL::BN.new(nil, 2) }
 


### PR DESCRIPTION
Hi!

This PR is related to #248 .

* add nil-guard for 1st argument of `OpenSSL::BN.new` 
* fix doc