### PR TITLE
engine: small cleanups on OpenSSL::Engine.load

### DIFF
--- a/ext/openssl/extconf.rb
+++ b/ext/openssl/extconf.rb
@@ -110,7 +110,7 @@ end
 Logging::message "=== Checking for OpenSSL features... ===\n"
 # compile options
 have_func("RAND_egd")
-engines = %w{builtin_engines dynamic 4758cca aep atalla chil
+engines = %w{dynamic 4758cca aep atalla chil
              cswift nuron sureware ubsec padlock capi gmp gost cryptodev}
 engines.each { |name|
   have_func("ENGINE_load_#{name}()", "openssl/engine.h")

--- a/ext/openssl/extconf.rb
+++ b/ext/openssl/extconf.rb
@@ -110,8 +110,8 @@ end
 Logging::message "=== Checking for OpenSSL features... ===\n"
 # compile options
 have_func("RAND_egd")
-engines = %w{builtin_engines openbsd_dev_crypto dynamic 4758cca aep atalla chil
-             cswift nuron sureware ubsec padlock capi gmp gost cryptodev aesni}
+engines = %w{builtin_engines dynamic 4758cca aep atalla chil
+             cswift nuron sureware ubsec padlock capi gmp gost cryptodev}
 engines.each { |name|
   have_func("ENGINE_load_#{name}()", "openssl/engine.h")
 }

--- a/ext/openssl/ossl_engine.c
+++ b/ext/openssl/ossl_engine.c
@@ -93,9 +93,6 @@ static const rb_data_type_t ossl_engine_type = {
 static VALUE
 ossl_engine_s_load(int argc, VALUE *argv, VALUE klass)
 {
-#if !defined(HAVE_ENGINE_LOAD_BUILTIN_ENGINES)
-    return Qnil;
-#else
     VALUE name;
 
     rb_scan_args(argc, argv, "01", &name);
@@ -151,7 +148,6 @@ ossl_engine_s_load(int argc, VALUE *argv, VALUE klass)
     OSSL_ENGINE_LOAD_IF_MATCH(openssl, OPENSSL);
     rb_warning("no such builtin loader for `%"PRIsVALUE"'", name);
     return Qnil;
-#endif /* HAVE_ENGINE_LOAD_BUILTIN_ENGINES */
 }
 
 /*

--- a/ext/openssl/ossl_engine.c
+++ b/ext/openssl/ossl_engine.c
@@ -147,12 +147,6 @@ ossl_engine_s_load(int argc, VALUE *argv, VALUE klass)
 #if HAVE_ENGINE_LOAD_CRYPTODEV
     OSSL_ENGINE_LOAD_IF_MATCH(cryptodev, CRYPTODEV);
 #endif
-#if HAVE_ENGINE_LOAD_AESNI
-    OSSL_ENGINE_LOAD_IF_MATCH(aesni, AESNI);
-#endif
-#endif
-#ifdef HAVE_ENGINE_LOAD_OPENBSD_DEV_CRYPTO
-    OSSL_ENGINE_LOAD_IF_MATCH(openbsd_dev_crypto, OPENBSD_DEV_CRYPTO);
 #endif
     OSSL_ENGINE_LOAD_IF_MATCH(openssl, OPENSSL);
     rb_warning("no such builtin loader for `%"PRIsVALUE"'", name);

--- a/ext/openssl/ossl_engine.c
+++ b/ext/openssl/ossl_engine.c
@@ -101,10 +101,10 @@ ossl_engine_s_load(int argc, VALUE *argv, VALUE klass)
         return Qtrue;
     }
     StringValueCStr(name);
-#ifndef OPENSSL_NO_STATIC_ENGINE
 #if HAVE_ENGINE_LOAD_DYNAMIC
     OSSL_ENGINE_LOAD_IF_MATCH(dynamic, DYNAMIC);
 #endif
+#ifndef OPENSSL_NO_STATIC_ENGINE
 #if HAVE_ENGINE_LOAD_4758CCA
     OSSL_ENGINE_LOAD_IF_MATCH(4758cca, 4758CCA);
 #endif
@@ -141,9 +141,9 @@ ossl_engine_s_load(int argc, VALUE *argv, VALUE klass)
 #if HAVE_ENGINE_LOAD_GOST
     OSSL_ENGINE_LOAD_IF_MATCH(gost, GOST);
 #endif
+#endif
 #if HAVE_ENGINE_LOAD_CRYPTODEV
     OSSL_ENGINE_LOAD_IF_MATCH(cryptodev, CRYPTODEV);
-#endif
 #endif
     OSSL_ENGINE_LOAD_IF_MATCH(openssl, OPENSSL);
     rb_warning("no such builtin loader for `%"PRIsVALUE"'", name);


### PR DESCRIPTION
engine: remove really outdated static engines

They no longer exists in OpenSSL 1.0.1, which is the oldest version
Ruby/OpenSSL currently compiles with.

Note that OpenSSL 1.0.2 and older is already in EOL state. The following
engines should also be removed when we completely drop support for those
versions as they were removed in OpenSSL 1.1.0.

 - 4758cca
 - aep
 - atalla
 - chil
 - cswift
 - nuron
 - sureware
 - ubsec
 - gmp
 - gost

---

engine: do not check for ENGINE_load_builtin_engines()

Remove dead code. The function, or a macro in OpenSSL 1.1.0 and newer,
always exists unless the whole engine code is disabled with
OPENSSL_NO_ENGINE.

---

engine: fix guards for 'dynamic' and 'cryptodev' engines

Those two engines exist as builtin engines even if static engines are
disabled with OPENSSL_NO_STATIC_ENGINE. This is the default with recent
OpenSSL.

This has prevented Engine.load("dynamic") from working and required
the user to call OpenSSL::Engine.load with no arguments, which loads all
builtin engines including 'dynamic'.

Note that OpenSSL 1.1.0 and newer calls (the equivalent of)
ENGINE_load_builtin_engines() on its initialization. This includes
'dynamic' and 'cryptodev' engines (if available).
