### PR TITLE
Helpers for accessing AIA extensions of certs

### DIFF
--- a/History.md
+++ b/History.md
@@ -17,10 +17,12 @@ Version 2.2.0 (not yet released)
   for last finished message sent and received.
 * Add `OpenSSL::Timestamp` module for handing timestamp requests and
   responses.
-* Add helper methods for `OpenSSL::X509::{Certificate,CRL}`:
+* Add helper methods for `OpenSSL::X509::Certificate`:
   `find_extension`, `subject_key_identifier`,
-  `authority_key_identifier` (`Certificate` only) and `crl_uris`
-  (`Certificate` only).
+  `authority_key_identifier`, `crl_uris`, `ca_issuer_uris` and
+  `ocsp_uris`.
+* Add helper methods for `OpenSSL::X509::CRL`:
+  `find_extension` and `subject_key_identifier`.
 * Remove `OpenSSL::PKCS7::SignerInfo#name` alias for `#issuer`.
 * Add `OpenSSL::ECPoint#add` for adding points to an elliptic curve
   group.

--- a/ext/openssl/ossl_ocsp.c
+++ b/ext/openssl/ossl_ocsp.c
@@ -1734,18 +1734,11 @@ Init_ossl_ocsp(void)
      * To submit the request to the CA for verification we need to extract the
      * OCSP URI from the subject certificate:
      *
-     *   authority_info_access = subject.extensions.find do |extension|
-     *     extension.oid == 'authorityInfoAccess'
-     *   end
-     *
-     *   descriptions = authority_info_access.value.split "\n"
-     *   ocsp = descriptions.find do |description|
-     *     description.start_with? 'OCSP'
-     *   end
+     *   ocsp_uris = subject.ocsp_uris
      *
      *   require 'uri'
      *
-     *   ocsp_uri = URI ocsp[/URI:(.*)/, 1]
+     *   ocsp_uri = URI ocsp_uris[0]
      *
      * To submit the request we'll POST the request to the OCSP URI (per RFC
      * 2560).  Note that we only handle HTTP requests and don't handle any

--- a/lib/openssl/x509.rb
+++ b/lib/openssl/x509.rb
@@ -168,6 +168,11 @@ module OpenSSL
       module AuthorityInfoAccess
         include Helpers
 
+        # Get the information and services for the issuer from the certificate's
+        # authority information access extension exteension, as described in RFC5280
+        # Section 4.2.2.1.
+        #
+        # Returns an array of strings or nil or raises ASN1::ASN1Error.
         def ca_issuer_uris
           aia_asn1 = parse_aia_asn1
           return nil if aia_asn1.nil?
@@ -183,6 +188,10 @@ module OpenSSL
           ca_issuer&.map(&:value)&.map(&:last)&.map(&:value)
         end
 
+        # Get the URIs for OCSP from the certificate's authority information access
+        # extension exteension, as described in RFC5280 Section 4.2.2.1.
+        #
+        # Returns an array of strings or nil or raises ASN1::ASN1Error.
         def ocsp_uris
           aia_asn1 = parse_aia_asn1
           return nil if aia_asn1.nil?

--- a/lib/openssl/x509.rb
+++ b/lib/openssl/x509.rb
@@ -177,10 +177,6 @@ module OpenSSL
           aia_asn1 = parse_aia_asn1
           return nil if aia_asn1.nil?
 
-          if aia_asn1.tag_class != :UNIVERSAL || aia_asn1.tag != ASN1::SEQUENCE
-            raise ASN1::ASN1Error, "invalid extension"
-          end
-
           ca_issuer = aia_asn1.value.select do |authority_info_access|
             authority_info_access.value.first.value == "caIssuers"
           end
@@ -210,7 +206,7 @@ module OpenSSL
             return nil if ext.nil?
 
             aia_asn1 = ASN1.decode(ext.value_der)
-            if aia_asn1.tag_class != :UNIVERSAL || aia_asn1.tag != ASN1::SEQUENCE
+            if ext.critical? || aia_asn1.tag_class != :UNIVERSAL || aia_asn1.tag != ASN1::SEQUENCE
               raise ASN1::ASN1Error, "invalid extension"
             end
 

--- a/lib/openssl/x509.rb
+++ b/lib/openssl/x509.rb
@@ -204,17 +204,18 @@ module OpenSSL
         end
 
         private
-        def parse_aia_asn1
-          ext = find_extension("authorityInfoAccess")
-          return nil if ext.nil?
 
-          aia_asn1 = ASN1.decode(ext.value_der)
-          if aia_asn1.tag_class != :UNIVERSAL || aia_asn1.tag != ASN1::SEQUENCE
-            raise ASN1::ASN1Error, "invalid extension"
+          def parse_aia_asn1
+            ext = find_extension("authorityInfoAccess")
+            return nil if ext.nil?
+
+            aia_asn1 = ASN1.decode(ext.value_der)
+            if aia_asn1.tag_class != :UNIVERSAL || aia_asn1.tag != ASN1::SEQUENCE
+              raise ASN1::ASN1Error, "invalid extension"
+            end
+
+            aia_asn1
           end
-
-          aia_asn1
-        end
       end
     end
 

--- a/test/test_x509cert.rb
+++ b/test/test_x509cert.rb
@@ -90,6 +90,7 @@ class OpenSSL::TestX509Certificate < OpenSSL::TestCase
       ["authorityKeyIdentifier","issuer:always,keyid:always",false],
       ["extendedKeyUsage","clientAuth, emailProtection, codeSigning",false],
       ["subjectAltName","email:ee1@ruby-lang.org",false],
+      ["authorityInfoAccess","caIssuers;URI:http://www.example.com/caIssuers,OCSP;URI:http://www.example.com/ocsp",false],
     ]
     ee1_cert = issue_cert(@ee1, @rsa1024, 2, ee1_exts, ca_cert, @rsa2048)
     assert_equal(ca_cert.subject.to_der, ee1_cert.issuer.to_der)
@@ -98,8 +99,6 @@ class OpenSSL::TestX509Certificate < OpenSSL::TestCase
       assert_equal(ee1_exts[i].last, ext.critical?)
     }
     assert_nil(ee1_cert.crl_uris)
-    assert_nil(ee1_cert.ca_issuer_uris)
-    assert_nil(ee1_cert.ocsp_uris)
 
     ef = OpenSSL::X509::ExtensionFactory.new
     ef.config = OpenSSL::Config.parse(<<~_cnf_)


### PR DESCRIPTION
Hi!

This PR is similar to #260 and #275.
It adds `ca_issuer_uris` and `ocsp_uris` instance methods to `OpenSSL::X509::Certificate`.