### PR TITLE
Update to dist: xenial.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,9 @@
 language: c
 sudo: required
-group: edge
-dist: trusty
+dist: xenial
 services:
   - docker
-before_install:
-  - sudo apt-get -qq update
 install:
-  - sudo sh -c "curl -L https://github.com/docker/compose/releases/download/1.8.0/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose"
-  - sudo chmod +x /usr/local/bin/docker-compose
 script:
   - docker -v
   - docker-compose -v


### PR DESCRIPTION
This PR comes from https://github.com/ruby/openssl/pull/230#issuecomment-548602977 .

Let's see how it works.

* I choose xenial, because "ruby/ruby" `.travis.yml` is using it.
* docker-compose is pre-installed.
* We can remove "group: edge", as it is added at
  https://github.com/ruby/openssl/commit/7568c6e
