### PR TITLE
test/openssl/test_ssl: skip test_fallback_scsv if necessary

### DIFF
--- a/test/openssl/test_ssl.rb
+++ b/test/openssl/test_ssl.rb
@@ -1419,6 +1419,10 @@ end
   end
 
   def test_fallback_scsv
+    supported = check_supported_protocol_versions
+    return unless supported.include?(OpenSSL::SSL::TLS1_1_VERSION) &&
+      supported.include?(OpenSSL::SSL::TLS1_2_VERSION)
+
     pend "Fallback SCSV is not supported" unless \
       OpenSSL::SSL::SSLContext.method_defined?(:enable_fallback_scsv)
 


### PR DESCRIPTION
Run the test case only when the OpenSSL supports both TLS 1.1 and TLS
1.2. Note that the fallback SCSV mechanism is for TLS 1.2 or older and
not for 1.3.

Fixes: https://github.com/ruby/openssl/issues/336