### PR TITLE
Add GitHub actions

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,0 +1,58 @@
+name: OpenSSL
+
+on:
+  push:
+    branches:
+      - '*'
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  build:
+    name: >-
+      OS: ${{ matrix.os }}  Ruby: ${{ matrix.ruby }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ 'ubuntu-16.04', 'ubuntu-18.04', 'macos', 'windows-latest' ]
+        ruby: [ '2.3.x', '2.4.x', '2.5.x', '2.6.x' ]
+        exclude:
+        - os: ubuntu-16.04
+          ruby: 2.4.x
+        - os: ubuntu-16.04
+          ruby: 2.5.x
+        - os: ubuntu-16.04
+          ruby: 2.6.x
+        - os: ubuntu-18.04
+          ruby: 2.3.x
+        - os: macos
+          ruby: 2.3.x
+        - os: windows-latest
+          ruby: 2.3.x
+    steps:
+    - name: repo checkout
+      uses: actions/checkout@v1
+      with:
+        fetch-depth: 10
+    - name: load ruby
+      uses: actions/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+
+    - name: windows - update MSYS2, openssl
+      if:   startsWith(matrix.os, 'windows')
+      uses: MSP-Greg/msys2-action@master
+      with:
+        base:  update
+        mingw: openssl
+
+    - name: depends
+      run:  rake install_dependencies
+    - name: compile
+      run:  rake compile -- --enable-debug
+    - name: test
+      run:  rake test TESTOPTS="-v --no-show-detail-immediately" OSSL_MDEBUG=1
+      env:
+        CI: true

--- a/ext/openssl/extconf.rb
+++ b/ext/openssl/extconf.rb
@@ -40,6 +40,12 @@ end
 Logging::message "=== Checking for required stuff... ===\n"
 result = pkg_config("openssl") && have_header("openssl/ssl.h")
 
+if $mingw
+  append_cflags '-D_FORTIFY_SOURCE=2'
+  append_ldflags '-fstack-protector'
+  have_library 'ssp'
+end
+
 def find_openssl_library
   if $mswin || $mingw
     # required for static OpenSSL libraries

--- a/test/test_ssl.rb
+++ b/test/test_ssl.rb
@@ -439,6 +439,8 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
       server_connect(port, ctx) { |ssl|
         client_finished = ssl.finished_message
         client_peer_finished = ssl.peer_finished_message
+        sleep 0.05
+        ssl.send :stop
       }
     }
     assert_equal(server_finished, client_peer_finished)
@@ -1579,10 +1581,10 @@ end
   def test_fileno
     ctx = OpenSSL::SSL::SSLContext.new
     sock1, sock2 = socketpair
-    
+
     socket = OpenSSL::SSL::SSLSocket.new(sock1)
     server = OpenSSL::SSL::SSLServer.new(sock2, ctx)
-    
+
     assert_equal socket.fileno, socket.to_io.fileno
     assert_equal server.fileno, server.to_io.fileno
   ensure


### PR DESCRIPTION
Ubuntu 16.04 - Ruby 2.3, OpenSSL 1.1.1

Ubuntu 18.04 - Ruby 2.4, 2.5, 2.6, OpenSSL 1.1.1

macOS - 2.4, 2.5, 2.6, OpenSSL 1.0.2

Windows - Ruby 2.4, 2.5, 2.6, OpenSSL 1.0.2 & 1.1.1

Commits:

1. 'Add GitHub Actions- Ubuntu, macOS, Windows' - adds Actions, MinGW  jobs fully update MSYS2 toolchain and add correct OpenSSL files.

2. 'extconf.rb - update for new MSYS2, libssp' - current MSYS2 tools require using libssp.

3. 'OpenSSL::TestSSL#test_finished_messages - gracefully close client' - test would not pass on MinGW build using 1.1.1d.  Added two lines to close client
