### PR TITLE
ext/openssl/extconf.rb: avoid -Werror=deprecated-declarations

### DIFF
--- a/ext/openssl/deprecation.rb
+++ b/ext/openssl/deprecation.rb
@@ -12,6 +12,10 @@ module OpenSSL
     flag
   end
 
+  def self.restore_warning_flag
+    $warnflags = @warnflags
+  end
+
   def self.check_func(func, header)
     have_func(func, header, deprecated_warning_flag)
   end

--- a/ext/openssl/extconf.rb
+++ b/ext/openssl/extconf.rb
@@ -19,7 +19,7 @@ dir_config("kerberos")
 
 Logging::message "=== OpenSSL for Ruby configurator ===\n"
 
-# Add -Werror=deprecated-declarations to $warnflags if available
+# Check with -Werror=deprecated-declarations if available
 OpenSSL.deprecated_warning_flag
 
 ##
@@ -185,5 +185,6 @@ have_func("SSL_CTX_set_post_handshake_auth")
 Logging::message "=== Checking done. ===\n"
 
 create_header
+OpenSSL.restore_warning_flag
 create_makefile("openssl")
 Logging::message "Done.\n"


### PR DESCRIPTION
It fails to build on Solaris:

https://rubyci.org/logs/rubyci.s3.amazonaws.com/solaris11-gcc/ruby-master/log/20200216T090008Z.log.html.gz
```
ossl_cipher.c: 関数 ‘ossl_cipher_init’ 内:
ossl_cipher.c:228:2: エラー: ‘EVP_md5’ is deprecated [-Werror=deprecated-declarations]
  228 |  EVP_BytesToKey(EVP_CIPHER_CTX_cipher(ctx), EVP_md5(), iv,
      |  ^~~~~~~~~~~~~~
In file included from /usr/include/openssl/x509.h:73,
                 from /usr/include/openssl/x509v3.h:63,
                 from ossl.h:23,
                 from ossl_cipher.c:10:
/usr/include/openssl/evp.h:732:26: 備考: ここで宣言されています
  732 | DEPRECATED const EVP_MD *EVP_md5(void);
      |                          ^~~~~~~
```

This is a backport of https://github.com/ruby/ruby/commit/0b55f8a14f28b070177ee0ddcd76edb46af9a395