### PR TITLE
fix flaky test

### DIFF
--- a/test/test_ssl.rb
+++ b/test/test_ssl.rb
@@ -427,18 +427,22 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
   def test_finished_messages
     server_finished = nil
     server_peer_finished = nil
+    client_finished = nil
+    client_peer_finished = nil
 
     start_server(accept_proc: proc { |server|
       server_finished = server.finished_message
       server_peer_finished = server.peer_finished_message
-    }){ |port, server|
+    }) { |port|
       ctx = OpenSSL::SSL::SSLContext.new
       ctx.verify_mode = OpenSSL::SSL::VERIFY_NONE
       server_connect(port, ctx) { |ssl|
-        assert_equal(server_finished, ssl.peer_finished_message)
-        assert_equal(server_peer_finished, ssl.finished_message)
+        client_finished = ssl.finished_message
+        client_peer_finished = ssl.peer_finished_message
       }
     }
+    assert_equal(server_finished, client_peer_finished)
+    assert_equal(server_peer_finished, client_finished)
   end
 
   def test_sslctx_set_params


### PR DESCRIPTION
Hi!

This PR is related to `test_finished_messages` method.

- fix flaky test
    - `server_finished` would nil, if [assert_equal](https://github.com/ruby/openssl/blob/e7ed01b580a139ad0fb320ad5f29bbb40ef2ddc2/test/test_ssl.rb#L438L439) run before `server_finished` was assigned.
- clean `start_server` method `block` argument
    - `start_server` method `block` argument requires an only [port](https://github.com/ruby/openssl/blob/e7ed01b580a139ad0fb320ad5f29bbb40ef2ddc2/test/utils.rb#L267).

You can reproduce the flaky bug, if you do the `git checkout e7ed01b` and insert `sleep` before [server_finished is assigned](https://github.com/ruby/openssl/blob/e7ed01b580a139ad0fb320ad5f29bbb40ef2ddc2/test/test_ssl.rb#L432).