### PR TITLE
Allow specifying the data length for CCM mode

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,7 +80,7 @@ $ docker-compose run debug
 ```
 
 All possible values for `RUBY_VERSION` and `OPENSSL_VERSION` can be found in
-[`.travis.yml`](https://github.com/ruby/openssl/tree/master/.travis.yml).
+[`test.yml`](https://github.com/ruby/openssl/tree/master/.github/workflows/test.yml).
 
 **NOTE**: these commands must be run from the openssl repository root, in order
 to use the

--- a/ext/openssl/ossl_cipher.c
+++ b/ext/openssl/ossl_cipher.c
@@ -814,6 +814,31 @@ ossl_cipher_block_size(VALUE self)
 }
 
 /*
+ *  call-seq:
+ *     cipher.ccm_data_len = integer -> integer
+ *
+ *  Sets the length of the plaintext / ciphertext message that will be
+ *  processed in CCM mode. Make sure to call this method after #key= and
+ *  #iv= have been set, and before #auth_data=.
+ *
+ *  Only call this method after calling Cipher#encrypt or Cipher#decrypt.
+ */
+static VALUE
+ossl_cipher_set_ccm_data_len(VALUE self, VALUE data_len)
+{
+    int in_len, out_len;
+    EVP_CIPHER_CTX *ctx;
+
+    in_len = NUM2INT(data_len);
+
+    GetCipher(self, ctx);
+    if (EVP_CipherUpdate(ctx, NULL, &out_len, NULL, in_len) != 1)
+        ossl_raise(eCipherError, NULL);
+
+    return data_len;
+}
+
+/*
  * INIT
  */
 void
@@ -1059,6 +1084,7 @@ Init_ossl_cipher(void)
     rb_define_method(cCipher, "iv_len", ossl_cipher_iv_length, 0);
     rb_define_method(cCipher, "block_size", ossl_cipher_block_size, 0);
     rb_define_method(cCipher, "padding=", ossl_cipher_set_padding, 1);
+    rb_define_method(cCipher, "ccm_data_len=", ossl_cipher_set_ccm_data_len, 1);
 
     id_auth_tag_len = rb_intern_const("auth_tag_len");
     id_key_set = rb_intern_const("key_set");

--- a/test/openssl/test_cipher.rb
+++ b/test/openssl/test_cipher.rb
@@ -174,6 +174,48 @@ class OpenSSL::TestCipher < OpenSSL::TestCase
     assert_not_predicate(cipher, :authenticated?)
   end
 
+  def test_aes_ccm
+    # RFC 3610 Section 8, Test Case 1
+    key = ["c0c1c2c3c4c5c6c7c8c9cacbcccdcecf"].pack("H*")
+    iv =  ["00000003020100a0a1a2a3a4a5"].pack("H*")
+    aad = ["0001020304050607"].pack("H*")
+    pt =  ["08090a0b0c0d0e0f101112131415161718191a1b1c1d1e"].pack("H*")
+    ct =  ["588c979a61c663d2f066d0c2c0f989806d5f6b61dac384"].pack("H*")
+    tag = ["17e8d12cfdf926e0"].pack("H*")
+
+    kwargs = {auth_tag_len: 8, iv_len: 13, key: key, iv: iv}
+    cipher = new_encryptor("aes-128-ccm", **kwargs, ccm_data_len: pt.length, auth_data: aad)
+    assert_equal ct, cipher.update(pt) << cipher.final
+    assert_equal tag, cipher.auth_tag
+    cipher = new_decryptor("aes-128-ccm", **kwargs, ccm_data_len: ct.length, auth_tag: tag, auth_data: aad)
+    assert_equal pt, cipher.update(ct) << cipher.final
+
+    # truncated tag is accepted
+    cipher = new_encryptor("aes-128-ccm", **kwargs, ccm_data_len: pt.length, auth_data: aad)
+    assert_equal ct, cipher.update(pt) << cipher.final
+    assert_equal tag[0, 8], cipher.auth_tag(8)
+    cipher = new_decryptor("aes-128-ccm", **kwargs, ccm_data_len: ct.length, auth_tag: tag[0, 8], auth_data: aad)
+    assert_equal pt, cipher.update(ct) << cipher.final
+
+    # wrong tag is rejected
+    tag2 = tag.dup
+    tag2.setbyte(-1, (tag2.getbyte(-1) + 1) & 0xff)
+    cipher = new_decryptor("aes-128-ccm", **kwargs, ccm_data_len: ct.length, auth_tag: tag2, auth_data: aad)
+    assert_raise(OpenSSL::Cipher::CipherError) { cipher.update(ct) }
+
+    # wrong aad is rejected
+    aad2 = aad[0..-2] << aad[-1].succ
+    cipher = new_decryptor("aes-128-ccm", **kwargs, ccm_data_len: ct.length, auth_tag: tag, auth_data: aad2)
+    assert_raise(OpenSSL::Cipher::CipherError) { cipher.update(ct) }
+
+    # wrong ciphertext is rejected
+    ct2 = ct[0..-2] << ct[-1].succ
+    cipher = new_decryptor("aes-128-ccm", **kwargs, ccm_data_len: ct2.length, auth_tag: tag, auth_data: aad)
+    assert_raise(OpenSSL::Cipher::CipherError) { cipher.update(ct2) }
+  end if has_cipher?("aes-128-ccm") &&
+         OpenSSL::Cipher.new("aes-128-ccm").authenticated? &&
+         OpenSSL::OPENSSL_VERSION_NUMBER >= 0x10101000  # version >= v1.1.1
+
   def test_aes_gcm
     # GCM spec Appendix B Test Case 4
     key = ["feffe9928665731c6d6a8f9467308308"].pack("H*")


### PR DESCRIPTION
As it is currently written the `Cipher` object can not be used in CCM mode with additional authenticate data. This is because per the OpenSSL documentation, when a Cipher is used in CCM mode the ciphertext, plaintext length must be specified to `EVP_CipherUpdate` as the `inl` parameter while both `in` and `out` are set to `NULL` (see the "CCM Mode" section of the OpenSSL docs here: https://www.openssl.org/docs/man1.1.1/man3/EVP_CipherUpdate.html). This PR changes the implementation of `#update` to allow the data parameter to be specified as an integer which is assumed to be the length of the ciphertext / plaintext for the update operation effectively fixing the limitation and allowing users to utilize the CCM mode.

