### PR TITLE
modify `CertificateId.new` doc

### DIFF
--- a/ext/openssl/ossl_ocsp.c
+++ b/ext/openssl/ossl_ocsp.c
@@ -1489,13 +1489,15 @@ ossl_ocspcid_initialize_copy(VALUE self, VALUE other)
  * call-seq:
  *   OpenSSL::OCSP::CertificateId.new(subject, issuer, digest = nil) -> certificate_id
  *   OpenSSL::OCSP::CertificateId.new(der_string)                    -> certificate_id
+ *   OpenSSL::OCSP::CertificateId.new(obj)                           -> certificate_id
  *
  * Creates a new OpenSSL::OCSP::CertificateId for the given _subject_ and
  * _issuer_ X509 certificates.  The _digest_ is a digest algorithm that is used
  * to compute the hash values. This defaults to SHA-1.
  *
  * If only one argument is given, decodes it as DER representation of a
- * certificate ID.
+ * certificate ID or generates certificate ID from the object that responds to
+ * the to_der method.
  */
 static VALUE
 ossl_ocspcid_initialize(int argc, VALUE *argv, VALUE self)

--- a/test/test_ocsp.rb
+++ b/test/test_ocsp.rb
@@ -84,6 +84,7 @@ class OpenSSL::TestOCSP < OpenSSL::TestCase
     assert_equal [cid.issuer_key_hash].pack("H*"), asn1.value[2].value
     assert_equal @cert.serial, asn1.value[3].value
     assert_equal der, OpenSSL::OCSP::CertificateId.new(der).to_der
+    assert_equal der, OpenSSL::OCSP::CertificateId.new(asn1).to_der
   end
 
   def test_certificate_id_dup


### PR DESCRIPTION
Hi!

This PR modifies the document about `CertificateId.new`.

When `CertificateId.new` is received only one argument,
`CertificateId.new` calls [ossl_to_der_if_possible](https://github.com/ruby/openssl/blob/6322ccbbf5671acc4cb1036f90b64e05e5ed3d28/ext/openssl/ossl_ocsp.c#L1511).
So, if it is the object that responds to the to_der method, it'll be okay.
For example, it is `OpenSSL::ASN1::ASN1Data` object.

This modifies
- the document about `CertificateId.new`
- the test about `CertificateId.new` by adding an assertion