### PR TITLE
Add feature for loading the chained certificate into Certificate array

### DIFF
--- a/ext/openssl/ossl_x509cert.c
+++ b/ext/openssl/ossl_x509cert.c
@@ -715,7 +715,8 @@ ossl_x509_load_chained_cert_from_file(VALUE self, VALUE path)
 {
     BIO *in;
     X509 *x509;
-    VALUE ary, cert;
+    VALUE ary = rb_ary_new();
+    VALUE cert;
 
     in = BIO_new(BIO_s_file());
     if (in == NULL)

--- a/lib/openssl/x509.rb
+++ b/lib/openssl/x509.rb
@@ -352,6 +352,20 @@ module OpenSSL
           q.text 'not_after='; q.pp self.not_after
         }
       end
+
+      # TODO: sikuan: Load the certificates (PEM, DER, etc.) from file, using BIO
+      #     input   string (File path)
+      #     output  array (Array of Certificate objects)
+      def load_file(path)
+        return load_chained_cert_from_file(path)
+      end
+
+      # TODO: sikuan: Load the certificates (PEM, DER, etc.) from BIO (various data sources)
+      #     input   cert content (DER(ASN1) or PEM)
+      #     output  array (Array of Certificate objects)
+      def read_certificates(cert_content)
+        raise NotImplementedError
+      end
     end
 
     class CRL


### PR DESCRIPTION
## Load the chained certificate into Certificate array

New feature proposal for issue #288

Create two functions:
 - [ ] `OpenSSL::X509::Certificate#load_file(path)`
    - Input: `string` (File path)
    - Output: `array` (Array of `Certificate` objects)
    - Related files:
        - [ext/openssl/ossl_x509cert.c](https://github.com/sikuan/openssl/blob/gsoc2020-ruby-sikuan-288/ext/openssl/ossl_x509cert.c)
        - [lib/openssl/x509.rb](https://github.com/sikuan/openssl/blob/gsoc2020-ruby-sikuan-288/lib/openssl/x509.rb)
    - Proposed features:
        - [x] Load PEM file
        - [ ] Load DER(ASN1) file
        - [x] Return the array of `Certificate` objects, which are the chained certificates
    - Proposed way to solve:
        - [x] Create a `BIO` wrapper in `ext/openssl/ossl_x509cert.c`
        - [ ] (proposing in progress)
 - [ ] `OpenSSL::X509::Certificate#read_certificates(cert_content)`
    - Input: certificate content (DER(ASN1) or PEM)
    - Output: `array` (Array of `Certificate` objects)
    - Related files:
        - [ext/openssl/ossl_x509cert.c](https://github.com/sikuan/openssl/blob/gsoc2020-ruby-sikuan-288/ext/openssl/ossl_x509cert.c)
        - [lib/openssl/x509.rb](https://github.com/sikuan/openssl/blob/gsoc2020-ruby-sikuan-288/lib/openssl/x509.rb)
    - Proposed features:
        - [ ] Load PEM
        - [ ] Load DER(ASN1)
        - [ ] Return the array of `Certificate` objects, which are the chained certificates
    - Proposed way to solve:
        - [ ] (proposing in progress)