### PR TITLE
Drop to reference OpenSSL::VERSION on gemspec

### DIFF
--- a/openssl.gemspec
+++ b/openssl.gemspec
@@ -1,13 +1,6 @@
-
-begin
-  require_relative "lib/openssl/version"
-rescue LoadError
-  require_relative "version"
-end
-
 Gem::Specification.new do |spec|
   spec.name          = "openssl"
-  spec.version       = OpenSSL::VERSION
+  spec.version       = "2.2.0"
   spec.authors       = ["Martin Bosslet", "SHIBATA Hiroshi", "Zachary Scott", "Kazuki Yamaguchi"]
   spec.email         = ["ruby-core@ruby-lang.org"]
   spec.summary       = %q{OpenSSL provides SSL, TLS and general purpose cryptography.}


### PR DESCRIPTION
 It failed to test with the ruby core repository.