### PR TITLE
Run OPENSSL_config to load system SSL configuration

### DIFF
--- a/ext/openssl/ossl.c
+++ b/ext/openssl/ossl.c
@@ -1114,6 +1114,7 @@ Init_openssl(void)
     if (!OPENSSL_init_ssl(0, NULL))
         rb_raise(rb_eRuntimeError, "OPENSSL_init_ssl");
 #else
+    OPENSSL_config(NULL);
     OpenSSL_add_ssl_algorithms();
     OpenSSL_add_all_algorithms();
     ERR_load_crypto_strings();


### PR DESCRIPTION
This can allow the use of non-default ciphers such as GOST using
Ruby if the system OpenSSL configuration allows them.

Fixes Ruby Bug 9822.