### PR TITLE
Fix minimal typo on documentation [skip ci]

### DIFF
--- a/ext/openssl/ossl.c
+++ b/ext/openssl/ossl.c
@@ -904,7 +904,7 @@ static void Init_ossl_locks(void)
  *   ca_key = OpenSSL::PKey::RSA.new 2048
  *   pass_phrase = 'my secure pass phrase goes here'
  *
- *   cipher = OpenSSL::Cipher::Cipher.new 'AES-256-CBC'
+ *   cipher = OpenSSL::Cipher.new 'AES-256-CBC'
  *
  *   open 'ca_key.pem', 'w', 0400 do |io|
  *     io.write ca_key.export(cipher, pass_phrase)


### PR DESCRIPTION
Althrough `OpenSSL::Cipher::Cipher` do exist, it's deprecated:

```ruby
cipher = OpenSSL::Cipher::Cipher.new 'AES-256-CBC'
# warning: constant OpenSSL::Cipher::Cipher is deprecated
# => #<OpenSSL::Cipher::Cipher:0x000056481ba57f58>
```