### PR TITLE
Clarify in history that PKCS8 reading is also supported

### DIFF
--- a/History.md
+++ b/History.md
@@ -49,8 +49,8 @@ Version 2.2.0 (not yet released)
   [[GitHub #185]](https://github.com/ruby/openssl/pull/185)
 * Allow recipient's certificate to be omitted in PCKS7#decrypt.
   [[GitHub #183]](https://github.com/ruby/openssl/pull/183)
-* Add instance methods for exporting public and private keys in PKCS8 format
-  to `OpenSSL::PKey` classes: `private_to_der`, `private_to_pem`,
+* Add support for reading keys in PKCS8 format and export via instance methods
+  added to `OpenSSL::PKey` classes: `private_to_der`, `private_to_pem`,
   `public_to_der` and `public_to_pem`.
 
 Version 2.1.2


### PR DESCRIPTION
Wasn't entirely clear from https://github.com/ruby/openssl/pull/297 but it's noted here: https://github.com/ruby/openssl/pull/297/files#diff-bae6e18b74ab1f890ac3e06a1aae16a2R179-R181

and tested here: https://github.com/ruby/openssl/pull/297/files#diff-9837c7521b804179c365ed1071604f70R410-R429