### PR TITLE
Fix double CI for repo branches

### DIFF
--- a/.github/workflows/ubuntu-macos.yml
+++ b/.github/workflows/ubuntu-macos.yml
@@ -1,6 +1,12 @@
 name: Ubuntu-macOS
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - '*'
+  pull_request:
+    branches:
+      - '*:*'
 
 jobs:
   build:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,6 +1,12 @@
 name: Windows
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - '*'
+  pull_request:
+    branches:
+      - '*:*'
 
 jobs:
   windows:


### PR DESCRIPTION
Ideally, the Actions workflows should allow CI in a fork, but doing so seems to create double the jobs when done in a PR here based on an upstream branch (not a fork branch)

For an example, see CI on https://github.com/ruby/openssl/pull/325.

This may fix the issue...