### PR TITLE
Export keys in PKCS8 format

### DIFF
--- a/History.md
+++ b/History.md
@@ -49,6 +49,9 @@ Version 2.2.0 (not yet released)
   [[GitHub #185]](https://github.com/ruby/openssl/pull/185)
 * Allow recipient's certificate to be omitted in PCKS7#decrypt.
   [[GitHub #183]](https://github.com/ruby/openssl/pull/183)
+* Add instance methods for exporting public and private keys in PKCS8 format
+  to `OpenSSL::PKey` classes: `private_to_der`, `private_to_pem`,
+  `public_to_der` and `public_to_pem`.
 
 Version 2.1.2
 =============

--- a/ext/openssl/ossl_pkey.c
+++ b/ext/openssl/ossl_pkey.c
@@ -167,21 +167,27 @@ ossl_pkey_new_from_data(int argc, VALUE *argv, VALUE self)
     pass = ossl_pem_passwd_value(pass);
 
     bio = ossl_obj2bio(&data);
-    if (!(pkey = d2i_PrivateKey_bio(bio, NULL))) {
-	OSSL_BIO_reset(bio);
-	if (!(pkey = PEM_read_bio_PrivateKey(bio, NULL, ossl_pem_passwd_cb, (void *)pass))) {
-	    OSSL_BIO_reset(bio);
-	    if (!(pkey = d2i_PUBKEY_bio(bio, NULL))) {
-		OSSL_BIO_reset(bio);
-		pkey = PEM_read_bio_PUBKEY(bio, NULL, ossl_pem_passwd_cb, (void *)pass);
-	    }
-	}
-    }
+    if ((pkey = d2i_PrivateKey_bio(bio, NULL)))
+	goto ok;
+    OSSL_BIO_reset(bio);
+    if ((pkey = d2i_PKCS8PrivateKey_bio(bio, NULL, ossl_pem_passwd_cb, (void *)pass)))
+	goto ok;
+    OSSL_BIO_reset(bio);
+    if ((pkey = d2i_PUBKEY_bio(bio, NULL)))
+	goto ok;
+    OSSL_BIO_reset(bio);
+    /* PEM_read_bio_PrivateKey() also parses PKCS #8 formats */
+    if ((pkey = PEM_read_bio_PrivateKey(bio, NULL, ossl_pem_passwd_cb, (void *)pass)))
+	goto ok;
+    OSSL_BIO_reset(bio);
+    if ((pkey = PEM_read_bio_PUBKEY(bio, NULL, NULL, NULL)))
+	goto ok;
 
     BIO_free(bio);
-    if (!pkey)
-	ossl_raise(ePKeyError, "Could not parse PKey");
+    ossl_raise(ePKeyError, "Could not parse PKey");
 
+ok:
+    BIO_free(bio);
     return ossl_pkey_new(pkey);
 }
 
@@ -291,6 +297,124 @@ ossl_pkey_initialize(VALUE self)
 	ossl_raise(rb_eTypeError, "OpenSSL::PKey::PKey can't be instantiated directly");
     }
     return self;
+}
+
+static VALUE
+do_pkcs8_export(int argc, VALUE *argv, VALUE self, int to_der)
+{
+    EVP_PKEY *pkey;
+    VALUE cipher, pass;
+    const EVP_CIPHER *enc = NULL;
+    BIO *bio;
+
+    GetPKey(self, pkey);
+    rb_scan_args(argc, argv, "02", &cipher, &pass);
+    if (argc > 0) {
+	/*
+	 * TODO: EncryptedPrivateKeyInfo actually has more options.
+	 * Should they be exposed?
+	 */
+	enc = ossl_evp_get_cipherbyname(cipher);
+	pass = ossl_pem_passwd_value(pass);
+    }
+
+    bio = BIO_new(BIO_s_mem());
+    if (!bio)
+	ossl_raise(ePKeyError, "BIO_new");
+    if (to_der) {
+	if (!i2d_PKCS8PrivateKey_bio(bio, pkey, enc, NULL, 0,
+				     ossl_pem_passwd_cb, (void *)pass)) {
+	    BIO_free(bio);
+	    ossl_raise(ePKeyError, "i2d_PKCS8PrivateKey_bio");
+	}
+    }
+    else {
+	if (!PEM_write_bio_PKCS8PrivateKey(bio, pkey, enc, NULL, 0,
+					   ossl_pem_passwd_cb, (void *)pass)) {
+	    BIO_free(bio);
+	    ossl_raise(ePKeyError, "PEM_write_bio_PKCS8PrivateKey");
+	}
+    }
+    return ossl_membio2str(bio);
+}
+
+/*
+ * call-seq:
+ *    pkey.private_to_der                   -> string
+ *    pkey.private_to_der(cipher, password) -> string
+ *
+ * Serializes the private key to DER-encoded PKCS #8 format. If called without
+ * arguments, unencrypted PKCS #8 PrivateKeyInfo format is used. If called with
+ * a cipher name and a password, PKCS #8 EncryptedPrivateKeyInfo format with
+ * PBES2 encryption scheme is used.
+ */
+static VALUE
+ossl_pkey_private_to_der(int argc, VALUE *argv, VALUE self)
+{
+    return do_pkcs8_export(argc, argv, self, 1);
+}
+
+/*
+ * call-seq:
+ *    pkey.private_to_pem                   -> string
+ *    pkey.private_to_pem(cipher, password) -> string
+ *
+ * Serializes the private key to PEM-encoded PKCS #8 format. See #private_to_der
+ * for more details.
+ */
+static VALUE
+ossl_pkey_private_to_pem(int argc, VALUE *argv, VALUE self)
+{
+    return do_pkcs8_export(argc, argv, self, 0);
+}
+
+static VALUE
+do_spki_export(VALUE self, int to_der)
+{
+    EVP_PKEY *pkey;
+    BIO *bio;
+
+    GetPKey(self, pkey);
+    bio = BIO_new(BIO_s_mem());
+    if (!bio)
+	ossl_raise(ePKeyError, "BIO_new");
+    if (to_der) {
+	if (!i2d_PUBKEY_bio(bio, pkey)) {
+	    BIO_free(bio);
+	    ossl_raise(ePKeyError, "i2d_PUBKEY_bio");
+	}
+    }
+    else {
+	if (!PEM_write_bio_PUBKEY(bio, pkey)) {
+	    BIO_free(bio);
+	    ossl_raise(ePKeyError, "PEM_write_bio_PUBKEY");
+	}
+    }
+    return ossl_membio2str(bio);
+}
+
+/*
+ * call-seq:
+ *    pkey.public_to_der -> string
+ *
+ * Serializes the public key to DER-encoded X.509 SubjectPublicKeyInfo format.
+ */
+static VALUE
+ossl_pkey_public_to_der(VALUE self)
+{
+    return do_spki_export(self, 1);
+}
+
+/*
+ * call-seq:
+ *    pkey.public_to_pem -> string
+ *
+ * Serializes the public key to PEM-encoded X.509 SubjectPublicKeyInfo format.
+ */
+static VALUE
+ossl_pkey_public_to_pem(VALUE self)
+{
+    return do_spki_export(self, 0);
 }
 
 /*
@@ -491,6 +615,10 @@ Init_ossl_pkey(void)
 
     rb_define_alloc_func(cPKey, ossl_pkey_alloc);
     rb_define_method(cPKey, "initialize", ossl_pkey_initialize, 0);
+    rb_define_method(cPKey, "private_to_der", ossl_pkey_private_to_der, -1);
+    rb_define_method(cPKey, "private_to_pem", ossl_pkey_private_to_pem, -1);
+    rb_define_method(cPKey, "public_to_der", ossl_pkey_public_to_der, 0);
+    rb_define_method(cPKey, "public_to_pem", ossl_pkey_public_to_pem, 0);
 
     rb_define_method(cPKey, "sign", ossl_pkey_sign, 2);
     rb_define_method(cPKey, "verify", ossl_pkey_verify, 3);


### PR DESCRIPTION
Closes https://github.com/ruby/openssl/issues/294 by cherry-picking from https://github.com/ruby/openssl/pull/119 

The only line that needed changing to make it work on latest master was https://github.com/ruby/openssl/pull/119/files#diff-bae6e18b74ab1f890ac3e06a1aae16a2R614 to use `ossl_evp_get_cipherbyname ` as this was renamed in https://github.com/ruby/openssl/commit/679b6f490671439d1bc50ef4371d9fb3bbba0e29