### PR TITLE
Prefer `frozen_string_literal: true`.

### DIFF
--- a/ext/openssl/deprecation.rb
+++ b/ext/openssl/deprecation.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 module OpenSSL
   def self.deprecated_warning_flag
     unless flag = (@deprecated_warning_flag ||= nil)

--- a/ext/openssl/extconf.rb
+++ b/ext/openssl/extconf.rb
@@ -1,5 +1,5 @@
 # -*- coding: us-ascii -*-
-# frozen_string_literal: false
+# frozen_string_literal: true
 =begin
 = Info
   'OpenSSL for Ruby 2' project

--- a/lib/openssl.rb
+++ b/lib/openssl.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 =begin
 = Info
   'OpenSSL for Ruby 2' project

--- a/lib/openssl/bn.rb
+++ b/lib/openssl/bn.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 #--
 #
 # = Ruby-space definitions that completes C-space funcs for BN

--- a/lib/openssl/buffering.rb
+++ b/lib/openssl/buffering.rb
@@ -22,6 +22,29 @@
 module OpenSSL::Buffering
   include Enumerable
 
+  # A buffer which will retain binary encoding.
+  class Buffer < String
+    BINARY = Encoding::BINARY
+
+    def initialize
+      super
+
+      force_encoding(BINARY)
+    end
+    
+    def << string
+      if string.encoding == BINARY
+        super(string)
+      else
+        super(string.b)
+      end
+
+      return self
+    end
+
+    alias concat <<
+  end
+
   ##
   # The "sync mode" of the SSLSocket.
   #
@@ -40,7 +63,7 @@ module OpenSSL::Buffering
   def initialize(*)
     super
     @eof = false
-    @rbuffer = String.new
+    @rbuffer = Buffer.new
     @sync = @io.sync
   end
 
@@ -312,7 +335,7 @@ module OpenSSL::Buffering
   # buffer is flushed to the underlying socket.
 
   def do_write(s)
-    @wbuffer = String.new unless defined? @wbuffer
+    @wbuffer = Buffer.new unless defined? @wbuffer
     @wbuffer << s
     @wbuffer.force_encoding(Encoding::BINARY)
     @sync ||= false
@@ -398,7 +421,7 @@ module OpenSSL::Buffering
   # See IO#puts for full details.
 
   def puts(*args)
-    s = String.new
+    s = Buffer.new
     if args.empty?
       s << "\n"
     end
@@ -416,7 +439,7 @@ module OpenSSL::Buffering
   # See IO#print for full details.
 
   def print(*args)
-    s = String.new
+    s = Buffer.new
     args.each{ |arg| s << arg.to_s }
     do_write(s)
     nil

--- a/lib/openssl/buffering.rb
+++ b/lib/openssl/buffering.rb
@@ -1,5 +1,5 @@
 # coding: binary
-# frozen_string_literal: false
+# frozen_string_literal: true
 #--
 #= Info
 #  'OpenSSL for Ruby 2' project
@@ -40,7 +40,7 @@ module OpenSSL::Buffering
   def initialize(*)
     super
     @eof = false
-    @rbuffer = ""
+    @rbuffer = String.new
     @sync = @io.sync
   end
 
@@ -312,7 +312,7 @@ module OpenSSL::Buffering
   # buffer is flushed to the underlying socket.
 
   def do_write(s)
-    @wbuffer = "" unless defined? @wbuffer
+    @wbuffer = String.new unless defined? @wbuffer
     @wbuffer << s
     @wbuffer.force_encoding(Encoding::BINARY)
     @sync ||= false
@@ -398,7 +398,7 @@ module OpenSSL::Buffering
   # See IO#puts for full details.
 
   def puts(*args)
-    s = ""
+    s = String.new
     if args.empty?
       s << "\n"
     end
@@ -416,7 +416,7 @@ module OpenSSL::Buffering
   # See IO#print for full details.
 
   def print(*args)
-    s = ""
+    s = String.new
     args.each{ |arg| s << arg.to_s }
     do_write(s)
     nil

--- a/lib/openssl/cipher.rb
+++ b/lib/openssl/cipher.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 #--
 # = Ruby-space predefined Cipher subclasses
 #

