### PR TITLE
Add Marshal support to X509 objects

### DIFF
--- a/lib/openssl/x509.rb
+++ b/lib/openssl/x509.rb
@@ -14,6 +14,22 @@
 
 module OpenSSL
   module X509
+    module Marshal
+      def self.included(base)
+        base.extend(ClassMethods)
+      end
+
+      module ClassMethods
+        def _load(string)
+          new(string)
+        end
+      end
+
+      def _dump(_level)
+        to_der
+      end
+    end
+
     class ExtensionFactory
       def create_extension(*arg)
         if arg.size > 1
@@ -41,6 +57,8 @@ module OpenSSL
     end
 
     class Extension
+      include Marshal
+
       def ==(other)
         return false unless Extension === other
         to_der == other.to_der
@@ -116,6 +134,8 @@ module OpenSSL
     end
 
     class Name
+      include Marshal
+
       module RFC2253DN
         Special = ',=+<>#;'
         HexChar = /[0-9a-fA-F]/
@@ -219,6 +239,8 @@ module OpenSSL
     end
 
     class Attribute
+      include Marshal
+
       def ==(other)
         return false unless Attribute === other
         to_der == other.to_der
@@ -232,6 +254,7 @@ module OpenSSL
     end
 
     class Certificate
+      include Marshal
       include Extension::SubjectKeyIdentifier
       include Extension::AuthorityKeyIdentifier
 
@@ -248,6 +271,7 @@ module OpenSSL
     end
 
     class CRL
+      include Marshal
       include Extension::AuthorityKeyIdentifier
 
       def ==(other)
@@ -264,6 +288,8 @@ module OpenSSL
     end
 
     class Request
+      include Marshal
+
       def ==(other)
         return false unless Request === other
         to_der == other.to_der

--- a/test/test_x509attr.rb
+++ b/test/test_x509attr.rb
@@ -79,6 +79,16 @@ class OpenSSL::TestX509Attribute < OpenSSL::TestCase
     assert_equal true, attr1 == attr2
     assert_equal false, attr1 == attr3
   end
+
+  def test_marshal
+    val = OpenSSL::ASN1::Set([
+      OpenSSL::ASN1::UTF8String("abc123")
+    ])
+    attr = OpenSSL::X509::Attribute.new("challengePassword", val)
+    deserialized = Marshal.load(Marshal.dump(attr))
+
+    assert_equal attr.to_der, deserialized.to_der
+  end
 end
 
 end

--- a/test/test_x509cert.rb
+++ b/test/test_x509cert.rb
@@ -196,6 +196,17 @@ class OpenSSL::TestX509Certificate < OpenSSL::TestCase
     assert_equal false, cert3 == cert4
   end
 
+  def test_marshal
+    now = Time.now
+    cacert = issue_cert(@ca, @rsa1024, 1, [], nil, nil,
+      not_before: now, not_after: now + 3600)
+    cert = issue_cert(@ee1, @rsa2048, 2, [], cacert, @rsa1024,
+      not_before: now, not_after: now + 3600)
+    deserialized = Marshal.load(Marshal.dump(cert))
+
+    assert_equal cert.to_der, deserialized.to_der
+  end
+
   private
 
   def certificate_error_returns_false

--- a/test/test_x509crl.rb
+++ b/test/test_x509crl.rb
@@ -256,6 +256,22 @@ class OpenSSL::TestX509CRL < OpenSSL::TestCase
     assert_equal true, rev2 == crl2.revoked[1]
   end
 
+  def test_marshal
+    now = Time.now
+
+    cacert = issue_cert(@ca, @rsa1024, 1, [], nil, nil)
+    crl = issue_crl([], 1, now, now + 3600, [], cacert, @rsa1024, "sha256")
+    rev = OpenSSL::X509::Revoked.new.tap { |rev|
+      rev.serial = 1
+      rev.time = now
+    }
+    crl.add_revoked(rev)
+    deserialized = Marshal.load(Marshal.dump(crl))
+
+    assert_equal crl.to_der, deserialized.to_der
+    assert_equal crl.revoked[0].to_der, deserialized.revoked[0].to_der
+  end
+
   private
 
   def crl_error_returns_false

--- a/test/test_x509ext.rb
+++ b/test/test_x509ext.rb
@@ -87,6 +87,14 @@ class OpenSSL::TestX509Extension < OpenSSL::TestCase
     assert_equal false, ext1 == ext3
   end
 
+  def test_marshal
+    ef = OpenSSL::X509::ExtensionFactory.new
+    ext = ef.create_extension("basicConstraints", "critical, CA:TRUE, pathlen:2")
+    deserialized = Marshal.load(Marshal.dump(ext))
+
+    assert_equal ext.to_der, deserialized.to_der
+  end
+
   def test_value_der
     ext = OpenSSL::X509::Extension.new(@basic_constraints.to_der)
     assert_equal @basic_constraints_value.to_der, ext.value_der

--- a/test/test_x509name.rb
+++ b/test/test_x509name.rb
@@ -453,6 +453,13 @@ class OpenSSL::TestX509Name < OpenSSL::TestCase
     assert_equal false, name0.eql?(name2)
   end
 
+  def test_marshal
+    name = OpenSSL::X509::Name.new([["DC", "org"], ["DC", "ruby-lang"], ["CN", "bar.ruby-lang.org"]])
+    deserialized = Marshal.load(Marshal.dump(name))
+
+    assert_equal name.to_der, deserialized.to_der
+  end
+
   def test_dup
     name = OpenSSL::X509::Name.parse("/CN=ruby-lang.org")
     assert_equal(name.to_der, name.dup.to_der)

--- a/test/test_x509req.rb
+++ b/test/test_x509req.rb
@@ -151,6 +151,13 @@ class OpenSSL::TestX509Request < OpenSSL::TestCase
     assert_equal false, req1 == req3
   end
 
+  def test_marshal
+    req = issue_csr(0, @dn, @rsa1024, "sha256")
+    deserialized = Marshal.load(Marshal.dump(req))
+
+    assert_equal req.to_der, deserialized.to_der
+  end
+
   private
 
   def request_error_returns_false


### PR DESCRIPTION
This allows for example to use Rails' cache to store these objects. Without this patch you'd get errors like `TypeError (no _dump_data is defined for class OpenSSL::X509::Certificate)`.

Note that the X509::Revoked class doesn't need the newly introduced modules as the DER output of X509::CRL already includes these.

https://ruby-doc.org/core-2.6.5/Marshal.html