### PR TITLE
Raise ASN1::ASN1Error

### DIFF
--- a/History.md
+++ b/History.md
@@ -19,7 +19,8 @@ Version 2.2.0 (not yet released)
   responses.
 * Add helper methods for `OpenSSL::X509::{Certificate,CRL}`:
   `find_extension`, `subject_key_identifier`,
-  and `authority_key_identifier` (`Certificate` only).
+  `authority_key_identifier` (`Certificate` only) and `crl_uris`
+  (`Certificate` only).
 * Remove `OpenSSL::PKCS7::SignerInfo#name` alias for `#issuer`.
 * Add `OpenSSL::ECPoint#add` for adding points to an elliptic curve
   group.

--- a/lib/openssl/x509.rb
+++ b/lib/openssl/x509.rb
@@ -99,7 +99,7 @@ module OpenSSL
 
           ski_asn1 = ASN1.decode(ext.value_der)
           if ext.critical? || ski_asn1.tag_class != :UNIVERSAL || ski_asn1.tag != ASN1::OCTET_STRING
-            raise ASN1::ASN1Error "invalid extension"
+            raise ASN1::ASN1Error.new("invalid extension")
           end
 
           ski_asn1.value
@@ -121,7 +121,7 @@ module OpenSSL
 
           aki_asn1 = ASN1.decode(ext.value_der)
           if ext.critical? || aki_asn1.tag_class != :UNIVERSAL || aki_asn1.tag != ASN1::SEQUENCE
-            raise ASN1::ASN1Error "invalid extension"
+            raise ASN1::ASN1Error.new("invalid extension")
           end
 
           key_id = aki_asn1.value.find do |v|
@@ -146,7 +146,7 @@ module OpenSSL
 
           cdp_asn1 = ASN1.decode(ext.value_der)
           if cdp_asn1.tag_class != :UNIVERSAL || cdp_asn1.tag != ASN1::SEQUENCE
-            raise ASN1::ASN1Error "invalid extension"
+            raise ASN1::ASN1Error.new("invalid extension")
           end
 
           crl_uris = cdp_asn1.map do |crl_distribution_point|

--- a/lib/openssl/x509.rb
+++ b/lib/openssl/x509.rb
@@ -99,7 +99,7 @@ module OpenSSL
 
           ski_asn1 = ASN1.decode(ext.value_der)
           if ext.critical? || ski_asn1.tag_class != :UNIVERSAL || ski_asn1.tag != ASN1::OCTET_STRING
-            raise ASN1::ASN1Error.new("invalid extension")
+            raise ASN1::ASN1Error, "invalid extension"
           end
 
           ski_asn1.value
@@ -121,7 +121,7 @@ module OpenSSL
 
           aki_asn1 = ASN1.decode(ext.value_der)
           if ext.critical? || aki_asn1.tag_class != :UNIVERSAL || aki_asn1.tag != ASN1::SEQUENCE
-            raise ASN1::ASN1Error.new("invalid extension")
+            raise ASN1::ASN1Error, "invalid extension"
           end
 
           key_id = aki_asn1.value.find do |v|
@@ -146,7 +146,7 @@ module OpenSSL
 
           cdp_asn1 = ASN1.decode(ext.value_der)
           if cdp_asn1.tag_class != :UNIVERSAL || cdp_asn1.tag != ASN1::SEQUENCE
-            raise ASN1::ASN1Error.new("invalid extension")
+            raise ASN1::ASN1Error, "invalid extension"
           end
 
           crl_uris = cdp_asn1.map do |crl_distribution_point|

--- a/test/test_x509cert.rb
+++ b/test/test_x509cert.rb
@@ -117,6 +117,27 @@ class OpenSSL::TestX509Certificate < OpenSSL::TestCase
     no_exts_cert = issue_cert(@ca, @rsa2048, 1, [], nil, nil)
     assert_equal nil, no_exts_cert.authority_key_identifier
     assert_equal nil, no_exts_cert.subject_key_identifier
+    assert_equal nil, no_exts_cert.crl_uris
+  end
+
+  def test_invalid_extension
+    integer = OpenSSL::ASN1::Integer.new(0)
+    invalid_exts_cert = generate_cert(@ee1, @rsa1024, 1, nil)
+    ["subjectKeyIdentifier", "authorityKeyIdentifier", "crlDistributionPoints"].each do |ext|
+      invalid_exts_cert.add_extension(
+        OpenSSL::X509::Extension.new(ext, integer.to_der)
+      )
+    end
+
+    assert_raise(OpenSSL::ASN1::ASN1Error, "invalid extension") {
+      invalid_exts_cert.authority_key_identifier
+    }
+    assert_raise(OpenSSL::ASN1::ASN1Error, "invalid extension") {
+      invalid_exts_cert.subject_key_identifier
+    }
+    assert_raise(OpenSSL::ASN1::ASN1Error, "invalid extension") {
+      invalid_exts_cert.crl_uris
+    }
   end
 
   def test_sign_and_verify_rsa_sha1


### PR DESCRIPTION
Hi!

This PR is in order to raise the appropriate exception.
if certificate extension ASN1 format is not appropriate, not `NoMethodError` but `ASN1Error` is raised.