--- a/lib/openssl/config.rb
+++ b/lib/openssl/config.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 =begin
 = Ruby-space definitions that completes C-space funcs for Config
 
@@ -53,9 +53,8 @@ module OpenSSL
       def parse_config(io)
         begin
           parse_config_lines(io)
-        rescue ConfigError => e
-          e.message.replace("error in line #{io.lineno}: " + e.message)
-          raise
+        rescue => error
+          raise ConfigError, "error in line #{io.lineno}: " + error.message
         end
       end
 

--- a/lib/openssl/digest.rb
+++ b/lib/openssl/digest.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 #--
 # = Ruby-space predefined Digest subclasses
 #

--- a/lib/openssl/pkcs5.rb
+++ b/lib/openssl/pkcs5.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 #--
 # Ruby/OpenSSL Project
 # Copyright (C) 2017 Ruby/OpenSSL Project Authors

--- a/lib/openssl/pkey.rb
+++ b/lib/openssl/pkey.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 #--
 # Ruby/OpenSSL Project
 # Copyright (C) 2017 Ruby/OpenSSL Project Authors

--- a/lib/openssl/ssl.rb
+++ b/lib/openssl/ssl.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 =begin
 = Info
   'OpenSSL for Ruby 2' project

--- a/lib/openssl/x509.rb
+++ b/lib/openssl/x509.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 #--
 # = Ruby-space definitions that completes C-space funcs for X509 and subclasses
 #

--- a/test/test_asn1.rb
+++ b/test/test_asn1.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require_relative 'utils'
 
 if defined?(OpenSSL)
@@ -167,7 +167,7 @@ class  OpenSSL::TestASN1 < OpenSSL::TestCase
     assert_equal(OpenSSL::ASN1::OctetString, ext.value[2].class)
     extv = OpenSSL::ASN1.decode(ext.value[2].value)
     assert_equal(OpenSSL::ASN1::BitString, extv.class)
-    str = "\000"; str[0] = 0b00000110.chr
+    str = +"\000"; str[0] = 0b00000110.chr
     assert_equal(str, extv.value)
 
     ext = extensions.value[0].value[2]  # subjetKeyIdentifier

--- a/test/test_bn.rb
+++ b/test/test_bn.rb
@@ -1,5 +1,5 @@
 # coding: us-ascii
-# frozen_string_literal: false
+# frozen_string_literal: true
 require_relative 'utils'
 require "prime"
 

--- a/test/test_buffering.rb
+++ b/test/test_buffering.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require_relative 'utils'
 
 if defined?(OpenSSL)
@@ -10,7 +10,7 @@ class OpenSSL::TestBuffering < OpenSSL::TestCase
     attr_accessor :sync
 
     def initialize
-      @io = ""
+      @io = String.new
       def @io.sync
         true
       end

--- a/test/test_buffering.rb
+++ b/test/test_buffering.rb
@@ -10,7 +10,7 @@ class OpenSSL::TestBuffering < OpenSSL::TestCase
     attr_accessor :sync
 
     def initialize
-      @io = String.new
+      @io = Buffer.new
       def @io.sync
         true
       end
@@ -39,6 +39,13 @@ class OpenSSL::TestBuffering < OpenSSL::TestCase
   def setup
     super
     @io = IO.new
+  end
+
+  def test_encoding
+    @io.write '😊'
+    @io.flush
+
+    assert_equal @io.string.encoding, Encoding::BINARY
   end
 
   def test_flush

--- a/test/test_cipher.rb
+++ b/test/test_cipher.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require_relative 'utils'
 
 if defined?(OpenSSL)

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require_relative 'utils'
 
 if defined?(OpenSSL)

--- a/test/test_digest.rb
+++ b/test/test_digest.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require_relative 'utils'
 
 if defined?(OpenSSL)

--- a/test/test_engine.rb
+++ b/test/test_engine.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require_relative 'utils'
 
 if defined?(OpenSSL) && defined?(OpenSSL::Engine)

--- a/test/test_fips.rb
+++ b/test/test_fips.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require_relative 'utils'
 
 if defined?(OpenSSL)

