### PR TITLE
Modify `SSLContext#add_certificate_chain_file`

### DIFF
--- a/ext/openssl/ossl_ssl.c
+++ b/ext/openssl/ossl_ssl.c
@@ -1337,9 +1337,9 @@ ossl_sslctx_add_certificate(int argc, VALUE *argv, VALUE self)
  *   A path to a private key file. An instance of String.
  *
  * === Example
- *   ctx.add_certificate_chain(rsa_and_intermediate_certs_path, rsa_key_path)
+ *   ctx.add_certificate_chain_file(rsa_and_intermediate_certs_path, rsa_key_path)
  *
- *   ctx.add_certificate_chain(ecdsa_and_intermediate_certs_path, ecdsa_key_path)
+ *   ctx.add_certificate_chain_file(ecdsa_and_intermediate_certs_path, ecdsa_key_path)
  *
  * === Note
  * The file format of the certificate and private key must be PEM.

--- a/ext/openssl/ossl_ssl.c
+++ b/ext/openssl/ossl_ssl.c
@@ -1354,14 +1354,45 @@ static VALUE
 ossl_sslctx_add_certificate_chain_file(VALUE self, VALUE certs_path, VALUE pkey_path)
 {
     SSL_CTX *ctx;
+    X509 *x509;
+    char *ccerts_path, *cpkey_path;
+    FILE *fp;
+    EVP_PKEY *pkey, *pub_pkey;
 
     GetSSLCTX(self, ctx);
 
+    /* Retrieve private key */
+    cpkey_path = StringValueCStr(pkey_path);
+    fp = fopen(cpkey_path, "r");
+    if (!fp)
+        rb_raise(rb_eArgError, "failed to open pkey file");
+    pkey = PEM_read_PrivateKey(fp, NULL, 0, NULL);
+    fclose(fp);
+    if (!pkey)
+        rb_raise(rb_eArgError, "failed to open pkey file");
+    /* Retrieve public key */
+    ccerts_path = StringValueCStr(certs_path);
+    fp = fopen(ccerts_path, "r");
+    if (!fp)
+        rb_raise(rb_eArgError, "failed to open certs file");
+    x509 = PEM_read_X509(fp, NULL, 0, NULL);
+    fclose(fp);
+    if (!x509)
+        rb_raise(rb_eArgError, "failed to open certs file");
+    pub_pkey = X509_get_pubkey(x509);
+    /* The reference counter is bumped, and decremented immediately. */
+    EVP_PKEY_free(pub_pkey);
+    if (!pub_pkey)
+        rb_raise(rb_eArgError, "certificate does not contain public key");
+
+    if (EVP_PKEY_cmp(pub_pkey, pkey) != 1)
+        rb_raise(rb_eArgError, "public key mismatch");
+
     /* SSL_CTX_use_certificate_chain_file() loads PEM format file. */
-    if (SSL_CTX_use_certificate_chain_file(ctx, StringValueCStr(certs_path)) != 1)
+    if (SSL_CTX_use_certificate_chain_file(ctx, ccerts_path) != 1)
         ossl_raise(eSSLError, "SSL_CTX_use_certificate_chain_file");
 
-    if (SSL_CTX_use_PrivateKey_file(ctx, StringValueCStr(pkey_path), SSL_FILETYPE_PEM) != 1)
+    if (SSL_CTX_use_PrivateKey_file(ctx, cpkey_path, SSL_FILETYPE_PEM) != 1)
         ossl_raise(eSSLError, "SSL_CTX_use_PrivateKey_file");
 
     return self;

--- a/ext/openssl/ossl_ssl.c
+++ b/ext/openssl/ossl_ssl.c
@@ -1337,9 +1337,9 @@ ossl_sslctx_add_certificate(int argc, VALUE *argv, VALUE self)
  *   A path to a private key file. An instance of String.
  *
  * === Example
- *   ctx.add_certificate_chain(rsa_cert_path, rsa_key_path)
+ *   ctx.add_certificate_chain(rsa_and_intermediate_certs_path, rsa_key_path)
  *
- *   ctx.add_certificate_chain(ecdsa_cert_path, ecdsa_key_path)
+ *   ctx.add_certificate_chain(ecdsa_and_intermediate_certs_path, ecdsa_key_path)
  *
  * === Note
  * The file format of the certificate and private key must be PEM.

--- a/ext/openssl/ossl_ssl.c
+++ b/ext/openssl/ossl_ssl.c
@@ -1326,17 +1326,18 @@ ossl_sslctx_add_certificate(int argc, VALUE *argv, VALUE self)
  * call-seq:
  *    ctx.add_certificate_chain_file(certs_path, pkey_path) -> true | false
  *
- * Loads (chain) certificate(s) from _certs_path_ and private key from
+ * Loads chain certificates from _certs_path_ and a private key from
  * _pkey_path_.
  *
  * === Parameters
  * _certs_path_::
- *   A path to a (chain) certificate(s) file. A instance of String.
+ *   A path to a chain certificates file. It may be a single certificate.
+ *   An instance of String.
  * _pkey_path_::
- *   A path to a private key file. A instance of String.
+ *   A path to a private key file. An instance of String.
  *
  * === Note
- * The file format of certificate and private key must be PEM.
+ * The file format of the certificate and private key must be PEM.
  *
  * The certificate file must be starting with the subject's certificate and
  * followed by intermediate CA certificates (and root CA certificate).

--- a/ext/openssl/ossl_ssl.c
+++ b/ext/openssl/ossl_ssl.c
@@ -1324,7 +1324,7 @@ ossl_sslctx_add_certificate(int argc, VALUE *argv, VALUE self)
 
 /*
  * call-seq:
- *    ctx.add_certificate_chain_file(certs_path, pkey_path) -> true | false
+ *    ctx.add_certificate_chain_file(certs_path, pkey_path) -> self
  *
  * Loads chain certificates from _certs_path_ and a private key from
  * _pkey_path_.
@@ -1336,11 +1336,19 @@ ossl_sslctx_add_certificate(int argc, VALUE *argv, VALUE self)
  * _pkey_path_::
  *   A path to a private key file. An instance of String.
  *
+ * === Example
+ *   ctx.add_certificate_chain(rsa_cert_path, rsa_key_path)
+ *
+ *   ctx.add_certificate_chain(ecdsa_cert_path, ecdsa_key_path)
+ *
  * === Note
  * The file format of the certificate and private key must be PEM.
  *
  * The certificate file must be starting with the subject's certificate and
- * followed by intermediate CA certificates (and root CA certificate).
+ * followed by intermediate CA certificate(s).
+ *
+ * OpenSSL before the version 1.0.2 could handle only one extra chain across
+ * all key types. Calling this method discards the chain set previously.
  */
 static VALUE
 ossl_sslctx_add_certificate_chain_file(VALUE self, VALUE certs_path, VALUE pkey_path)
@@ -1348,20 +1356,15 @@ ossl_sslctx_add_certificate_chain_file(VALUE self, VALUE certs_path, VALUE pkey_
     SSL_CTX *ctx;
 
     GetSSLCTX(self, ctx);
-    if (NIL_P(certs_path))
-        ossl_raise(rb_eArgError, "certs_path must be the path to certificates");
-
-    if (NIL_P(pkey_path))
-        ossl_raise(rb_eArgError, "pkey_path must be the path to private key");
 
     /* SSL_CTX_use_certificate_chain_file() loads PEM format file. */
     if (SSL_CTX_use_certificate_chain_file(ctx, StringValueCStr(certs_path)) != 1)
-        return Qfalse;
+        ossl_raise(eSSLError, "SSL_CTX_use_certificate_chain_file");
 
     if (SSL_CTX_use_PrivateKey_file(ctx, StringValueCStr(pkey_path), SSL_FILETYPE_PEM) != 1)
-        return Qfalse;
+        ossl_raise(eSSLError, "SSL_CTX_use_PrivateKey_file");
 
-    return Qtrue;
+    return self;
 }
 
 /*

--- a/test/test_ssl.rb
+++ b/test/test_ssl.rb
@@ -187,7 +187,6 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
 
   def test_add_certificate_chain_file
     # Create chain certificates file
-    GC.disable # for tempfile
     certs = Tempfile.open { |f| f << @svr_cert.to_pem << @ca_cert.to_pem; f }
     pkey = Tempfile.open { |f| f << @svr_key.to_pem; f }
 
@@ -209,6 +208,8 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
   ensure
     certs&.close
     pkey&.close
+    certs&.unlink
+    pkey&.unlink
   end
 
   def test_add_certificate_chain_file_multiple_certs
@@ -239,7 +240,6 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
     ecdsa_cert = issue_cert(ecdsa_dn, ecdsa_key, 456, exts, ca2_cert, ca2_key)
 
     # Create chain certificates file
-    GC.disable # for tempfile
     certs1 = Tempfile.open { |f| f << @svr_cert.to_pem << @ca_cert.to_pem; f }
     pkey1 = Tempfile.open { |f| f << @svr_key.to_pem; f }
     certs2 = Tempfile.open { |f| f << ecdsa_cert.to_pem << ca2_cert.to_pem; f }
@@ -281,8 +281,12 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
   ensure
     certs1&.close
     pkey1&.close
+    certs1&.unlink
+    pkey1&.unlink
     certs2&.close
     pkey2&.close
+    certs2&.unlink
+    pkey2&.unlink
   end
 
   def test_sysread_and_syswrite

--- a/test/test_ssl.rb
+++ b/test/test_ssl.rb
@@ -186,8 +186,29 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
   end
 
   def test_add_certificate_chain_file
-    ctx = OpenSSL::SSL::SSLContext.new
-    assert ctx.add_certificate_chain_file(Fixtures.file_path("chain", "server.crt"))
+    # Create chain certificates file
+    GC.disable # for tempfile
+    certs = Tempfile.open { |f| f << @svr_cert.to_pem << @ca_cert.to_pem; f }
+    pkey = Tempfile.open { |f| f << @svr_key.to_pem; f }
+
+    ctx_proc = -> ctx {
+      # Unset values set by start_server
+      ctx.cert = ctx.key = ctx.extra_chain_cert = nil
+      assert ctx.add_certificate_chain_file(certs.path, pkey.path)
+    }
+
+    start_server(ctx_proc: ctx_proc) { |port|
+      server_connect(port) { |ssl|
+        assert_equal @svr_cert.subject, ssl.peer_cert.subject
+        assert_equal [@svr_cert.subject, @ca_cert.subject],
+          ssl.peer_cert_chain.map(&:subject)
+
+        ssl.puts "abc"; assert_equal "abc\n", ssl.gets
+      }
+    }
+  ensure
+    certs&.close
+    pkey&.close
   end
 
   def test_sysread_and_syswrite

--- a/test/test_ssl.rb
+++ b/test/test_ssl.rb
@@ -194,7 +194,7 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
     ctx_proc = -> ctx {
       # Unset values set by start_server
       ctx.cert = ctx.key = ctx.extra_chain_cert = nil
-      assert ctx.add_certificate_chain_file(certs.path, pkey.path)
+      assert_nothing_raised { ctx.add_certificate_chain_file(certs.path, pkey.path) }
     }
 
     start_server(ctx_proc: ctx_proc) { |port|
@@ -209,6 +209,80 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
   ensure
     certs&.close
     pkey&.close
+  end
+
+  def test_add_certificate_chain_file_multiple_certs
+    pend "EC is not supported" unless defined?(OpenSSL::PKey::EC)
+    pend "TLS 1.2 is not supported" unless tls12_supported?
+
+    # SSL_CTX_set0_chain() is needed for setting multiple certificate chains
+    add0_chain_supported = openssl?(1, 0, 2)
+
+    if add0_chain_supported
+      ca2_key = Fixtures.pkey("rsa2048")
+      ca2_exts = [
+        ["basicConstraints", "CA:TRUE", true],
+        ["keyUsage", "cRLSign, keyCertSign", true],
+      ]
+      ca2_dn = OpenSSL::X509::Name.parse_rfc2253("CN=CA2")
+      ca2_cert = issue_cert(ca2_dn, ca2_key, 123, ca2_exts, nil, nil)
+    else
+      # Use the same CA as @svr_cert
+      ca2_key = @ca_key; ca2_cert = @ca_cert
+    end
+
+    ecdsa_key = Fixtures.pkey("p256")
+    exts = [
+      ["keyUsage", "digitalSignature", false],
+    ]
+    ecdsa_dn = OpenSSL::X509::Name.parse_rfc2253("CN=localhost2")
+    ecdsa_cert = issue_cert(ecdsa_dn, ecdsa_key, 456, exts, ca2_cert, ca2_key)
+
+    # Create chain certificates file
+    GC.disable # for tempfile
+    certs1 = Tempfile.open { |f| f << @svr_cert.to_pem << @ca_cert.to_pem; f }
+    pkey1 = Tempfile.open { |f| f << @svr_key.to_pem; f }
+    certs2 = Tempfile.open { |f| f << ecdsa_cert.to_pem << ca2_cert.to_pem; f }
+    pkey2 = Tempfile.open { |f| f << ecdsa_key.to_pem; f }
+
+    ctx_proc = -> ctx {
+      # Unset values set by start_server
+      ctx.cert = ctx.key = ctx.extra_chain_cert = nil
+      ctx.ecdh_curves = "P-256" unless openssl?(1, 0, 2)
+      assert_nothing_raised {
+        ctx.add_certificate_chain_file(certs1.path, pkey1.path) # RSA
+        ctx.add_certificate_chain_file(certs2.path, pkey2.path) # ECDSA
+      }
+    }
+
+    start_server(ctx_proc: ctx_proc) do |port|
+      ctx = OpenSSL::SSL::SSLContext.new
+      ctx.max_version = :TLS1_2
+      ctx.ciphers = "aRSA"
+      server_connect(port, ctx) { |ssl|
+        assert_equal @svr_cert.subject, ssl.peer_cert.subject
+        assert_equal [@svr_cert.subject, @ca_cert.subject],
+          ssl.peer_cert_chain.map(&:subject)
+
+        ssl.puts "abc"; assert_equal "abc\n", ssl.gets
+      }
+
+      ctx = OpenSSL::SSL::SSLContext.new
+      ctx.max_version = :TLS1_2
+      ctx.ciphers = "aECDSA"
+      server_connect(port, ctx) { |ssl|
+        assert_equal ecdsa_cert.subject, ssl.peer_cert.subject
+        assert_equal [ecdsa_cert.subject, ca2_cert.subject],
+          ssl.peer_cert_chain.map(&:subject)
+
+        ssl.puts "123"; assert_equal "123\n", ssl.gets
+      }
+    end
+  ensure
+    certs1&.close
+    pkey1&.close
+    certs2&.close
+    pkey2&.close
   end
 
   def test_sysread_and_syswrite


### PR DESCRIPTION
Hi!

This PR is related to #305.

This modifies `OpenSSL::SSL::SSLContext#add_certificate_chain_file` to accept the path to the private key.

This PR
- modifies `add_certificate_chain_file`
- adds the doc for `add_certificate_chain_file` 
- modifies testcase about `add_certificate_chain_file` 

This PR referenced `SSLContext#add_certificate`.