Before the patch there would be an exception when trying to set `#auth_data` stating that additional data could not be set. After the patch, users can set the length of the message to encrypt using `#update` and fully utilize this cipher mode. Note that this behavior is only necessary for CCM mode. GCM on the other hand works as is, and does not require specifying the length of the plaintext / ciphertext.

## Example Usage
Example functioning CCM mode implementation (requires changes proposed by this PR):
```ruby
require 'openssl'

auth_data = 'ABCDABCD'
message = 'WXYZWXYZ'

def bin_to_hex(s)
  s.each_byte.map { |b| b.to_s(16).rjust(2, '0') }.join
end

def build_cipher(mode, data)
  cipher = OpenSSL::Cipher.new('AES-128-CCM')
  cipher.send(mode)
  cipher.auth_tag_len = 16
  cipher.iv_len = 11
  cipher.iv = "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
  cipher.key = "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
  cipher.update(data.length)  # set the plaintext / ciphertext length
  cipher
end

puts "Gem Version:     #{OpenSSL::VERSION}"
puts "OpenSSL Version: #{OpenSSL::OPENSSL_VERSION}"

cipher = build_cipher(:encrypt, message)
cipher.auth_data = auth_data

encrypted = cipher.update(message) + cipher.final
auth_tag = cipher.auth_tag

puts "encrypted: #{bin_to_hex(encrypted)}"
puts "signature: #{bin_to_hex(auth_tag)}"

cipher = build_cipher(:decrypt, encrypted)
cipher.auth_data = auth_data
cipher.auth_tag = auth_tag
decrypted = cipher.update(encrypted) + cipher.final

puts "decrypted: #{decrypted}"
```

Output:
```
Gem Version:     2.2.0
OpenSSL Version: OpenSSL 1.1.1d FIPS  10 Sep 2019
encrypted: 79c293318d0ca535
signature: 9dddaf882f7c94f333895c9e69a63d40
decrypted: WXYZWXYZ
```

If for whatever reason this implementation isn't ideal, the gist of an alternative is that the length of the plaintext / ciphertext needs to be able to be specified in a call similar to `EVP_CipherUpdate(ctx, NULL, &len, NULL, text_len)` before the AAD is set. An example implementation in C is available on the OpenSSL wiki here: https://wiki.openssl.org/index.php/EVP_Authenticated_Encryption_and_Decryption#Authenticated_Encryption_using_CCM_mode.