### PR TITLE
Remove OpenSSL::PKCS7::SignerInfo#name

### DIFF
--- a/ext/openssl/ossl_pkcs7.c
+++ b/ext/openssl/ossl_pkcs7.c
@@ -1088,7 +1088,6 @@ Init_ossl_pkcs7(void)
     rb_define_alloc_func(cPKCS7Signer, ossl_pkcs7si_alloc);
     rb_define_method(cPKCS7Signer, "initialize", ossl_pkcs7si_initialize,3);
     rb_define_method(cPKCS7Signer, "issuer", ossl_pkcs7si_get_issuer, 0);
-    rb_define_alias(cPKCS7Signer, "name", "issuer");
     rb_define_method(cPKCS7Signer, "serial", ossl_pkcs7si_get_serial,0);
     rb_define_method(cPKCS7Signer,"signed_time",ossl_pkcs7si_get_signed_time,0);
 


### PR DESCRIPTION
This method name is misleading, because it returns the name of the
signer's issuer, not the name of the signing certificate. It is
just an alias of issuer, which is more accurate.  The "name" method
is historical, it was replaced by the "issuer" method in 2005, and
since then has been alias for backwards compatibility.

There are no tests for the "name" method.

Fixes Ruby Bug 8178.
