### PR TITLE
Helper to retrieve CRL URIs from a certificate

### DIFF
--- a/lib/openssl/x509.rb
+++ b/lib/openssl/x509.rb
@@ -113,6 +113,39 @@ module OpenSSL
           key_id.nil? ? nil : key_id.value
         end
       end
+
+      module CRLDistributionPoints
+        include Helpers
+
+        # Get the distributionPoint fullName URI from the certificate's CRL
+        # distribution points extension, as described in RFC5280 Section
+        # 4.2.1.13
+        #
+        # Returns an array of strings or nil or raises ASN1::ASN1Error.
+        def crl_uris
+          ext = find_extension("crlDistributionPoints")
+          return nil if ext.nil?
+
+          cdp_asn1 = ASN1.decode(ext.value_der)
+          if cdp_asn1.tag_class != :UNIVERSAL || cdp_asn1.tag != ASN1::SEQUENCE
+            raise ASN1::ASN1Error "invalid extension"
+          end
+
+          crl_uris = cdp_asn1.map do |crl_distribution_point|
+            distribution_point = crl_distribution_point.value.find do |v|
+              v.tag_class == :CONTEXT_SPECIFIC && v.tag == 0
+            end
+            full_name = distribution_point&.value&.find do |v|
+              v.tag_class == :CONTEXT_SPECIFIC && v.tag == 0
+            end
+            full_name&.value&.find do |v|
+              v.tag_class == :CONTEXT_SPECIFIC && v.tag == 6 # uniformResourceIdentifier
+            end
+          end
+
+          crl_uris&.map(&:value)
+        end
+      end
     end
 
     class Name
@@ -234,6 +267,7 @@ module OpenSSL
     class Certificate
       include Extension::SubjectKeyIdentifier
       include Extension::AuthorityKeyIdentifier
+      include Extension::CRLDistributionPoints
 
       def pretty_print(q)
         q.object_group(self) {

--- a/test/utils.rb
+++ b/test/utils.rb
@@ -60,11 +60,10 @@ module OpenSSL::TestUtils
 
   module_function
 
-  def issue_cert(dn, key, serial, extensions, issuer, issuer_key,
-                 not_before: nil, not_after: nil, digest: "sha256")
+  def generate_cert(dn, key, serial, issuer,
+                    not_before: nil, not_after: nil)
     cert = OpenSSL::X509::Certificate.new
     issuer = cert unless issuer
-    issuer_key = key unless issuer_key
     cert.version = 2
     cert.serial = serial
     cert.subject = dn
@@ -73,6 +72,16 @@ module OpenSSL::TestUtils
     now = Time.now
     cert.not_before = not_before || now - 3600
     cert.not_after = not_after || now + 3600
+    cert
+  end
+
+
+  def issue_cert(dn, key, serial, extensions, issuer, issuer_key,
+                 not_before: nil, not_after: nil, digest: "sha256")
+    cert = generate_cert(dn, key, serial, issuer,
+                         not_before: not_before, not_after: not_after)
+    issuer = cert unless issuer
+    issuer_key = key unless issuer_key
     ef = OpenSSL::X509::ExtensionFactory.new
     ef.subject_certificate = cert
     ef.issuer_certificate = issuer


### PR DESCRIPTION
Similar to https://github.com/ruby/openssl/pull/260

According to [RFC 5280](https://tools.ietf.org/html/rfc5280#section-4.2.1.13) a distribution point can contain a lot of things, but in practice I'm seeing only `fullName` URIs (`6`).