### PR TITLE
Add `OpenSSL.memcmp?` for constant time/timing safe comparison

### DIFF
--- a/ext/openssl/ossl.c
+++ b/ext/openssl/ossl.c
@@ -605,6 +605,41 @@ static void Init_ossl_locks(void)
 #endif /* !HAVE_OPENSSL_110_THREADING_API */
 
 /*
+ * call-seq:
+ *   OpenSSL.memcmp?(string, string) -> boolean
+ *
+ * Constant time memory comparison. Inputs must be of equal length, otherwise
+ * an error is raised since timing attacks could leak the length of a
+ * secret.
+ *
+ * For securely comparing user input, it's recommended to use hashing and
+ * regularly compare after to prevent an unlikely false positive due to a
+ * collision.
+ *
+ *   user_input      = "..."
+ *   expected        = "..."
+ *   hashed_input    = OpenSSL::Digest::SHA256.digest(user_input)
+ *   hashed_expected = OpenSSL::Digest::SHA256.digest(expected)
+ *   OpenSSL.memcmp?(hashed_input, hashed_expected) && user_input == expected
+ */
+static VALUE
+ossl_crypto_memcmp(VALUE dummy, VALUE str1, VALUE str2)
+{
+    const unsigned char *p1 = (const unsigned char *)StringValuePtr(str1);
+    const unsigned char *p2 = (const unsigned char *)StringValuePtr(str2);
+    long len1 = RSTRING_LEN(str1);
+    long len2 = RSTRING_LEN(str2);
+
+    if(len1 != len2)
+    ossl_raise(rb_eArgError, "inputs must be of equal length");
+
+    switch (CRYPTO_memcmp(p1, p2, len1)) {
+      case 0:	return Qtrue;
+      default:	return Qfalse;
+    }
+}
+
+/*
  * OpenSSL provides SSL, TLS and general purpose cryptography.  It wraps the
  * OpenSSL[https://www.openssl.org/] library.
  *
@@ -1125,6 +1160,7 @@ Init_openssl(void)
      */
     mOSSL = rb_define_module("OpenSSL");
     rb_global_variable(&mOSSL);
