### PR TITLE
ssl: avoid declarations after statements

### DIFF
--- a/ext/openssl/ossl_ssl.c
+++ b/ext/openssl/ossl_ssl.c
@@ -2327,16 +2327,16 @@ static VALUE
 ossl_ssl_get_finished(VALUE self)
 {
     SSL *ssl;
+    char sizer[1], *buf;
+    size_t len;
 
     GetSSL(self, ssl);
 
-    char sizer[1];
-    size_t len = SSL_get_finished(ssl, sizer, 0);
+    len = SSL_get_finished(ssl, sizer, 0);
+    if (len == 0)
+        return Qnil;
 
-    if(len == 0)
-      return Qnil;
-
-    char* buf = ALLOCA_N(char, len);
+    buf = ALLOCA_N(char, len);
     SSL_get_finished(ssl, buf, len);
     return rb_str_new(buf, len);
 }
@@ -2352,16 +2352,16 @@ static VALUE
 ossl_ssl_get_peer_finished(VALUE self)
 {
     SSL *ssl;
+    char sizer[1], *buf;
+    size_t len;
 
     GetSSL(self, ssl);
 
-    char sizer[1];
-    size_t len = SSL_get_peer_finished(ssl, sizer, 0);
+    len = SSL_get_peer_finished(ssl, sizer, 0);
+    if (len == 0)
+        return Qnil;
 
-    if(len == 0)
-      return Qnil;
-
-    char* buf = ALLOCA_N(char, len);
+    buf = ALLOCA_N(char, len);
     SSL_get_peer_finished(ssl, buf, len);
     return rb_str_new(buf, len);
 }


### PR DESCRIPTION
We cannot use C99 features yet, as we still support Ruby 2.6 and older.

Fixes: debaca25604c ("Adds support for the 'get_finished' and 'get_peer_finished' functions", 2019-06-25)