### PR TITLE
Revert "Fix segfaults in OpenSSL::PKey::RSA#private_{en,de}crypt when…

### DIFF
--- a/ext/openssl/ossl_pkey_rsa.c
+++ b/ext/openssl/ossl_pkey_rsa.c
@@ -488,13 +488,13 @@ static VALUE
 ossl_rsa_private_encrypt(int argc, VALUE *argv, VALUE self)
 {
     RSA *rsa;
-    const BIGNUM *rsa_n, *rsa_d;
+    const BIGNUM *rsa_n;
     int buf_len, pad;
     VALUE str, buffer, padding;
 
     GetRSA(self, rsa);
-    RSA_get0_key(rsa, &rsa_n, NULL, &rsa_d);
-    if (!rsa_n || !rsa_d)
+    RSA_get0_key(rsa, &rsa_n, NULL, NULL);
+    if (!rsa_n)
 	ossl_raise(eRSAError, "incomplete RSA");
     if (!RSA_PRIVATE(self, rsa))
 	ossl_raise(eRSAError, "private key needed.");
@@ -522,13 +522,13 @@ static VALUE
 ossl_rsa_private_decrypt(int argc, VALUE *argv, VALUE self)
 {
     RSA *rsa;
-    const BIGNUM *rsa_n, *rsa_d;
+    const BIGNUM *rsa_n;
     int buf_len, pad;
     VALUE str, buffer, padding;
 
     GetRSA(self, rsa);
-    RSA_get0_key(rsa, &rsa_n, NULL, &rsa_d);
-    if (!rsa_n || !rsa_d)
+    RSA_get0_key(rsa, &rsa_n, NULL, NULL);
+    if (!rsa_n)
 	ossl_raise(eRSAError, "incomplete RSA");
     if (!RSA_PRIVATE(self, rsa))
 	ossl_raise(eRSAError, "private key needed.");


### PR DESCRIPTION
… private exp not set"

This reverts commit e30b9a27f00338b065e90c6172d1c4509edc2853 (#255)
except the added test code.

The 'd' value can be NULL when the RSA private key is backed by an
OpenSSL engine, such as an HSM. In that case, only 'n' and 'e' are
visible from the OpenSSL API.

The original issue has been fixed by Pull Request #258 in another way.

Reference: https://github.com/ruby/openssl/pull/255
Reference: https://github.com/ruby/openssl/pull/258