### PR TITLE
Use version.rb in gemspec

### DIFF
--- a/openssl.gemspec
+++ b/openssl.gemspec
@@ -1,6 +1,8 @@
+require_relative 'lib/openssl/version'
+
 Gem::Specification.new do |spec|
   spec.name          = "openssl"
-  spec.version       = "2.2.0"
+  spec.version       = OpenSSL::VERSION
   spec.authors       = ["Martin Bosslet", "SHIBATA Hiroshi", "Zachary Scott", "Kazuki Yamaguchi"]
   spec.email         = ["ruby-core@ruby-lang.org"]
   spec.summary       = %q{OpenSSL provides SSL, TLS and general purpose cryptography.}


### PR DESCRIPTION
Use version.rb in gemspec so version string exists in one location.

I built the gem, and also built ruby with the same gemspec.  Both contained the version string as expected.