### PR TITLE
Code update (eof) and Actions CI for 1.1.1e

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,7 +85,7 @@ jobs:
           - openssl-1.0.1u # EOL
           - openssl-1.0.2u # EOL
           - openssl-1.1.0l # EOL
-          - openssl-1.1.1d
+          - openssl-1.1.1e
           # - libressl-2.3.7 # EOL
           # - libressl-2.4.5 # EOL
           # - libressl-2.5.5 # EOL

--- a/ext/openssl/ossl_ssl.c
+++ b/ext/openssl/ossl_ssl.c
@@ -1896,7 +1896,17 @@ ossl_ssl_read_internal(int argc, VALUE *argv, VALUE self, int nonblock)
 			rb_eof_error();
 		    }
 		}
-                /* fall through */
+		/* fall through */
+#ifdef SSL_R_UNEXPECTED_EOF_WHILE_READING
+	    case SSL_ERROR_SSL:
+		/* defined for OpenSSL versions 1.1.1e and later */
+		if (OpenSSL_version_num() >= 0x1010105fL &&
+		    ERR_GET_REASON(ERR_peek_last_error()) == SSL_R_UNEXPECTED_EOF_WHILE_READING) {
+		    rb_eof_error();
+		    continue;
+		}
+		/* fall through */
+#endif
 	    default:
 		ossl_raise(eSSLError, "SSL_read");
 	    }


### PR DESCRIPTION
Update the Actions CI job that builds OpenSSL from 1.1.1d to 1.1.1e.

This shows the failure that occurs with Ruby master builds using 1.1.1e.

Note that Windows MinGW builds are self-contained, and current builds from 2.5 and later have 1.1.1d dll's packaged with them.  Earlier patch/teeny builds may have earlier versions of 1.1.1.

So, compiling here in CI will compile with 1.1.1e, but the tests run with the bundled dll's...