### PR TITLE
lib/openssl.rb: require openssl/version.rb

### DIFF
--- a/lib/openssl.rb
+++ b/lib/openssl.rb
@@ -21,6 +21,7 @@ require_relative 'openssl/hmac'
 require_relative 'openssl/x509'
 require_relative 'openssl/ssl'
 require_relative 'openssl/pkcs5'
+require_relative 'openssl/version'
 
 module OpenSSL
   # call-seq:

--- a/lib/openssl/version.rb
+++ b/lib/openssl/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module OpenSSL
-  VERSION = "2.2.0" unless defined?(VERSION)
+  VERSION = "2.2.0"
 end


### PR DESCRIPTION
The OpenSSL::VERSION constant is now defined by lib/openssl/version.rb
instead of by the extension. Add missing require statement.

Fixes: 0cddb0b736c8 ("Simplify handling of version constant.", 2019-10-31)
Fixes: https://github.com/ruby/openssl/issues/347