--- a/test/test_hmac.rb
+++ b/test/test_hmac.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require_relative 'utils'
 
 if defined?(OpenSSL)

--- a/test/test_kdf.rb
+++ b/test/test_kdf.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require_relative 'utils'
 
 if defined?(OpenSSL)

--- a/test/test_ns_spki.rb
+++ b/test/test_ns_spki.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require_relative 'utils'
 
 if defined?(OpenSSL)
@@ -9,7 +9,7 @@ class OpenSSL::TestNSSPI < OpenSSL::TestCase
     # This request data is adopt from the specification of
     # "Netscape Extensions for User Key Generation".
     # -- http://wp.netscape.com/eng/security/comm4-keygen.html
-    @b64  = "MIHFMHEwXDANBgkqhkiG9w0BAQEFAANLADBIAkEAnX0TILJrOMUue+PtwBRE6XfV"
+    @b64 = +"MIHFMHEwXDANBgkqhkiG9w0BAQEFAANLADBIAkEAnX0TILJrOMUue+PtwBRE6XfV"
     @b64 << "WtKQbsshxk5ZhcUwcwyvcnIq9b82QhJdoACdD34rqfCAIND46fXKQUnb0mvKzQID"
     @b64 << "AQABFhFNb3ppbGxhSXNNeUZyaWVuZDANBgkqhkiG9w0BAQQFAANBAAKv2Eex2n/S"
     @b64 << "r/7iJNroWlSzSMtTiQTEB+ADWHGj9u1xrUrOilq/o2cuQxIfZcNZkYAkWP4DubqW"

--- a/test/test_ocsp.rb
+++ b/test/test_ocsp.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require_relative "utils"
 
 if defined?(OpenSSL)

--- a/test/test_pair.rb
+++ b/test/test_pair.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require_relative 'utils'
 require_relative 'ut_eof'
 
