### PR TITLE
Add OPENSSL_LIBRARY_VERSION_NUMBER constant

### DIFF
--- a/ext/openssl/ossl.c
+++ b/ext/openssl/ossl.c
@@ -1166,6 +1166,7 @@ Init_openssl(void)
      */
 #if !defined(LIBRESSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x10100000
     rb_define_const(mOSSL, "OPENSSL_LIBRARY_VERSION", rb_str_new2(OpenSSL_version(OPENSSL_VERSION)));
+    rb_define_const(mOSSL, "OPENSSL_LIBRARY_VERSION_NUMBER", INT2NUM(OpenSSL_version_num()));
 #else
     rb_define_const(mOSSL, "OPENSSL_LIBRARY_VERSION", rb_str_new2(SSLeay_version(SSLEAY_VERSION)));
 #endif


### PR DESCRIPTION
With the release of OpenSSL 1.1.1e, being able to determine the version number of the loaded OpenSSL library may be helpful.  Adds the constant `OPENSSL_LIBRARY_VERSION_NUMBER` to `OpenSSL`.

**The Windows master builds (mingw and mswin) are compiled with OpenSSL 1.1.1e, and will fail.**