### PR TITLE
test/openssl/test_ssl.rb: ignore SSLError when the connection is closed

### DIFF
--- a/test/openssl/test_ssl.rb
+++ b/test/openssl/test_ssl.rb
@@ -1398,8 +1398,13 @@ end
     }
   end
 
+  def readwrite_loop_safe(ctx, ssl)
+    readwrite_loop(ctx, ssl)
+  rescue OpenSSL::SSL::SSLError
+  end
+
   def test_close_after_socket_close
-    start_server { |port|
+    start_server(server_proc: method(:readwrite_loop_safe)) { |port|
       sock = TCPSocket.new("127.0.0.1", port)
       ssl = OpenSSL::SSL::SSLSocket.new(sock)
       ssl.connect


### PR DESCRIPTION
"test_close_after_socket_close" checks if ssl.close is no-op even after
the wrapped socket is closed.  The test itself is fair, but the other
endpoint that is reading the SSL connection may fail with SSLError:
"SSL_read: unexpected eof while reading" in some environments:

https://github.com/ruby/ruby/actions/runs/60085389 (MinGW)
https://rubyci.org/logs/rubyci.s3.amazonaws.com/android28-x86_64/ruby-master/log/20200321T034442Z.fail.html.gz
```
  1) Failure:
OpenSSL::TestSSL#test_close_after_socket_close [D:/a/ruby/ruby/src/test/openssl/utils.rb:299]:
exceptions on 1 threads:
SSL_read: unexpected eof while reading
```

This changeset rescues and ignores the SSLError in the test.

Note: I've already committed this change into ruby/ruby to suppress the CI failures.
https://github.com/ruby/ruby/commit/be76e86e69106c6906322dc30aa75c3ff65da63c