@@ -128,11 +128,11 @@ module OpenSSL::TestPairM
     ssl_pair {|s1, s2|
       s2.write "a\nbcd"
       assert_equal("a\n", s1.gets)
-      result = ""
+      result = String.new
       result << s1.readpartial(10) until result.length == 3
       assert_equal("bcd", result)
       s2.write "efg"
-      result = ""
+      result = String.new
       result << s1.readpartial(10) until result.length == 3
       assert_equal("efg", result)
       s2.close
@@ -242,22 +242,22 @@ module OpenSSL::TestPairM
   def test_read_with_outbuf
     ssl_pair { |s1, s2|
       s1.write("abc\n")
-      buf = ""
+      buf = String.new
       ret = s2.read(2, buf)
       assert_same ret, buf
       assert_equal "ab", ret
 
-      buf = "garbage"
+      buf = +"garbage"
       ret = s2.read(2, buf)
       assert_same ret, buf
       assert_equal "c\n", ret
 
-      buf = "garbage"
+      buf = +"garbage"
       assert_equal :wait_readable, s2.read_nonblock(100, buf, exception: false)
       assert_equal "", buf
 
       s1.close
-      buf = "garbage"
+      buf = +"garbage"
       assert_equal nil, s2.read(100, buf)
       assert_equal "", buf
     }

--- a/test/test_pkcs12.rb
+++ b/test/test_pkcs12.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require_relative "utils"
 
 if defined?(OpenSSL)

--- a/test/test_pkcs7.rb
+++ b/test/test_pkcs7.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require_relative 'utils'
 
 if defined?(OpenSSL)

--- a/test/test_pkey_dh.rb
+++ b/test/test_pkey_dh.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require_relative 'utils'
 
 if defined?(OpenSSL) && defined?(OpenSSL::PKey::DH)

--- a/test/test_pkey_dsa.rb
+++ b/test/test_pkey_dsa.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require_relative 'utils'
 
 if defined?(OpenSSL) && defined?(OpenSSL::PKey::DSA)

--- a/test/test_pkey_ec.rb
+++ b/test/test_pkey_ec.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require_relative 'utils'
 
 if defined?(OpenSSL) && defined?(OpenSSL::PKey::EC)

--- a/test/test_pkey_rsa.rb
+++ b/test/test_pkey_rsa.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require_relative "utils"
 
 if defined?(OpenSSL)

--- a/test/test_random.rb
+++ b/test/test_random.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require_relative "utils"
 
 if defined?(OpenSSL)

--- a/test/test_ssl.rb
+++ b/test/test_ssl.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require_relative "utils"
 
 if defined?(OpenSSL)
@@ -292,12 +292,12 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
   def test_sysread_and_syswrite
     start_server { |port|
       server_connect(port) { |ssl|
-        str = "x" * 100 + "\n"
+        str = +("x" * 100 + "\n")
         ssl.syswrite(str)
         newstr = ssl.sysread(str.bytesize)
         assert_equal(str, newstr)
 
-        buf = ""
+        buf = String.new
         ssl.syswrite(str)
         assert_same buf, ssl.sysread(str.size, buf)
         assert_equal(str, buf)

--- a/test/test_ssl_session.rb
+++ b/test/test_ssl_session.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require_relative "utils"
 
 if defined?(OpenSSL)

--- a/test/test_x509attr.rb
+++ b/test/test_x509attr.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require_relative "utils"
 
 if defined?(OpenSSL)

--- a/test/test_x509cert.rb
+++ b/test/test_x509cert.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require_relative "utils"
 
 if defined?(OpenSSL)

--- a/test/test_x509crl.rb
+++ b/test/test_x509crl.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require_relative "utils"
 
 if defined?(OpenSSL)

--- a/test/test_x509ext.rb
+++ b/test/test_x509ext.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require_relative 'utils'
 
 if defined?(OpenSSL)

--- a/test/test_x509name.rb
+++ b/test/test_x509name.rb
@@ -1,5 +1,5 @@
 # coding: ASCII-8BIT
-# frozen_string_literal: false
+# frozen_string_literal: true
 require_relative 'utils'
 
 if defined?(OpenSSL)
@@ -389,7 +389,7 @@ class OpenSSL::TestX509Name < OpenSSL::TestCase
     dn.each { |x| name.add_entry(*x) }
 
     str = name.to_utf8
-    expected = "CN=フー\\, バー,DC=ruby-lang,DC=org".force_encoding("UTF-8")
+    expected = String.new("CN=フー\\, バー,DC=ruby-lang,DC=org").force_encoding("UTF-8")
     assert_equal expected, str
     assert_equal Encoding.find("UTF-8"), str.encoding
 

--- a/test/test_x509req.rb
+++ b/test/test_x509req.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require_relative "utils"
 
 if defined?(OpenSSL)

--- a/test/test_x509store.rb
+++ b/test/test_x509store.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require_relative "utils"
 
 if defined?(OpenSSL)

--- a/test/ut_eof.rb
+++ b/test/ut_eof.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'test/unit'
 
 if defined?(OpenSSL)
@@ -18,12 +18,12 @@ module OpenSSL::TestEOF
       assert_nil(f.read(1))
     }
     open_file("") {|f|
-      s = "x"
+      s = +"x"
       assert_equal("", f.read(nil, s))
       assert_equal("", s)
     }
     open_file("") {|f|
-      s = "x"
+      s = +"x"
       assert_nil(f.read(10, s))
       assert_equal("", s)
     }
@@ -75,12 +75,12 @@ module OpenSSL::TestEOF
       assert_equal("", f.read(0))
     }
     open_file("a") {|f|
-      s = "x"
+      s = +"x"
       assert_equal("a", f.read(nil, s))
       assert_equal("a", s)
     }
     open_file("a") {|f|
-      s = "x"
+      s = +"x"
       assert_equal("a", f.read(10, s))
       assert_equal("a", s)
     }

--- a/test/utils.rb
+++ b/test/utils.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 begin
   require "openssl"
 


### PR DESCRIPTION
```
Allocated String Report
-----------------------------------
    182005  ""
     60750  /home/samuel/.rbenv/versions/2.7.0/lib/ruby/2.7.0/openssl/buffering.rb:442
```

```
do_write ""
```

Is allocating 60k strings... so I figured maybe it's time to sort this out.