### PR TITLE
Prepend slashes to X509::Name.parse argument in examples

### DIFF
--- a/ext/openssl/ossl.c
+++ b/ext/openssl/ossl.c
@@ -862,7 +862,7 @@ ossl_crypto_fixed_length_secure_compare(VALUE dummy, VALUE str1, VALUE str2)
  * signature.
  *
  *   key = OpenSSL::PKey::RSA.new 2048
- *   name = OpenSSL::X509::Name.parse 'CN=nobody/DC=example'
+ *   name = OpenSSL::X509::Name.parse '/CN=nobody/DC=example'
  *
  *   cert = OpenSSL::X509::Certificate.new
  *   cert.version = 2
@@ -944,7 +944,7 @@ ossl_crypto_fixed_length_secure_compare(VALUE dummy, VALUE str1, VALUE str2)
  * A CA certificate is created the same way we created a certificate above, but
  * with different extensions.
  *
- *   ca_name = OpenSSL::X509::Name.parse 'CN=ca/DC=example'
+ *   ca_name = OpenSSL::X509::Name.parse '/CN=ca/DC=example'
  *
  *   ca_cert = OpenSSL::X509::Certificate.new
  *   ca_cert.serial = 0

--- a/ext/openssl/ossl_x509name.c
+++ b/ext/openssl/ossl_x509name.c
@@ -498,7 +498,7 @@ ossl_x509name_to_der(VALUE self)
  * You can create a Name by parsing a distinguished name String or by
  * supplying the distinguished name as an Array.
  *
- *   name = OpenSSL::X509::Name.parse 'CN=nobody/DC=example'
+ *   name = OpenSSL::X509::Name.parse '/CN=nobody/DC=example'
  *
  *   name = OpenSSL::X509::Name.new [['CN', 'nobody'], ['DC', 'example']]
  */


### PR DESCRIPTION
Addresses [issue 15882](https://bugs.ruby-lang.org/issues/15882) with [Zach Rowe's patch.](https://bugs.ruby-lang.org/attachments/7810)

The `#parse_openssl` method [expects a forward slash at the beginning of the argument](https://github.com/ruby/openssl/blob/master/lib/openssl/x509.rb#L302) if used as the delimiter.

```ruby
# With the slash
OpenSSL::X509::Name.parse_openssl('/CN=nobody/DC=example').to_a
# =>[["CN","nobody",12],["DC","example",22]]

# Without the slash
OpenSSL::X509::Name.parse_openssl('CN=nobody/DC=example').to_a
# =>[["CN","nobody/DC=example",12]]
```
