### PR TITLE
ts: simplify OpenSSL::Timestamp::Request#algorithm

### DIFF
--- a/ext/openssl/ossl_ts.c
+++ b/ext/openssl/ossl_ts.c
@@ -217,7 +217,7 @@ ossl_ts_req_initialize(int argc, VALUE *argv, VALUE self)
  * algorithm that was used to create the message imprint digest.
  *
  *  call-seq:
- *       request.get_algorithm    -> string or nil
+ *       request.algorithm    -> string
  */
 static VALUE
 ossl_ts_req_get_algorithm(VALUE self)
@@ -225,15 +225,10 @@ ossl_ts_req_get_algorithm(VALUE self)
     TS_REQ *req;
     TS_MSG_IMPRINT *mi;
     X509_ALGOR *algor;
-    int algi;
 
     GetTSRequest(self, req);
     mi = TS_REQ_get_msg_imprint(req);
     algor = TS_MSG_IMPRINT_get_algo(mi);
-    algi = OBJ_obj2nid(algor->algorithm);
-    if (algi == NID_undef || algi == NID_ccitt)
-        return Qnil;
-
     return get_asn1obj(algor->algorithm);
 }
 

--- a/test/openssl/test_ts.rb
+++ b/test/openssl/test_ts.rb
@@ -67,16 +67,6 @@ _end_of_pem_
     @ts_cert_ee ||= OpenSSL::Certs.ts_cert_ee(ee_key, intermediate_cert, intermediate_key)
   end
 
-  def test_create_request
-    req = OpenSSL::Timestamp::Request.new
-    assert_equal(true, req.cert_requested?)
-    assert_equal(1, req.version)
-    assert_nil(req.algorithm)
-    assert_equal("", req.message_imprint)
-    assert_nil(req.policy_id)
-    assert_nil(req.nonce)
-  end
-
   def test_request_mandatory_fields
     req = OpenSSL::Timestamp::Request.new
     assert_raise(OpenSSL::Timestamp::TimestampError) do


### PR DESCRIPTION
Stop the special treatment of invalid hashAlgorithm of the message
imprint. Those invalid values can only appear after the object is
instantiated, before the user sets an actual message digest algorithm.

OpenSSL::Timestamp::TokenInfo#algorithm already does the same.

Also, remove the test case "test_create_request" since it does not make
much sense. Those fields are to be set by the user after creation of
the object and checking the initial value is pointless.

Fixes: https://github.com/ruby/openssl/issues/335