### PR TITLE
.travis.yml - remove 2.3/1.0.2, 2.5/1.1.1, head/1.0.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,23 +12,10 @@ script:
 matrix:
   fast_finish: true
   include:
-    - env: RUBY_VERSION=ruby-2.3 OPENSSL_VERSION=openssl-1.0.2
     - env: RUBY_VERSION=ruby-2.4 OPENSSL_VERSION=openssl-1.0.2
     - env: RUBY_VERSION=ruby-2.5 OPENSSL_VERSION=openssl-1.0.1
     - env: RUBY_VERSION=ruby-2.5 OPENSSL_VERSION=openssl-1.0.2
     - env: RUBY_VERSION=ruby-2.5 OPENSSL_VERSION=openssl-1.1.0
-    - env: RUBY_VERSION=ruby-2.5 OPENSSL_VERSION=openssl-1.1.1
     - env: RUBY_VERSION=ruby-2.5 OPENSSL_VERSION=libressl-2.5
     - env: RUBY_VERSION=ruby-2.5 OPENSSL_VERSION=libressl-2.6
     - env: RUBY_VERSION=ruby-2.5 OPENSSL_VERSION=libressl-2.7
-    - language: ruby
-      rvm: ruby-head
-      before_install:
-        - "rake install_dependencies"
-      script:
-        - "rake compile -- --enable-debug"
-        - "rake test"
-  allow_failures:
-    - language: ruby
-      rvm: ruby-head
-    - env: RUBY_VERSION=ruby-2.5 OPENSSL_VERSION=openssl-1.1.1


### PR DESCRIPTION
Two jobs in Travis are duplicates of Actions jobs, and one is unlikely.

The below two jobs are running in Actions on all OS's
Ruby 2.3 and OpenSSL 1.0.2
Ruby 2.5 and OpenSSL 1.1.1

Ruby head and OpenSSL 1.0.2 - OpenSSL 1.0.2 is EOL, and the CI is running 1.0.2g, last release was 1.0.2u.