+    rb_define_singleton_method(mOSSL, "memcmp?", ossl_crypto_memcmp, 2);
 
     /*
      * OpenSSL ruby extension version

--- a/test/test_ossl.rb
+++ b/test/test_ossl.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+require_relative "utils"
+
+if defined?(OpenSSL)
+
+class OpenSSL::OSSL < OpenSSL::SSLTestCase
+  def test_memcmp?
+    assert_raises(ArgumentError) { OpenSSL.memcmp?("aaa", "a") }
+    assert_raises(ArgumentError) { OpenSSL.memcmp?("aaa", "aa") }
+
+    assert OpenSSL.memcmp?("aaa", "aaa")
+    assert OpenSSL.memcmp?(
+      OpenSSL::Digest::SHA256.digest("aaa"), OpenSSL::Digest::SHA256.digest("aaa")
+    )
+
+    assert_raises(ArgumentError) { OpenSSL.memcmp?("aaa", "aaaa") }
+    refute OpenSSL.memcmp?("aaa", "baa")
+    refute OpenSSL.memcmp?("aaa", "aba")
+    refute OpenSSL.memcmp?("aaa", "aab")
+    assert_raises(ArgumentError) { OpenSSL.memcmp?("aaa", "aaab") }
+    assert_raises(ArgumentError) { OpenSSL.memcmp?("aaa", "b") }
+    assert_raises(ArgumentError) { OpenSSL.memcmp?("aaa", "bb") }
+    refute OpenSSL.memcmp?("aaa", "bbb")
+    assert_raises(ArgumentError) { OpenSSL.memcmp?("aaa", "bbbb") }
+  end
+end
+
+end

--- a/test/test_ossl.rb
+++ b/test/test_ossl.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 require_relative "utils"
 
+require 'benchmark'
+
 if defined?(OpenSSL)
 
 class OpenSSL::OSSL < OpenSSL::SSLTestCase
@@ -22,6 +24,21 @@ class OpenSSL::OSSL < OpenSSL::SSLTestCase
     assert_raises(ArgumentError) { OpenSSL.memcmp?("aaa", "bb") }
     refute OpenSSL.memcmp?("aaa", "bbb")
     assert_raises(ArgumentError) { OpenSSL.memcmp?("aaa", "bbbb") }
+  end
+
+  def test_memcmp_timing
+    # Ensure using memcmp? takes almost exactly the same amount of time to compare two different strings.
+    # Regular string comparison will short-circuit on the first non-matching character, failing this test.
+    # NOTE: this test may be susceptible to noise if the system running the tests is otherwise under load.
+    a = "x" * 512_000
+    b = "#{a}y"
+    c = "y#{a}"
+    a = "#{a}x"
+
+    n = 10_000
+    a_b_time = Benchmark.measure { n.times { OpenSSL.memcmp?(a, b) } }.real
+    a_c_time = Benchmark.measure { n.times { OpenSSL.memcmp?(a, c) } }.real
+    assert_in_delta(a_b_time, a_c_time, 1, "memcmp? timing test failed")
   end
 end
 


### PR DESCRIPTION
Fixes https://bugs.ruby-lang.org/issues/10098 - at the 2019-02-07 developer meeting it was punted back to OpenSSL to implement. I went with @shyouhei's suggestion to mirror `String#casecmp?` naming.

One way or the other, I think having a function like this built in to the standard library instead of several application implementations is a good thing. E.g. [.NET Core](https://github.com/dotnet/corefx/pull/27103) has it too.

Some benchmarking on my Macbook Pro 15" 2018 shows this is also faster than Ruby implementations:
```
> BYTES=16 bundle exec benchmark.rb
Calculating -------------------------------------
      Active Support    457.338k (± 0.8%) i/s -      2.311M in   5.053220s
                Rack    569.963k (± 0.5%) i/s -      2.871M in   5.036927s
             OpenSSL     11.822M (± 0.8%) i/s -     59.350M in   5.020598s

Comparison:
             OpenSSL: 11822116.2 i/s
                Rack:   569963.5 i/s - 20.74x  slower
      Active Support:   457338.3 i/s - 25.85x  slower



> BYTES=32 bundle exec benchmark.rb
Calculating -------------------------------------
      Active Support    259.457k (± 0.6%) i/s -      1.309M in   5.046238s
                Rack    309.408k (± 1.0%) i/s -      1.553M in   5.020759s
             OpenSSL     10.744M (± 0.7%) i/s -     53.870M in   5.014193s

Comparison:
             OpenSSL: 10743986.5 i/s
                Rack:   309408.0 i/s - 34.72x  slower
      Active Support:   259457.5 i/s - 41.41x  slower
```

```ruby
require 'benchmark/ips'
require 'openssl'

BYTES = ENV["BYTES"].to_i
STRING1 = 'A' * BYTES
STRING2 = 'A' * BYTES

def active_support(a, b)
  raise ArgumentError, "string length mismatch." unless a.bytesize == b.bytesize

  l = a.unpack "C#{a.bytesize}"

  res = 0
  b.each_byte { |byte| res |= byte ^ l.shift }
  res == 0
end

def rack(a, b)
  return false unless a.bytesize == b.bytesize

  l = a.unpack("C*")

  r, i = 0, -1
  b.each_byte { |v| r |= v ^ l[i+=1] }
  r == 0
end

def openssl(a, b)
  OpenSSL.memcmp?(a, b)
end

Benchmark.ips do |x|
  x.report('Active Support') { active_support(STRING1, STRING2) }
  x.report('Rack')           { rack(STRING1, STRING2) }
  x.report('OpenSSL')        { openssl(STRING1, STRING2) }
  x.compare!
end
```
