### PR TITLE
Set key_set ivar to false if encrypt/decrypt called without key

### DIFF
--- a/ext/openssl/ossl_cipher.c
+++ b/ext/openssl/ossl_cipher.c
@@ -237,8 +237,7 @@ ossl_cipher_init(int argc, VALUE *argv, VALUE self, int mode)
 	ossl_raise(eCipherError, NULL);
     }
 
-    if (p_key)
-	rb_ivar_set(self, id_key_set, Qtrue);
+    rb_ivar_set(self, id_key_set, p_key ? Qtrue : Qfalse);
 
     return self;
 }

--- a/test/test_cipher.rb
+++ b/test/test_cipher.rb
@@ -305,6 +305,21 @@ class OpenSSL::TestCipher < OpenSSL::TestCase
     }
   end
 
+  def test_crypt_after_key
+    key = ["2b7e151628aed2a6abf7158809cf4f3c"].pack("H*")
+    %w'ecb cbc cfb ctr gcm'.each do |c|
+      cipher = OpenSSL::Cipher.new("aes-128-#{c}")
+      cipher.key = key
+      cipher.encrypt
+      assert_raise(OpenSSL::Cipher::CipherError) { cipher.update("") }
+
+      cipher = OpenSSL::Cipher.new("aes-128-#{c}")
+      cipher.key = key
+      cipher.decrypt
+      assert_raise(OpenSSL::Cipher::CipherError) { cipher.update("") }
+    end
+  end
+
   private
 
   def new_encryptor(algo, **kwargs)


### PR DESCRIPTION
This makes it obvious you have made a mistake if you call key= and
then encrypt or decrypt.  Calling encrypt or decrypt without an
argument automatically sets the key to NULL, in which case the
key_set ivar should be changed from false to true given if had
been set before calling encrypt or decrypt.

Fixes Ruby Bug 8720.