### PR TITLE
Silence warning on spaceship tests

### DIFF
--- a/test/test_x509name.rb
+++ b/test/test_x509name.rb
@@ -413,9 +413,9 @@ class OpenSSL::TestX509Name < OpenSSL::TestCase
     n3 = OpenSSL::X509::Name.new([["CN", "ab"]])
 
     assert_equal 0, n1 <=> n2
-    assert_equal -1, n1 <=> n3
+    assert_equal(-1, n1 <=> n3)
     assert_equal 0, n2 <=> n1
-    assert_equal -1, n2 <=> n3
+    assert_equal(-1, n2 <=> n3)
     assert_equal 1, n3 <=> n1
     assert_equal 1, n3 <=> n2
     assert_equal nil, n1 <=> 'abc'


### PR DESCRIPTION
When running the test suite, these new warnings appears:

```
/src/test/test_x509name.rb:416: warning: ambiguous first argument; put parentheses or a space even after `-' operator
/src/test/test_x509name.rb:418: warning: ambiguous first argument; put parentheses or a space even after `-' operator
```
