### PR TITLE
Helpers for accessing AKI/SKI extensions of certs/crls

### DIFF
--- a/test/test_x509cert.rb
+++ b/test/test_x509cert.rb
@@ -76,11 +76,8 @@ class OpenSSL::TestX509Certificate < OpenSSL::TestCase
       ["authorityKeyIdentifier","issuer:always,keyid:always",false],
     ]
     ca_cert = issue_cert(@ca, @rsa2048, 1, ca_exts, nil, nil)
-    aki_fields = ca_cert.authority_key_identifier
     keyid = get_subject_key_id(ca_cert.to_der, hex: false)
-    assert_equal keyid, aki_fields[:key_identifier]
-    assert_equal ca_cert.subject, aki_fields[:authority_cert_issuer]
-    assert_equal ca_cert.serial, aki_fields[:authority_cert_serial_number]
+    assert_equal keyid, ca_cert.authority_key_identifier
     assert_equal keyid, ca_cert.subject_key_identifier
     ca_cert.extensions.each_with_index{|ext, i|
       assert_equal(ca_exts[i].first, ext.oid)

--- a/test/test_x509crl.rb
+++ b/test/test_x509crl.rb
@@ -132,16 +132,7 @@ class OpenSSL::TestX509CRL < OpenSSL::TestCase
     assert_equal(false, exts[0].critical?)
 
     expected_keyid = OpenSSL::TestUtils.get_subject_key_id(cert, hex: false)
-    actual_keyid = crl.authority_key_identifier[:key_identifier]
-    assert_equal expected_keyid, actual_keyid
-
-    expected_issuer = cert.issuer
-    actual_issuer = crl.authority_key_identifier[:authority_cert_issuer]
-    assert_equal expected_issuer, actual_issuer
-
-    expected_serial = cert.serial
-    actual_serial = crl.authority_key_identifier[:authority_cert_serial_number]
-    assert_equal expected_serial, actual_serial
+    assert_equal expected_keyid, crl.authority_key_identifier
 
     assert_equal("authorityKeyIdentifier", exts[1].oid)
     keyid = OpenSSL::TestUtils.get_subject_key_id(cert)

--- a/test/utils.rb
+++ b/test/utils.rb
@@ -111,13 +111,18 @@ module OpenSSL::TestUtils
     crl
   end
 
-  def get_subject_key_id(cert)
+  def get_subject_key_id(cert, hex: true)
     asn1_cert = OpenSSL::ASN1.decode(cert)
     tbscert   = asn1_cert.value[0]
     pkinfo    = tbscert.value[6]
     publickey = pkinfo.value[1]
     pkvalue   = publickey.value
-    OpenSSL::Digest::SHA1.hexdigest(pkvalue).scan(/../).join(":").upcase
+    digest = OpenSSL::Digest::SHA1.digest(pkvalue)
+    if hex
+      digest.unpack("H2"*20).join(":").upcase
+    else
+      digest
+    end
   end
 
   def openssl?(major = nil, minor = nil, fix = nil, patch = 0)


### PR DESCRIPTION
I'm taking a stab at implementing some of the functionality discussed in https://github.com/ruby/openssl/pull/234#issuecomment-502712858. This stuff is kind of tedious to write, so I thought I'd open a PR that just adds helpers for two extensions to make sure we're on the same page about how this should work. Support for more extensions can be added in future PRs if this works out.

This PR adds a `#subject_key_identifier` method to the `Certificate` class that parses out the value of the `subjectKeyIdentifier` extension. This is fairly straightforward. This PR also adds a `#authority_key_identifier` method to the `Certificate` and `CRL` classes that parses out the value of the `authorityKeyIdentifier` extension. This extension has a number of possible fields and I decided that a `Hash` was the simplest way to represent this data.

In both cases, I tried to validate the extension contents per the specification and covered many of the edge cases. The flexibility of these extensions makes things difficult though. For example, the `authority_cert_issuer` field of the `authorityKeyIdentifier` extension is a `GeneralNames`, which can be a `SEQUENCE` of `GeneralName`s, each of which can be one of nine different types, some of which have multiple possible subtypes. In practice though, this field should always be an RDN sequence. I opted to only handle the common case and return `nil` otherwise. I'm happy to discuss other options here and to be more or less flexible with these complex types.

/cc @ioquatix 