### PR TITLE
Fix typo of `OpenSSL::OCSP` extern var

### DIFF
--- a/ext/openssl/ossl_ocsp.h
+++ b/ext/openssl/ossl_ocsp.h
@@ -13,9 +13,9 @@
 
 #if !defined(OPENSSL_NO_OCSP)
 extern VALUE mOCSP;
-extern VALUE cOPCSReq;
-extern VALUE cOPCSRes;
-extern VALUE cOPCSBasicRes;
+extern VALUE cOCSPReq;
+extern VALUE cOCSPRes;
+extern VALUE cOCSPBasicRes;
 #endif
 
 void Init_ossl_ocsp(void);


### PR DESCRIPTION
This PR fixes small typos.