### PR TITLE
engine: revert OpenSSL::Engine.load changes for cloudhsm

### DIFF
--- a/ext/openssl/extconf.rb
+++ b/ext/openssl/extconf.rb
@@ -111,8 +111,7 @@ Logging::message "=== Checking for OpenSSL features... ===\n"
 # compile options
 have_func("RAND_egd")
 engines = %w{builtin_engines openbsd_dev_crypto dynamic 4758cca aep atalla chil
-             cswift nuron sureware ubsec padlock capi gmp gost cryptodev aesni
-             cloudhsm}
+             cswift nuron sureware ubsec padlock capi gmp gost cryptodev aesni}
 engines.each { |name|
   have_func("ENGINE_load_#{name}()", "openssl/engine.h")
 }

--- a/ext/openssl/ossl_engine.c
+++ b/ext/openssl/ossl_engine.c
@@ -150,9 +150,6 @@ ossl_engine_s_load(int argc, VALUE *argv, VALUE klass)
 #if HAVE_ENGINE_LOAD_AESNI
     OSSL_ENGINE_LOAD_IF_MATCH(aesni, AESNI);
 #endif
-#if HAVE_ENGINE_LOAD_CLOUDHSM
-    OSSL_ENGINE_LOAD_IF_MATCH(cloudhsm, CLOUDHSM);
-#endif
 #endif
 #ifdef HAVE_ENGINE_LOAD_OPENBSD_DEV_CRYPTO
     OSSL_ENGINE_LOAD_IF_MATCH(openbsd_dev_crypto, OPENBSD_DEV_CRYPTO);


### PR DESCRIPTION
Revert two commits:

 - ea49ccc82aa4 Add cloudhsm to extconf.rb
 - 33ed3ba10424 Add cloudhsm to ossl_engine.c

OpenSSL::Engine.load is a binding for ENGINE_load_*() functions which
are provided by OpenSSL itself, so-called "static engines".

Since the AWS CloudHSM engine is a dynamic engine, which is provided as
a shared library, this change is not a correct solution for the issue.

Reference: https://github.com/ruby/openssl/issues/189
Reference: https://github.com/ruby/openssl/pull/190