### PR TITLE
Remove taint support

### DIFF
--- a/ext/openssl/ossl_rand.c
+++ b/ext/openssl/ossl_rand.c
@@ -67,8 +67,6 @@ ossl_rand_add(VALUE self, VALUE str, VALUE entropy)
 static VALUE
 ossl_rand_load_file(VALUE self, VALUE filename)
 {
-    rb_check_safe_obj(filename);
-
     if(!RAND_load_file(StringValueCStr(filename), -1)) {
 	ossl_raise(eRandomError, NULL);
     }
@@ -86,8 +84,6 @@ ossl_rand_load_file(VALUE self, VALUE filename)
 static VALUE
 ossl_rand_write_file(VALUE self, VALUE filename)
 {
-    rb_check_safe_obj(filename);
-
     if (RAND_write_file(StringValueCStr(filename)) == -1) {
 	ossl_raise(eRandomError, NULL);
     }
@@ -164,8 +160,6 @@ ossl_rand_pseudo_bytes(VALUE self, VALUE len)
 static VALUE
 ossl_rand_egd(VALUE self, VALUE filename)
 {
-    rb_check_safe_obj(filename);
-
     if (RAND_egd(StringValueCStr(filename)) == -1) {
 	ossl_raise(eRandomError, NULL);
     }
@@ -185,8 +179,6 @@ static VALUE
 ossl_rand_egd_bytes(VALUE self, VALUE filename, VALUE len)
 {
     int n = NUM2INT(len);
-
-    rb_check_safe_obj(filename);
 
     if (RAND_egd_bytes(StringValueCStr(filename), n) == -1) {
 	ossl_raise(eRandomError, NULL);

--- a/ext/openssl/ossl_ssl.c
+++ b/ext/openssl/ossl_ssl.c
@@ -1843,7 +1843,6 @@ ossl_ssl_read_internal(int argc, VALUE *argv, VALUE self, int nonblock)
 	else
 	    rb_str_modify_expand(str, ilen - RSTRING_LEN(str));
     }
-    OBJ_TAINT(str);
     rb_str_set_len(str, 0);
     if (ilen == 0)
 	return str;

--- a/ext/openssl/ossl_x509store.c
+++ b/ext/openssl/ossl_x509store.c
@@ -304,7 +304,6 @@ ossl_x509store_add_file(VALUE self, VALUE file)
     char *path = NULL;
 
     if(file != Qnil){
-	rb_check_safe_obj(file);
 	path = StringValueCStr(file);
     }
     GetX509Store(self, store);
@@ -340,7 +339,6 @@ ossl_x509store_add_path(VALUE self, VALUE dir)
     char *path = NULL;
 
     if(dir != Qnil){
-	rb_check_safe_obj(dir);
 	path = StringValueCStr(dir);
     }
     GetX509Store(self, store);


### PR DESCRIPTION
Ruby 2.7 deprecates taint and it no longer has an effect.
The lack of taint support should not cause a problem in
previous Ruby versions.