### PR TITLE
x509name: return nil for wrong type in Name#<=>

### DIFF
--- a/ext/openssl/ossl_x509name.c
+++ b/ext/openssl/ossl_x509name.c
@@ -387,16 +387,20 @@ ossl_x509name_cmp0(VALUE self, VALUE other)
 
 /*
  * call-seq:
- *    name.cmp(other) -> -1 | 0 | 1
- *    name <=> other  -> -1 | 0 | 1
+ *    name.cmp(other) -> -1 | 0 | 1 | nil
+ *    name <=> other  -> -1 | 0 | 1 | nil
  *
  * Compares this Name with _other_ and returns +0+ if they are the same and +-1+
  * or ++1+ if they are greater or less than each other respectively.
+ * Returns +nil+ if they are not comparable (i.e. different types).
  */
 static VALUE
 ossl_x509name_cmp(VALUE self, VALUE other)
 {
     int result;
+
+    if (!rb_obj_is_kind_of(other, cX509Name))
+	return Qnil;
 
     result = ossl_x509name_cmp0(self, other);
     if (result < 0) return INT2FIX(-1);

--- a/test/test_x509name.rb
+++ b/test/test_x509name.rb
@@ -402,6 +402,9 @@ class OpenSSL::TestX509Name < OpenSSL::TestCase
     n2 = OpenSSL::X509::Name.parse_rfc2253 'CN=a'
 
     assert_equal n1, n2
+
+    assert_equal false, n1 == 'abc'
+    assert_equal false, n2 == nil
   end
 
   def test_spaceship
@@ -415,6 +418,9 @@ class OpenSSL::TestX509Name < OpenSSL::TestCase
     assert_equal -1, n2 <=> n3
     assert_equal 1, n3 <=> n1
     assert_equal 1, n3 <=> n2
+    assert_equal nil, n1 <=> 'abc'
+    assert_equal nil, n2 <=> 123
+    assert_equal nil, n3 <=> nil
   end
 
   def name_hash(name)


### PR DESCRIPTION
Previously, OpenSSL::X509::Name#{cmp,<=>} would raise a TypeError if you
attempted to compare a Name object with another object of a different
type. Most Ruby classes instead return nil in this situation.

The old behavior resulted in some strange outcomes:

    >> n1 = OpenSSL::X509::Name.new

    >> 'abc' == n1
    => false

    >> n1 == 'abc'
    TypeError: wrong argument type String (expected OpenSSL/X509/NAME)

With the new behavior, cmp/<=> will return nil if the other object is
not an X509::Name instead of raising an error. This allows `==` to also
return false instead of raising an error for type mismatches.

New behavior:

    >> n1 = OpenSSL::X509::Name.new

    >> n1 == 'abc'
    => false

    >> n1 <=> 'abc'
    => nil