### PR TITLE
Lookup digests/cipher by name instead of constants

### DIFF
--- a/ext/openssl/ossl.c
+++ b/ext/openssl/ossl.c
@@ -739,7 +739,7 @@ ossl_crypto_fixed_length_secure_compare(VALUE dummy, VALUE str1, VALUE str2)
  * To sign a document, a cryptographically secure hash of the document is
  * computed first, which is then signed using the private key.
  *
- *   digest = OpenSSL::Digest::SHA256.new
+ *   digest = OpenSSL::Digest.new('SHA256')
  *   signature = key.sign digest, document
  *
  * To validate the signature, again a hash of the document is computed and
@@ -747,7 +747,7 @@ ossl_crypto_fixed_length_secure_compare(VALUE dummy, VALUE str1, VALUE str2)
  * compared to the hash just computed, if they are equal the signature was
  * valid.
  *
- *   digest = OpenSSL::Digest::SHA256.new
+ *   digest = OpenSSL::Digest.new('SHA256')
  *   if key.verify digest, signature, document
  *     puts 'Valid'
  *   else
@@ -782,7 +782,7 @@ ossl_crypto_fixed_length_secure_compare(VALUE dummy, VALUE str1, VALUE str2)
  *   salt = OpenSSL::Random.random_bytes 16
  *   iter = 20000
  *   key_len = cipher.key_len
- *   digest = OpenSSL::Digest::SHA256.new
+ *   digest = OpenSSL::Digest.new('SHA256')
  *
  *   key = OpenSSL::PKCS5.pbkdf2_hmac(pwd, salt, iter, key_len, digest)
  *   cipher.key = key
@@ -805,7 +805,7 @@ ossl_crypto_fixed_length_secure_compare(VALUE dummy, VALUE str1, VALUE str2)
  *   salt = ... # the one generated above
  *   iter = 20000
  *   key_len = cipher.key_len
- *   digest = OpenSSL::Digest::SHA256.new
+ *   digest = OpenSSL::Digest.new('SHA256')
  *
  *   key = OpenSSL::PKCS5.pbkdf2_hmac(pwd, salt, iter, key_len, digest)
  *   cipher.key = key
@@ -901,7 +901,7 @@ ossl_crypto_fixed_length_secure_compare(VALUE dummy, VALUE str1, VALUE str2)
  * certificate.
  *
  *   cert.issuer = name
- *   cert.sign key, OpenSSL::Digest::SHA1.new
+ *   cert.sign key, OpenSSL::Digest.new('SHA1')
  *
  *   open 'certificate.pem', 'w' do |io| io.write cert.to_pem end
  *
@@ -977,7 +977,7 @@ ossl_crypto_fixed_length_secure_compare(VALUE dummy, VALUE str1, VALUE str2)
  *
  * Root CA certificates are self-signed.
  *
- *   ca_cert.sign ca_key, OpenSSL::Digest::SHA1.new
+ *   ca_cert.sign ca_key, OpenSSL::Digest.new('SHA1')
  *
  * The CA certificate is saved to disk so it may be distributed to all the
  * users of the keys this CA will sign.
@@ -995,7 +995,7 @@ ossl_crypto_fixed_length_secure_compare(VALUE dummy, VALUE str1, VALUE str2)
  *   csr.version = 0
  *   csr.subject = name
  *   csr.public_key = key.public_key
- *   csr.sign key, OpenSSL::Digest::SHA1.new
+ *   csr.sign key, OpenSSL::Digest.new('SHA1')
  *
  * A CSR is saved to disk and sent to the CA for signing.
  *
@@ -1039,7 +1039,7 @@ ossl_crypto_fixed_length_secure_compare(VALUE dummy, VALUE str1, VALUE str2)
  *   csr_cert.add_extension \
  *     extension_factory.create_extension('subjectKeyIdentifier', 'hash')
  *
- *   csr_cert.sign ca_key, OpenSSL::Digest::SHA1.new
+ *   csr_cert.sign ca_key, OpenSSL::Digest.new('SHA1')
  *
  *   open 'csr_cert.pem', 'w' do |io|
  *     io.write csr_cert.to_pem

--- a/ext/openssl/ossl.c
+++ b/ext/openssl/ossl.c
@@ -739,16 +739,14 @@ ossl_crypto_fixed_length_secure_compare(VALUE dummy, VALUE str1, VALUE str2)
  * To sign a document, a cryptographically secure hash of the document is
  * computed first, which is then signed using the private key.
  *
- *   digest = OpenSSL::Digest.new('SHA256')
- *   signature = key.sign digest, document
+ *   signature = key.sign 'SHA256', document
  *
  * To validate the signature, again a hash of the document is computed and
  * the signature is decrypted using the public key. The result is then
  * compared to the hash just computed, if they are equal the signature was
  * valid.
  *
- *   digest = OpenSSL::Digest.new('SHA256')
- *   if key.verify digest, signature, document
+ *   if key.verify 'SHA256', signature, document
  *     puts 'Valid'
  *   else
  *     puts 'Invalid'

--- a/ext/openssl/ossl_cipher.c
+++ b/ext/openssl/ossl_cipher.c
@@ -851,22 +851,6 @@ Init_ossl_cipher(void)
      *
      *  cipher = OpenSSL::Cipher.new('AES-128-CBC')
      *
-     * For each algorithm supported, there is a class defined under the
-     * Cipher class that goes by the name of the cipher, e.g. to obtain an
-     * instance of AES, you could also use
-     *
-     *   # these are equivalent
-     *   cipher = OpenSSL::Cipher::AES.new(128, :CBC)
-     *   cipher = OpenSSL::Cipher::AES.new(128, 'CBC')
-     *   cipher = OpenSSL::Cipher::AES.new('128-CBC')
-     *
-     * Finally, due to its wide-spread use, there are also extra classes
-     * defined for the different key sizes of AES
-     *
-     *   cipher = OpenSSL::Cipher::AES128.new(:CBC)
-     *   cipher = OpenSSL::Cipher::AES192.new(:CBC)
-     *   cipher = OpenSSL::Cipher::AES256.new(:CBC)
-     *
      * === Choosing either encryption or decryption mode
      *
      * Encryption and decryption are often very similar operations for
@@ -895,7 +879,7 @@ Init_ossl_cipher(void)
      * without processing the password further. A simple and secure way to
      * create a key for a particular Cipher is
      *
-     *  cipher = OpenSSL::Cipher::AES256.new(:CFB)
+     *  cipher = OpenSSL::Cipher.new('AES-256-CFB')
      *  cipher.encrypt
      *  key = cipher.random_key # also sets the generated key on the Cipher
      *
@@ -963,14 +947,14 @@ Init_ossl_cipher(void)
      *
      *   data = "Very, very confidential data"
      *
-     *   cipher = OpenSSL::Cipher::AES.new(128, :CBC)
+     *   cipher = OpenSSL::Cipher.new('AES-128-CBC')
      *   cipher.encrypt
      *   key = cipher.random_key
      *   iv = cipher.random_iv
      *
      *   encrypted = cipher.update(data) + cipher.final
      *   ...
-     *   decipher = OpenSSL::Cipher::AES.new(128, :CBC)
+     *   decipher = OpenSSL::Cipher.new('AES-128-CBC')
      *   decipher.decrypt
      *   decipher.key = key
      *   decipher.iv = iv
@@ -1006,7 +990,7 @@ Init_ossl_cipher(void)
      * not to reuse the _key_ and _nonce_ pair. Reusing an nonce ruins the
      * security guarantees of GCM mode.
      *
-     *   cipher = OpenSSL::Cipher::AES.new(128, :GCM).encrypt
+     *   cipher = OpenSSL::Cipher.new('AES-128-GCM').encrypt
      *   cipher.key = key
      *   cipher.iv = nonce
      *   cipher.auth_data = auth_data
@@ -1022,7 +1006,7 @@ Init_ossl_cipher(void)
      * ciphertext with a probability of 1/256.
      *
      *   raise "tag is truncated!" unless tag.bytesize == 16
-     *   decipher = OpenSSL::Cipher::AES.new(128, :GCM).decrypt
+     *   decipher = OpenSSL::Cipher.new('AES-128-GCM').decrypt
      *   decipher.key = key
      *   decipher.iv = nonce
      *   decipher.auth_tag = tag

--- a/ext/openssl/ossl_digest.c
+++ b/ext/openssl/ossl_digest.c
@@ -362,43 +362,6 @@ Init_ossl_digest(void)
      *
      *   digest = OpenSSL::Digest.new('SHA256')
      *
-     * === Mapping between Digest class and sn/ln
-     *
-     * The sn (short names) and ln (long names) are defined in
-     * <openssl/object.h> and <openssl/obj_mac.h>. They are textual
-     * representations of ASN.1 OBJECT IDENTIFIERs. Each supported digest
-     * algorithm has an OBJECT IDENTIFIER associated to it and those again
-     * have short/long names assigned to them.
-     * E.g. the OBJECT IDENTIFIER for SHA-1 is 1.3.14.3.2.26 and its
-     * sn is "SHA1" and its ln is "sha1".
-     * ==== MD2
-     * * sn: MD2
-     * * ln: md2
-     * ==== MD4
-     * * sn: MD4
-     * * ln: md4
-     * ==== MD5
-     * * sn: MD5
-     * * ln: md5
-     * ==== SHA
-     * * sn: SHA
-     * * ln: SHA
-     * ==== SHA-1
-     * * sn: SHA1
-     * * ln: sha1
-     * ==== SHA-224
-     * * sn: SHA224
-     * * ln: sha224
-     * ==== SHA-256
-     * * sn: SHA256
-     * * ln: sha256
-     * ==== SHA-384
-     * * sn: SHA384
-     * * ln: sha384
-     * ==== SHA-512
-     * * sn: SHA512
-     * * ln: sha512
-     *
      * "Breaking" a message digest algorithm means defying its one-way
      * function characteristics, i.e. producing a collision or finding a way
      * to get to the original data by means that are more efficient than

--- a/ext/openssl/ossl_digest.c
+++ b/ext/openssl/ossl_digest.c
@@ -192,7 +192,7 @@ ossl_digest_reset(VALUE self)
  * be passed individually to the Digest instance.
  *
  * === Example
- *   digest = OpenSSL::Digest::SHA256.new
+ *   digest = OpenSSL::Digest.new('SHA256')
  *   digest.update('First input')
  *   digest << 'Second input' # equivalent to digest.update('Second input')
  *   result = digest.digest
@@ -248,7 +248,7 @@ ossl_digest_finish(int argc, VALUE *argv, VALUE self)
  * Returns the sn of this Digest algorithm.
  *
  * === Example
- *   digest = OpenSSL::Digest::SHA512.new
+ *   digest = OpenSSL::Digest.new('SHA512')
  *   puts digest.name # => SHA512
  *
  */
@@ -270,7 +270,7 @@ ossl_digest_name(VALUE self)
  * final message digest result.
  *
  * === Example
- *   digest = OpenSSL::Digest::SHA1.new
+ *   digest = OpenSSL::Digest.new('SHA1')
  *   puts digest.digest_length # => 20
  *
  */
@@ -294,7 +294,7 @@ ossl_digest_size(VALUE self)
  * consecutively.
  *
  * === Example
- *   digest = OpenSSL::Digest::SHA1.new
+ *   digest = OpenSSL::Digest.new('SHA1')
  *   puts digest.block_length # => 64
  */
 static VALUE
@@ -348,15 +348,19 @@ Init_ossl_digest(void)
      * the integrity of a signed document, it suffices to re-compute the hash
      * and verify that it is equal to that in the signature.
      *
-     * Among the supported message digest algorithms are:
-     * * SHA, SHA1, SHA224, SHA256, SHA384 and SHA512
-     * * MD2, MD4, MDC2 and MD5
-     * * RIPEMD160
+     * You can get a list of all digest algorithms supported on your system by
+     * running this command in your terminal:
      *
-     * For each of these algorithms, there is a sub-class of Digest that
-     * can be instantiated as simply as e.g.
+     *   openssl list -digest-algorithms
      *
-     *   digest = OpenSSL::Digest::SHA1.new
+     * Among the OpenSSL 1.1.1 supported message digest algorithms are:
+     * * SHA224, SHA256, SHA384, SHA512, SHA512-224 and SHA512-256
+     * * SHA3-224, SHA3-256, SHA3-384 and SHA3-512
+     * * BLAKE2s256 and BLAKE2b512
+     *
+     * Each of these algorithms can be instantiated using the name:
+     *
+     *   digest = OpenSSL::Digest.new('SHA256')
      *
      * === Mapping between Digest class and sn/ln
      *
@@ -406,7 +410,7 @@ Init_ossl_digest(void)
      * === Hashing a file
      *
      *   data = File.read('document')
-     *   sha256 = OpenSSL::Digest::SHA256.new
+     *   sha256 = OpenSSL::Digest.new('SHA256')
      *   digest = sha256.digest(data)
      *
      * === Hashing several pieces of data at once
@@ -414,7 +418,7 @@ Init_ossl_digest(void)
      *   data1 = File.read('file1')
      *   data2 = File.read('file2')
      *   data3 = File.read('file3')
-     *   sha256 = OpenSSL::Digest::SHA256.new
+     *   sha256 = OpenSSL::Digest.new('SHA256')
      *   sha256 << data1
      *   sha256 << data2
      *   sha256 << data3
@@ -423,7 +427,7 @@ Init_ossl_digest(void)
      * === Reuse a Digest instance
      *
      *   data1 = File.read('file1')
-     *   sha256 = OpenSSL::Digest::SHA256.new
+     *   sha256 = OpenSSL::Digest.new('SHA256')
      *   digest1 = sha256.digest(data1)
      *
      *   data2 = File.read('file2')

--- a/ext/openssl/ossl_hmac.c
+++ b/ext/openssl/ossl_hmac.c
@@ -353,7 +353,7 @@ Init_ossl_hmac(void)
      *   data1 = File.read("file1")
      *   data2 = File.read("file2")
      *   key = "key"
-     *   digest = OpenSSL::Digest::SHA256.new
+     *   digest = OpenSSL::Digest.new('SHA256')
      *   hmac = OpenSSL::HMAC.new(key, digest)
      *   hmac << data1
      *   hmac << data2

--- a/ext/openssl/ossl_kdf.c
+++ b/ext/openssl/ossl_kdf.c
@@ -272,7 +272,7 @@ Init_ossl_kdf(void)
      *   # store this with the generated value
      *   salt = OpenSSL::Random.random_bytes(16)
      *   iter = 20_000
-     *   hash = OpenSSL::Digest::SHA256.new
+     *   hash = OpenSSL::Digest.new('SHA256')
      *   len = hash.digest_length
      *   # the final value to be stored
      *   value = OpenSSL::KDF.pbkdf2_hmac(pass, salt: salt, iterations: iter,

--- a/ext/openssl/ossl_ns_spki.c
+++ b/ext/openssl/ossl_ns_spki.c
@@ -350,7 +350,7 @@ ossl_spki_verify(VALUE self, VALUE key)
  *   spki = OpenSSL::Netscape::SPKI.new
  *   spki.challenge = "RandomChallenge"
  *   spki.public_key = key.public_key
- *   spki.sign(key, OpenSSL::Digest::SHA256.new)
+ *   spki.sign(key, OpenSSL::Digest.new('SHA256'))
  *   #send a request containing this to a server generating a certificate
  * === Verifying an SPKI request
  *   request = #...

--- a/ext/openssl/ossl_ocsp.c
+++ b/ext/openssl/ossl_ocsp.c
@@ -1719,7 +1719,7 @@ Init_ossl_ocsp(void)
      * subject certificate so the CA knows which certificate we are asking
      * about:
      *
-     *   digest = OpenSSL::Digest::SHA1.new
+     *   digest = OpenSSL::Digest.new('SHA1')
      *   certificate_id =
      *     OpenSSL::OCSP::CertificateId.new subject, issuer, digest
      *

--- a/ext/openssl/ossl_pkey.c
+++ b/ext/openssl/ossl_pkey.c
@@ -430,7 +430,7 @@ ossl_pkey_public_to_pem(VALUE self)
  *
  * == Example
  *   data = 'Sign me!'
- *   digest = OpenSSL::Digest::SHA256.new
+ *   digest = OpenSSL::Digest.new('SHA256')
  *   pkey = OpenSSL::PKey::RSA.new(2048)
  *   signature = pkey.sign(digest, data)
  */
@@ -484,7 +484,7 @@ ossl_pkey_sign(VALUE self, VALUE digest, VALUE data)
  *
  * == Example
  *   data = 'Sign me!'
- *   digest = OpenSSL::Digest::SHA256.new
+ *   digest = OpenSSL::Digest.new('SHA256')
  *   pkey = OpenSSL::PKey::RSA.new(2048)
  *   signature = pkey.sign(digest, data)
  *   pub_key = pkey.public_key

--- a/ext/openssl/ossl_pkey_dsa.c
+++ b/ext/openssl/ossl_pkey_dsa.c
@@ -513,7 +513,7 @@ ossl_dsa_to_public_key(VALUE self)
  * === Example
  *  dsa = OpenSSL::PKey::DSA.new(2048)
  *  doc = "Sign me"
- *  digest = OpenSSL::Digest::SHA1.digest(doc)
+ *  digest = OpenSSL::Digest.digest('SHA1', doc)
  *  sig = dsa.syssign(digest)
  *
  *
@@ -558,7 +558,7 @@ ossl_dsa_sign(VALUE self, VALUE data)
  * === Example
  *  dsa = OpenSSL::PKey::DSA.new(2048)
  *  doc = "Sign me"
- *  digest = OpenSSL::Digest::SHA1.digest(doc)
+ *  digest = OpenSSL::Digest.digest('SHA1', doc)
  *  sig = dsa.syssign(digest)
  *  puts dsa.sysverify(digest, sig) # => true
  *

--- a/ext/openssl/ossl_ts.c
+++ b/ext/openssl/ossl_ts.c
@@ -1281,7 +1281,7 @@ Init_ossl_ts(void)
      *      #Assumes ts.p12 is a PKCS#12-compatible file with a private key
      *      #and a certificate that has an extended key usage of 'timeStamping'
      *      p12 = OpenSSL::PKCS12.new(File.open('ts.p12', 'rb'), 'pwd')
-     *      md = OpenSSL::Digest::SHA1.new
+     *      md = OpenSSL::Digest.new('SHA1')
      *      hash = md.digest(data) #some binary data to be timestamped
      *      req = OpenSSL::Timestamp::Request.new
      *      req.algorithm = 'SHA1'
@@ -1498,8 +1498,8 @@ Init_ossl_ts(void)
      * Must be an Array of String or OpenSSL::Digest subclass instances.
      *
      * call-seq:
-     *       factory.allowed_digests = ["sha1", OpenSSL::Digest::SHA256.new] -> [ "sha1", OpenSSL::Digest::SHA256.new ]
-     *       factory.allowed_digests                                         -> array or nil
+     *       factory.allowed_digests = ["sha1", OpenSSL::Digest.new('SHA256').new] -> [ "sha1", OpenSSL::Digest) ]
+     *       factory.allowed_digests                                               -> array or nil
      *
      */
     cTimestampFactory = rb_define_class_under(mTimestamp, "Factory", rb_cObject);

--- a/ext/openssl/ossl_x509cert.c
+++ b/ext/openssl/ossl_x509cert.c
@@ -788,7 +788,7 @@ Init_ossl_x509cert(void)
      *   root_ca.add_extension(ef.create_extension("keyUsage","keyCertSign, cRLSign", true))
      *   root_ca.add_extension(ef.create_extension("subjectKeyIdentifier","hash",false))
      *   root_ca.add_extension(ef.create_extension("authorityKeyIdentifier","keyid:always",false))
-     *   root_ca.sign(root_key, OpenSSL::Digest::SHA256.new)
+     *   root_ca.sign(root_key, OpenSSL::Digest.new('SHA256'))
      *
      * The next step is to create the end-entity certificate using the root CA
      * certificate.
@@ -807,7 +807,7 @@ Init_ossl_x509cert(void)
      *   ef.issuer_certificate = root_ca
      *   cert.add_extension(ef.create_extension("keyUsage","digitalSignature", true))
      *   cert.add_extension(ef.create_extension("subjectKeyIdentifier","hash",false))
-     *   cert.sign(root_key, OpenSSL::Digest::SHA256.new)
+     *   cert.sign(root_key, OpenSSL::Digest.new('SHA256'))
      *
      */
     cX509Cert = rb_define_class_under(mX509, "Certificate", rb_cObject);

--- a/lib/openssl.rb
+++ b/lib/openssl.rb
@@ -31,8 +31,8 @@ module OpenSSL
   # the length of the secret. Returns +true+ if the strings are identical,
   # +false+ otherwise.
   def self.secure_compare(a, b)
-    hashed_a = OpenSSL::Digest::SHA256.digest(a)
-    hashed_b = OpenSSL::Digest::SHA256.digest(b)
+    hashed_a = OpenSSL::Digest.digest('SHA256', a)
+    hashed_b = OpenSSL::Digest.digest('SHA256', b)
     OpenSSL.fixed_length_secure_compare(hashed_a, hashed_b) && a == b
   end
 end

--- a/lib/openssl/digest.rb
+++ b/lib/openssl/digest.rb
@@ -15,17 +15,6 @@
 module OpenSSL
   class Digest
 
-    # You can get a list of all algorithms:
-    #   openssl list -digest-algorithms
-
-    ALGORITHMS = %w(MD4 MD5 RIPEMD160 SHA1 SHA224 SHA256 SHA384 SHA512)
-
-    if !OPENSSL_VERSION.include?("LibreSSL") && OPENSSL_VERSION_NUMBER > 0x10101000
-      ALGORITHMS.concat %w(BLAKE2b512 BLAKE2s256 SHA3-224 SHA3-256 SHA3-384 SHA3-512 SHA512-224 SHA512-256)
-    end
-
-    ALGORITHMS.freeze
-
     # Return the hash value computed with _name_ Digest. _name_ is either the
     # long name or short name of a supported digest algorithm.
     #
@@ -35,13 +24,13 @@ module OpenSSL
     #
     # which is equivalent to:
     #
-    #   OpenSSL::Digest::SHA256.digest("abc")
+    #   OpenSSL::Digest.digest('SHA256', "abc")
 
     def self.digest(name, data)
       super(data, name)
     end
 
-    ALGORITHMS.each do |name|
+    %w(MD4 MD5 RIPEMD160 SHA1 SHA224 SHA256 SHA384 SHA512).each do |name|
       klass = Class.new(self) {
         define_method(:initialize, ->(data = nil) {super(name, data)})
       }

--- a/sample/c_rehash.rb
+++ b/sample/c_rehash.rb
@@ -161,7 +161,7 @@ private
   end
 
   def fingerprint(der)
-    Digest::MD5.hexdigest(der).upcase
+    Digest.hexdigest('MD5', der).upcase
   end
 end
 

--- a/sample/echo_svr.rb
+++ b/sample/echo_svr.rb
@@ -37,7 +37,7 @@ else
   ef.issuer_certificate = cert
   cert.add_extension ef.create_extension("authorityKeyIdentifier",
                                          "keyid:always,issuer:always")
-  cert.sign(key, OpenSSL::Digest::SHA1.new)
+  cert.sign(key, OpenSSL::Digest.new('SHA1'))
 end
 
 ctx = OpenSSL::SSL::SSLContext.new()

--- a/sample/gen_csr.rb
+++ b/sample/gen_csr.rb
@@ -41,7 +41,7 @@ req = X509::Request.new
 req.version = 0
 req.subject = name
 req.public_key = keypair.public_key
-req.sign(keypair, Digest::MD5.new)
+req.sign(keypair, Digest.new('MD5'))
 
 puts "Writing #{csrout}..."
 File.open(csrout, "w") do |f|

--- a/test/openssl/test_asn1.rb
+++ b/test/openssl/test_asn1.rb
@@ -14,7 +14,7 @@ class  OpenSSL::TestASN1 < OpenSSL::TestCase
       ["keyUsage","keyCertSign, cRLSign",true],
       ["subjectKeyIdentifier","hash",false],
     ]
-    dgst = OpenSSL::Digest::SHA1.new
+    dgst = OpenSSL::Digest.new('SHA1')
     cert = OpenSSL::TestUtils.issue_cert(
       subj, key, s, exts, nil, nil, digest: dgst, not_before: now, not_after: now+3600)
 
@@ -178,7 +178,7 @@ class  OpenSSL::TestASN1 < OpenSSL::TestCase
     assert_equal(OpenSSL::ASN1::OctetString, ext.value[1].class)
     extv = OpenSSL::ASN1.decode(ext.value[1].value)
     assert_equal(OpenSSL::ASN1::OctetString, extv.class)
-    sha1 = OpenSSL::Digest::SHA1.new
+    sha1 = OpenSSL::Digest.new('SHA1')
     sha1.update(pkey.value[1].value)
     assert_equal(sha1.digest, extv.value)
 
@@ -189,7 +189,7 @@ class  OpenSSL::TestASN1 < OpenSSL::TestCase
     assert_equal(OpenSSL::ASN1::Null, pkey.value[0].value[1].class)
 
     assert_equal(OpenSSL::ASN1::BitString, sig_val.class)
-    cululated_sig = key.sign(OpenSSL::Digest::SHA1.new, tbs_cert.to_der)
+    cululated_sig = key.sign(OpenSSL::Digest.new('SHA1'), tbs_cert.to_der)
     assert_equal(cululated_sig, sig_val.value)
   end
 

--- a/test/openssl/test_cipher.rb
+++ b/test/openssl/test_cipher.rb
@@ -36,8 +36,8 @@ class OpenSSL::TestCipher < OpenSSL::TestCase
     cipher.pkcs5_keyivgen(pass, salt, num, "MD5")
     s1 = cipher.update(pt) << cipher.final
 
-    d1 = num.times.inject(pass + salt) {|out, _| OpenSSL::Digest::MD5.digest(out) }
-    d2 = num.times.inject(d1 + pass + salt) {|out, _| OpenSSL::Digest::MD5.digest(out) }
+    d1 = num.times.inject(pass + salt) {|out, _| OpenSSL::Digest.digest('MD5', out) }
+    d2 = num.times.inject(d1 + pass + salt) {|out, _| OpenSSL::Digest.digest('MD5', out) }
     key = (d1 + d2)[0, 24]
     iv = (d1 + d2)[24, 8]
     cipher = new_encryptor("DES-EDE3-CBC", key: key, iv: iv)

--- a/test/openssl/test_cipher.rb
+++ b/test/openssl/test_cipher.rb
@@ -148,12 +148,12 @@ class OpenSSL::TestCipher < OpenSSL::TestCase
   def test_AES
     pt = File.read(__FILE__)
     %w(ECB CBC CFB OFB).each{|mode|
-      c1 = OpenSSL::Cipher::AES256.new(mode)
+      c1 = OpenSSL::Cipher.new("AES-256-#{mode}")
       c1.encrypt
       c1.pkcs5_keyivgen("passwd")
       ct = c1.update(pt) + c1.final
 
-      c2 = OpenSSL::Cipher::AES256.new(mode)
+      c2 = OpenSSL::Cipher.new("AES-256-#{mode}")
       c2.decrypt
       c2.pkcs5_keyivgen("passwd")
       assert_equal(pt, c2.update(ct) + c2.final)
@@ -163,7 +163,7 @@ class OpenSSL::TestCipher < OpenSSL::TestCase
   def test_update_raise_if_key_not_set
     assert_raise(OpenSSL::Cipher::CipherError) do
       # it caused OpenSSL SEGV by uninitialized key [Bug #2768]
-      OpenSSL::Cipher::AES128.new("ECB").update "." * 17
+      OpenSSL::Cipher.new("AES-128-ECB").update "." * 17
     end
   end
 

--- a/test/openssl/test_digest.rb
+++ b/test/openssl/test_digest.rb
@@ -21,8 +21,8 @@ class OpenSSL::TestDigest < OpenSSL::TestCase
     @d1 << data
     assert_equal(bin, @d1.digest)
     assert_equal(hex, @d1.hexdigest)
-    assert_equal(bin, OpenSSL::Digest::MD5.digest(data))
-    assert_equal(hex, OpenSSL::Digest::MD5.hexdigest(data))
+    assert_equal(bin, OpenSSL::Digest.digest('MD5', data))
+    assert_equal(hex, OpenSSL::Digest.hexdigest('MD5', data))
   end
 
   def test_eql
@@ -53,19 +53,8 @@ class OpenSSL::TestDigest < OpenSSL::TestCase
     assert_equal(dig1, dig2, "reset")
   end
 
-  def test_required_digests
-    algorithms = OpenSSL::Digest::ALGORITHMS
-    required = %w{MD4 MD5 RIPEMD160 SHA1 SHA224 SHA256 SHA384 SHA512}
-
-    required.each do |name|
-      assert_include(algorithms, name)
-    end
-  end
-
   def test_digest_constants
-    algorithms = OpenSSL::Digest::ALGORITHMS
-
-    algorithms.each do |name|
+    %w{MD4 MD5 RIPEMD160 SHA1 SHA224 SHA256 SHA384 SHA512}.each do |name|
       assert_not_nil(OpenSSL::Digest.new(name))
       klass = OpenSSL::Digest.const_get(name.tr('-', '_'))
       assert_not_nil(klass.new)
@@ -87,39 +76,39 @@ class OpenSSL::TestDigest < OpenSSL::TestCase
     sha384_a = "54a59b9f22b0b80880d8427e548b7c23abd873486e1f035dce9cd697e85175033caa88e6d57bc35efae0b5afd3145f31"
     sha512_a = "1f40fc92da241694750979ee6cf582f2d5d7d28e18335de05abc54d0560e0f5302860c652bf08d560252aa5e74210546f369fbbbce8c12cfc7957b2652fe9a75"
 
-    assert_equal(sha224_a, OpenSSL::Digest::SHA224.hexdigest("a"))
-    assert_equal(sha256_a, OpenSSL::Digest::SHA256.hexdigest("a"))
-    assert_equal(sha384_a, OpenSSL::Digest::SHA384.hexdigest("a"))
-    assert_equal(sha512_a, OpenSSL::Digest::SHA512.hexdigest("a"))
+    assert_equal(sha224_a, OpenSSL::Digest.hexdigest('SHA224', "a"))
+    assert_equal(sha256_a, OpenSSL::Digest.hexdigest('SHA256', "a"))
+    assert_equal(sha384_a, OpenSSL::Digest.hexdigest('SHA384', "a"))
+    assert_equal(sha512_a, OpenSSL::Digest.hexdigest('SHA512', "a"))
 
-    assert_equal(sha224_a, encode16(OpenSSL::Digest::SHA224.digest("a")))
-    assert_equal(sha256_a, encode16(OpenSSL::Digest::SHA256.digest("a")))
-    assert_equal(sha384_a, encode16(OpenSSL::Digest::SHA384.digest("a")))
-    assert_equal(sha512_a, encode16(OpenSSL::Digest::SHA512.digest("a")))
+    assert_equal(sha224_a, encode16(OpenSSL::Digest.digest('SHA224', "a")))
+    assert_equal(sha256_a, encode16(OpenSSL::Digest.digest('SHA256', "a")))
+    assert_equal(sha384_a, encode16(OpenSSL::Digest.digest('SHA384', "a")))
+    assert_equal(sha512_a, encode16(OpenSSL::Digest.digest('SHA512', "a")))
   end
 
   def test_sha512_truncate
-    pend "SHA512_224 is not implemented" unless OpenSSL::Digest.const_defined?(:SHA512_224)
+    pend "SHA512_224 is not implemented" unless digest_available?('SHA512-224')
     sha512_224_a = "d5cdb9ccc769a5121d4175f2bfdd13d6310e0d3d361ea75d82108327"
     sha512_256_a = "455e518824bc0601f9fb858ff5c37d417d67c2f8e0df2babe4808858aea830f8"
 
-    assert_equal(sha512_224_a, OpenSSL::Digest::SHA512_224.hexdigest("a"))
-    assert_equal(sha512_256_a, OpenSSL::Digest::SHA512_256.hexdigest("a"))
+    assert_equal(sha512_224_a, OpenSSL::Digest.hexdigest('SHA512-224', "a"))
+    assert_equal(sha512_256_a, OpenSSL::Digest.hexdigest('SHA512-256', "a"))
 
-    assert_equal(sha512_224_a, encode16(OpenSSL::Digest::SHA512_224.digest("a")))
-    assert_equal(sha512_256_a, encode16(OpenSSL::Digest::SHA512_256.digest("a")))
+    assert_equal(sha512_224_a, encode16(OpenSSL::Digest.digest('SHA512-224', "a")))
+    assert_equal(sha512_256_a, encode16(OpenSSL::Digest.digest('SHA512-256', "a")))
   end
 
   def test_sha3
-    pend "SHA3 is not implemented" unless OpenSSL::Digest.const_defined?(:SHA3_224)
+    pend "SHA3 is not implemented" unless digest_available?('SHA3-224')
     s224 = '6b4e03423667dbb73b6e15454f0eb1abd4597f9a1b078e3f5b5a6bc7'
     s256 = 'a7ffc6f8bf1ed76651c14756a061d662f580ff4de43b49fa82d80a4b80f8434a'
     s384 = '0c63a75b845e4f7d01107d852e4c2485c51a50aaaa94fc61995e71bbee983a2ac3713831264adb47fb6bd1e058d5f004'
     s512 = 'a69f73cca23a9ac5c8b567dc185a756e97c982164fe25859e0d1dcc1475c80a615b2123af1f5f94c11e3e9402c3ac558f500199d95b6d3e301758586281dcd26'
-    assert_equal(OpenSSL::Digest::SHA3_224.hexdigest(""), s224)
-    assert_equal(OpenSSL::Digest::SHA3_256.hexdigest(""), s256)
-    assert_equal(OpenSSL::Digest::SHA3_384.hexdigest(""), s384)
-    assert_equal(OpenSSL::Digest::SHA3_512.hexdigest(""), s512)
+    assert_equal(OpenSSL::Digest.hexdigest('SHA3-224', ""), s224)
+    assert_equal(OpenSSL::Digest.hexdigest('SHA3-256', ""), s256)
+    assert_equal(OpenSSL::Digest.hexdigest('SHA3-384', ""), s384)
+    assert_equal(OpenSSL::Digest.hexdigest('SHA3-512', ""), s512)
   end
 
   def test_digest_by_oid_and_name_sha2
@@ -146,6 +135,14 @@ class OpenSSL::TestDigest < OpenSSL::TestCase
     assert_not_nil(d)
     d = OpenSSL::Digest.new(oid.oid)
     assert_not_nil(d)
+  end
+
+  def digest_available?(name)
+    begin
+      OpenSSL::Digest.new(name)
+    rescue RuntimeError
+      false
+    end
   end
 end
 

--- a/test/openssl/test_engine.rb
+++ b/test/openssl/test_engine.rb
@@ -47,7 +47,7 @@ class OpenSSL::TestEngine < OpenSSL::TestCase
       digest = engine.digest("SHA1")
       assert_not_nil(digest)
       data = "test"
-      assert_equal(OpenSSL::Digest::SHA1.digest(data), digest.digest(data))
+      assert_equal(OpenSSL::Digest.digest('SHA1', data), digest.digest(data))
     end;
   end
 

--- a/test/openssl/test_ns_spki.rb
+++ b/test/openssl/test_ns_spki.rb
@@ -22,7 +22,7 @@ class OpenSSL::TestNSSPI < OpenSSL::TestCase
     spki = OpenSSL::Netscape::SPKI.new
     spki.challenge = "RandomString"
     spki.public_key = key1.public_key
-    spki.sign(key1, OpenSSL::Digest::SHA1.new)
+    spki.sign(key1, OpenSSL::Digest.new('SHA1'))
     assert(spki.verify(spki.public_key))
     assert(spki.verify(key1.public_key))
     assert(!spki.verify(key2.public_key))

--- a/test/openssl/test_ocsp.rb
+++ b/test/openssl/test_ocsp.rb
@@ -50,26 +50,26 @@ class OpenSSL::TestOCSP < OpenSSL::TestCase
     cid = OpenSSL::OCSP::CertificateId.new(@cert, @ca_cert)
     assert_kind_of OpenSSL::OCSP::CertificateId, cid
     assert_equal @cert.serial, cid.serial
-    cid = OpenSSL::OCSP::CertificateId.new(@cert, @ca_cert, OpenSSL::Digest::SHA256.new)
+    cid = OpenSSL::OCSP::CertificateId.new(@cert, @ca_cert, OpenSSL::Digest.new('SHA256'))
     assert_kind_of OpenSSL::OCSP::CertificateId, cid
     assert_equal @cert.serial, cid.serial
   end
 
   def test_certificate_id_issuer_name_hash
     cid = OpenSSL::OCSP::CertificateId.new(@cert, @ca_cert)
-    assert_equal OpenSSL::Digest::SHA1.hexdigest(@cert.issuer.to_der), cid.issuer_name_hash
+    assert_equal OpenSSL::Digest.hexdigest('SHA1', @cert.issuer.to_der), cid.issuer_name_hash
     assert_equal "d91f736ac4dc3242f0fb9b77a3149bd83c5c43d0", cid.issuer_name_hash
   end
 
   def test_certificate_id_issuer_key_hash
     cid = OpenSSL::OCSP::CertificateId.new(@cert, @ca_cert)
-    assert_equal OpenSSL::Digest::SHA1.hexdigest(OpenSSL::ASN1.decode(@ca_cert.to_der).value[0].value[6].value[1].value), cid.issuer_key_hash
+    assert_equal OpenSSL::Digest.hexdigest('SHA1', OpenSSL::ASN1.decode(@ca_cert.to_der).value[0].value[6].value[1].value), cid.issuer_key_hash
     assert_equal "d1fef9fbf8ae1bc160cbfa03e2596dd873089213", cid.issuer_key_hash
   end
 
   def test_certificate_id_hash_algorithm
-    cid_sha1 = OpenSSL::OCSP::CertificateId.new(@cert, @ca_cert, OpenSSL::Digest::SHA1.new)
-    cid_sha256 = OpenSSL::OCSP::CertificateId.new(@cert, @ca_cert, OpenSSL::Digest::SHA256.new)
+    cid_sha1 = OpenSSL::OCSP::CertificateId.new(@cert, @ca_cert, OpenSSL::Digest.new('SHA1'))
+    cid_sha256 = OpenSSL::OCSP::CertificateId.new(@cert, @ca_cert, OpenSSL::Digest.new('SHA256'))
     assert_equal "sha1", cid_sha1.hash_algorithm
     assert_equal "sha256", cid_sha256.hash_algorithm
   end
@@ -94,7 +94,7 @@ class OpenSSL::TestOCSP < OpenSSL::TestCase
 
   def test_request_der
     request = OpenSSL::OCSP::Request.new
-    cid = OpenSSL::OCSP::CertificateId.new(@cert, @ca_cert, OpenSSL::Digest::SHA1.new)
+    cid = OpenSSL::OCSP::CertificateId.new(@cert, @ca_cert, OpenSSL::Digest.new('SHA1'))
     request.add_certid(cid)
     request.sign(@cert, @cert_key, [@ca_cert], 0)
     asn1 = OpenSSL::ASN1.decode(request.to_der)
@@ -164,14 +164,14 @@ class OpenSSL::TestOCSP < OpenSSL::TestCase
 
   def test_request_dup
     request = OpenSSL::OCSP::Request.new
-    cid = OpenSSL::OCSP::CertificateId.new(@cert, @ca_cert, OpenSSL::Digest::SHA1.new)
+    cid = OpenSSL::OCSP::CertificateId.new(@cert, @ca_cert, OpenSSL::Digest.new('SHA1'))
     request.add_certid(cid)
     assert_equal request.to_der, request.dup.to_der
   end
 
   def test_basic_response_der
     bres = OpenSSL::OCSP::BasicResponse.new
-    cid = OpenSSL::OCSP::CertificateId.new(@cert, @ca_cert, OpenSSL::Digest::SHA1.new)
+    cid = OpenSSL::OCSP::CertificateId.new(@cert, @ca_cert, OpenSSL::Digest.new('SHA1'))
     bres.add_status(cid, OpenSSL::OCSP::V_CERTSTATUS_GOOD, 0, nil, -300, 500, [])
     bres.add_nonce("NONCE")
     bres.sign(@ocsp_cert, @ocsp_key, [@ca_cert], 0)
@@ -214,7 +214,7 @@ class OpenSSL::TestOCSP < OpenSSL::TestCase
 
   def test_basic_response_dup
     bres = OpenSSL::OCSP::BasicResponse.new
-    cid = OpenSSL::OCSP::CertificateId.new(@cert, @ca_cert, OpenSSL::Digest::SHA1.new)
+    cid = OpenSSL::OCSP::CertificateId.new(@cert, @ca_cert, OpenSSL::Digest.new('SHA1'))
     bres.add_status(cid, OpenSSL::OCSP::V_CERTSTATUS_GOOD, 0, nil, -300, 500, [])
     bres.sign(@ocsp_cert, @ocsp_key, [@ca_cert], 0)
     assert_equal bres.to_der, bres.dup.to_der
@@ -223,9 +223,9 @@ class OpenSSL::TestOCSP < OpenSSL::TestCase
   def test_basic_response_response_operations
     bres = OpenSSL::OCSP::BasicResponse.new
     now = Time.at(Time.now.to_i)
-    cid1 = OpenSSL::OCSP::CertificateId.new(@cert, @ca_cert, OpenSSL::Digest::SHA1.new)
-    cid2 = OpenSSL::OCSP::CertificateId.new(@ocsp_cert, @ca_cert, OpenSSL::Digest::SHA1.new)
-    cid3 = OpenSSL::OCSP::CertificateId.new(@ca_cert, @ca_cert, OpenSSL::Digest::SHA1.new)
+    cid1 = OpenSSL::OCSP::CertificateId.new(@cert, @ca_cert, OpenSSL::Digest.new('SHA1'))
+    cid2 = OpenSSL::OCSP::CertificateId.new(@ocsp_cert, @ca_cert, OpenSSL::Digest.new('SHA1'))
+    cid3 = OpenSSL::OCSP::CertificateId.new(@ca_cert, @ca_cert, OpenSSL::Digest.new('SHA1'))
     bres.add_status(cid1, OpenSSL::OCSP::V_CERTSTATUS_REVOKED, OpenSSL::OCSP::REVOKED_STATUS_UNSPECIFIED, now - 400, -300, nil, nil)
     bres.add_status(cid2, OpenSSL::OCSP::V_CERTSTATUS_GOOD, nil, nil, -300, 500, [])
 
@@ -257,8 +257,8 @@ class OpenSSL::TestOCSP < OpenSSL::TestCase
 
   def test_single_response_check_validity
     bres = OpenSSL::OCSP::BasicResponse.new
-    cid1 = OpenSSL::OCSP::CertificateId.new(@cert, @ca_cert, OpenSSL::Digest::SHA1.new)
-    cid2 = OpenSSL::OCSP::CertificateId.new(@ocsp_cert, @ca_cert, OpenSSL::Digest::SHA1.new)
+    cid1 = OpenSSL::OCSP::CertificateId.new(@cert, @ca_cert, OpenSSL::Digest.new('SHA1'))
+    cid2 = OpenSSL::OCSP::CertificateId.new(@ocsp_cert, @ca_cert, OpenSSL::Digest.new('SHA1'))
     bres.add_status(cid1, OpenSSL::OCSP::V_CERTSTATUS_REVOKED, OpenSSL::OCSP::REVOKED_STATUS_UNSPECIFIED, -400, -300, -50, [])
     bres.add_status(cid2, OpenSSL::OCSP::V_CERTSTATUS_REVOKED, OpenSSL::OCSP::REVOKED_STATUS_UNSPECIFIED, -400, -300, nil, [])
     bres.add_status(cid2, OpenSSL::OCSP::V_CERTSTATUS_GOOD, nil, nil, Time.now + 100, nil, nil)
@@ -277,7 +277,7 @@ class OpenSSL::TestOCSP < OpenSSL::TestCase
 
   def test_response
     bres = OpenSSL::OCSP::BasicResponse.new
-    cid = OpenSSL::OCSP::CertificateId.new(@cert, @ca_cert, OpenSSL::Digest::SHA1.new)
+    cid = OpenSSL::OCSP::CertificateId.new(@cert, @ca_cert, OpenSSL::Digest.new('SHA1'))
     bres.add_status(cid, OpenSSL::OCSP::V_CERTSTATUS_GOOD, 0, nil, -300, 500, [])
     bres.sign(@ocsp_cert, @ocsp_key, [])
     res = OpenSSL::OCSP::Response.create(OpenSSL::OCSP::RESPONSE_STATUS_SUCCESSFUL, bres)
@@ -288,7 +288,7 @@ class OpenSSL::TestOCSP < OpenSSL::TestCase
 
   def test_response_der
     bres = OpenSSL::OCSP::BasicResponse.new
-    cid = OpenSSL::OCSP::CertificateId.new(@cert, @ca_cert, OpenSSL::Digest::SHA1.new)
+    cid = OpenSSL::OCSP::CertificateId.new(@cert, @ca_cert, OpenSSL::Digest.new('SHA1'))
     bres.add_status(cid, OpenSSL::OCSP::V_CERTSTATUS_GOOD, 0, nil, -300, 500, [])
     bres.sign(@ocsp_cert, @ocsp_key, [@ca_cert], 0)
     res = OpenSSL::OCSP::Response.create(OpenSSL::OCSP::RESPONSE_STATUS_SUCCESSFUL, bres)

--- a/test/openssl/test_ossl.rb
+++ b/test/openssl/test_ossl.rb
@@ -12,7 +12,7 @@ class OpenSSL::OSSL < OpenSSL::SSLTestCase
 
     assert OpenSSL.fixed_length_secure_compare("aaa", "aaa")
     assert OpenSSL.fixed_length_secure_compare(
-      OpenSSL::Digest::SHA256.digest("aaa"), OpenSSL::Digest::SHA256.digest("aaa")
+      OpenSSL::Digest.digest('SHA256', "aaa"), OpenSSL::Digest::SHA256.digest("aaa")
     )
 
     assert_raise(ArgumentError) { OpenSSL.fixed_length_secure_compare("aaa", "aaaa") }

--- a/test/openssl/test_pkey_dsa.rb
+++ b/test/openssl/test_pkey_dsa.rb
@@ -37,8 +37,8 @@ class OpenSSL::TestPKeyDSA < OpenSSL::PKeyTestCase
     dsa512 = Fixtures.pkey("dsa512")
     data = "Sign me!"
     if defined?(OpenSSL::Digest::DSS1)
-      signature = dsa512.sign(OpenSSL::Digest::DSS1.new, data)
-      assert_equal true, dsa512.verify(OpenSSL::Digest::DSS1.new, signature, data)
+      signature = dsa512.sign(OpenSSL::Digest.new('DSS1'), data)
+      assert_equal true, dsa512.verify(OpenSSL::Digest.new('DSS1'), signature, data)
     end
 
     signature = dsa512.sign("SHA1", data)
@@ -56,7 +56,7 @@ class OpenSSL::TestPKeyDSA < OpenSSL::PKeyTestCase
   def test_sys_sign_verify
     key = Fixtures.pkey("dsa256")
     data = 'Sign me!'
-    digest = OpenSSL::Digest::SHA1.digest(data)
+    digest = OpenSSL::Digest.digest('SHA1', data)
     sig = key.syssign(digest)
     assert(key.sysverify(digest, sig))
   end

--- a/test/openssl/test_pkey_rsa.rb
+++ b/test/openssl/test_pkey_rsa.rb
@@ -7,7 +7,7 @@ class OpenSSL::TestPKeyRSA < OpenSSL::PKeyTestCase
   def test_no_private_exp
     key = OpenSSL::PKey::RSA.new
     rsa = Fixtures.pkey("rsa2048")
-    key.set_key(rsa.n, rsa.e, nil) 
+    key.set_key(rsa.n, rsa.e, nil)
     key.set_factors(rsa.p, rsa.q)
     assert_raise(OpenSSL::PKey::RSAError){ key.private_encrypt("foo") }
     assert_raise(OpenSSL::PKey::RSAError){ key.private_decrypt("foo") }
@@ -119,8 +119,8 @@ class OpenSSL::TestPKeyRSA < OpenSSL::PKeyTestCase
 
   def test_digest_state_irrelevant_sign
     key = Fixtures.pkey("rsa1024")
-    digest1 = OpenSSL::Digest::SHA1.new
-    digest2 = OpenSSL::Digest::SHA1.new
+    digest1 = OpenSSL::Digest.new('SHA1')
+    digest2 = OpenSSL::Digest.new('SHA1')
     data = 'Sign me!'
     digest1 << 'Change state of digest1'
     sig1 = key.sign(digest1, data)
@@ -130,8 +130,8 @@ class OpenSSL::TestPKeyRSA < OpenSSL::PKeyTestCase
 
   def test_digest_state_irrelevant_verify
     key = Fixtures.pkey("rsa1024")
-    digest1 = OpenSSL::Digest::SHA1.new
-    digest2 = OpenSSL::Digest::SHA1.new
+    digest1 = OpenSSL::Digest.new('SHA1')
+    digest2 = OpenSSL::Digest.new('SHA1')
     data = 'Sign me!'
     sig = key.sign(digest1, data)
     digest1.reset

--- a/test/openssl/test_ts.rb
+++ b/test/openssl/test_ts.rb
@@ -77,7 +77,7 @@ _end_of_pem_
     assert_raise(OpenSSL::Timestamp::TimestampError) do
       req.to_der
     end
-    req.message_imprint = OpenSSL::Digest::SHA1.new.digest("data")
+    req.message_imprint = OpenSSL::Digest.digest('SHA1', "data")
     req.to_der
   end
 
@@ -160,7 +160,7 @@ _end_of_pem_
   def test_request_encode_decode
     req = OpenSSL::Timestamp::Request.new
     req.algorithm = "SHA1"
-    digest = OpenSSL::Digest::SHA1.new.digest("test")
+    digest = OpenSSL::Digest.digest('SHA1', "test")
     req.message_imprint = digest
     req.policy_id = "1.2.3.4.5"
     req.nonce = 42
@@ -193,7 +193,7 @@ _end_of_pem_
   def test_response_creation
     req = OpenSSL::Timestamp::Request.new
     req.algorithm = "SHA1"
-    digest = OpenSSL::Digest::SHA1.new.digest("test")
+    digest = OpenSSL::Digest.digest('SHA1', "test")
     req.message_imprint = digest
     req.policy_id = "1.2.3.4.5"
 
@@ -232,7 +232,7 @@ _end_of_pem_
     assert_raise(OpenSSL::Timestamp::TimestampError) do
       fac.create_timestamp(ee_key, ts_cert_ee, req)
     end
-    req.message_imprint = OpenSSL::Digest::SHA1.new.digest("data")
+    req.message_imprint = OpenSSL::Digest.digest('SHA1', "data")
     assert_raise(OpenSSL::Timestamp::TimestampError) do
       fac.create_timestamp(ee_key, ts_cert_ee, req)
     end
@@ -258,7 +258,7 @@ _end_of_pem_
   def test_response_allowed_digests
     req = OpenSSL::Timestamp::Request.new
     req.algorithm = "SHA1"
-    req.message_imprint = OpenSSL::Digest::SHA1.digest("test")
+    req.message_imprint = OpenSSL::Digest.digest('SHA1', "test")
 
     fac = OpenSSL::Timestamp::Factory.new
     fac.gen_time = Time.now
@@ -275,13 +275,13 @@ _end_of_pem_
     assert_equal OpenSSL::Timestamp::Response::GRANTED, resp.status
 
     # Explicitly allow SHA1 (object)
-    fac.allowed_digests = [OpenSSL::Digest::SHA1.new]
+    fac.allowed_digests = [OpenSSL::Digest.new('SHA1')]
     resp = fac.create_timestamp(ee_key, ts_cert_ee, req)
     assert_equal OpenSSL::Timestamp::Response::GRANTED, resp.status
 
     # Others not allowed
     req.algorithm = "SHA256"
-    req.message_imprint = OpenSSL::Digest::SHA256.digest("test")
+    req.message_imprint = OpenSSL::Digest.digest('SHA256', "test")
     resp = fac.create_timestamp(ee_key, ts_cert_ee, req)
     assert_equal OpenSSL::Timestamp::Response::REJECTION, resp.status
 
@@ -291,7 +291,7 @@ _end_of_pem_
     assert_equal OpenSSL::Timestamp::Response::REJECTION, resp.status
 
     # Non-String, non-Digest Array element
-    fac.allowed_digests = ["sha1", OpenSSL::Digest::SHA1.new, 123]
+    fac.allowed_digests = ["sha1", OpenSSL::Digest.new('SHA1'), 123]
     assert_raise(TypeError) do
       fac.create_timestamp(ee_key, ts_cert_ee, req)
     end
@@ -300,7 +300,7 @@ _end_of_pem_
   def test_response_default_policy
     req = OpenSSL::Timestamp::Request.new
     req.algorithm = "SHA1"
-    digest = OpenSSL::Digest::SHA1.new.digest("test")
+    digest = OpenSSL::Digest.digest('SHA1', "test")
     req.message_imprint = digest
 
     fac = OpenSSL::Timestamp::Factory.new
@@ -317,7 +317,7 @@ _end_of_pem_
   def test_response_bad_purpose
     req = OpenSSL::Timestamp::Request.new
     req.algorithm = "SHA1"
-    digest = OpenSSL::Digest::SHA1.new.digest("test")
+    digest = OpenSSL::Digest.digest('SHA1', "test")
     req.message_imprint = digest
     req.policy_id = "1.2.3.4.5"
     req.nonce = 42
@@ -336,7 +336,7 @@ _end_of_pem_
   def test_no_cert_requested
     req = OpenSSL::Timestamp::Request.new
     req.algorithm = "SHA1"
-    digest = OpenSSL::Digest::SHA1.new.digest("test")
+    digest = OpenSSL::Digest.digest('SHA1', "test")
     req.message_imprint = digest
     req.cert_requested = false
 
@@ -355,7 +355,7 @@ _end_of_pem_
     assert_raise(OpenSSL::Timestamp::TimestampError) do
       req = OpenSSL::Timestamp::Request.new
       req.algorithm = "SHA1"
-      digest = OpenSSL::Digest::SHA1.new.digest("test")
+      digest = OpenSSL::Digest.digest('SHA1', "test")
       req.message_imprint = digest
 
       fac = OpenSSL::Timestamp::Factory.new
@@ -423,7 +423,7 @@ _end_of_pem_
   def test_verify_ee_def_policy
     req = OpenSSL::Timestamp::Request.new
     req.algorithm = "SHA1"
-    digest = OpenSSL::Digest::SHA1.new.digest("test")
+    digest = OpenSSL::Digest.digest('SHA1', "test")
     req.message_imprint = digest
     req.nonce = 42
 
@@ -481,7 +481,7 @@ _end_of_pem_
   def test_verify_ee_additional_certs_array
     req = OpenSSL::Timestamp::Request.new
     req.algorithm = "SHA1"
-    digest = OpenSSL::Digest::SHA1.new.digest("test")
+    digest = OpenSSL::Digest.digest('SHA1', "test")
     req.message_imprint = digest
     req.policy_id = "1.2.3.4.5"
     req.nonce = 42
@@ -501,7 +501,7 @@ _end_of_pem_
   def test_verify_ee_additional_certs_with_root
     req = OpenSSL::Timestamp::Request.new
     req.algorithm = "SHA1"
-    digest = OpenSSL::Digest::SHA1.new.digest("test")
+    digest = OpenSSL::Digest.digest('SHA1', "test")
     req.message_imprint = digest
     req.policy_id = "1.2.3.4.5"
     req.nonce = 42
@@ -518,7 +518,7 @@ _end_of_pem_
   def test_verify_ee_cert_inclusion_not_requested
     req = OpenSSL::Timestamp::Request.new
     req.algorithm = "SHA1"
-    digest = OpenSSL::Digest::SHA1.new.digest("test")
+    digest = OpenSSL::Digest.digest('SHA1', "test")
     req.message_imprint = digest
     req.nonce = 42
     req.cert_requested = false
@@ -539,7 +539,7 @@ _end_of_pem_
     #CTX_free methods don't mess up e.g. the certificates
     req = OpenSSL::Timestamp::Request.new
     req.algorithm = "SHA1"
-    digest = OpenSSL::Digest::SHA1.new.digest("test")
+    digest = OpenSSL::Digest.digest('SHA1', "test")
     req.message_imprint = digest
     req.policy_id = "1.2.3.4.5"
     req.nonce = 42
@@ -560,7 +560,7 @@ _end_of_pem_
   def test_token_info_creation
     req = OpenSSL::Timestamp::Request.new
     req.algorithm = "SHA1"
-    digest = OpenSSL::Digest::SHA1.new.digest("test")
+    digest = OpenSSL::Digest.digest('SHA1', "test")
     req.message_imprint = digest
     req.policy_id = "1.2.3.4.5"
     req.nonce = OpenSSL::BN.new(123)
@@ -594,7 +594,7 @@ _end_of_pem_
   def timestamp_ee
     req = OpenSSL::Timestamp::Request.new
     req.algorithm = "SHA1"
-    digest = OpenSSL::Digest::SHA1.new.digest("test")
+    digest = OpenSSL::Digest.digest('SHA1', "test")
     req.message_imprint = digest
     req.policy_id = "1.2.3.4.5"
     req.nonce = 42
@@ -609,7 +609,7 @@ _end_of_pem_
   def timestamp_ee_no_cert
     req = OpenSSL::Timestamp::Request.new
     req.algorithm = "SHA1"
-    digest = OpenSSL::Digest::SHA1.new.digest("test")
+    digest = OpenSSL::Digest.digest('SHA1', "test")
     req.message_imprint = digest
     req.policy_id = "1.2.3.4.5"
     req.nonce = 42
@@ -625,7 +625,7 @@ _end_of_pem_
   def timestamp_direct
     req = OpenSSL::Timestamp::Request.new
     req.algorithm = "SHA1"
-    digest = OpenSSL::Digest::SHA1.new.digest("test")
+    digest = OpenSSL::Digest.digest('SHA1', "test")
     req.message_imprint = digest
     req.policy_id = "1.2.3.4.5"
     req.nonce = 42
@@ -640,7 +640,7 @@ _end_of_pem_
   def timestamp_direct_no_cert
     req = OpenSSL::Timestamp::Request.new
     req.algorithm = "SHA1"
-    digest = OpenSSL::Digest::SHA1.new.digest("test")
+    digest = OpenSSL::Digest.digest('SHA1', "test")
     req.message_imprint = digest
     req.policy_id = "1.2.3.4.5"
     req.nonce = 42

--- a/test/openssl/test_x509cert.rb
+++ b/test/openssl/test_x509cert.rb
@@ -205,7 +205,7 @@ class OpenSSL::TestX509Certificate < OpenSSL::TestCase
   end
 
   def test_sign_and_verify_rsa_dss1
-    cert = issue_cert(@ca, @rsa2048, 1, [], nil, nil, digest: OpenSSL::Digest::DSS1.new)
+    cert = issue_cert(@ca, @rsa2048, 1, [], nil, nil, digest: OpenSSL::Digest.new('DSS1'))
     assert_equal(false, cert.verify(@rsa1024))
     assert_equal(true, cert.verify(@rsa2048))
     assert_equal(false, certificate_error_returns_false { cert.verify(@dsa256) })

--- a/test/openssl/test_x509crl.rb
+++ b/test/openssl/test_x509crl.rb
@@ -20,7 +20,7 @@ class OpenSSL::TestX509CRL < OpenSSL::TestCase
 
     cert = issue_cert(@ca, @rsa2048, 1, [], nil, nil)
     crl = issue_crl([], 1, now, now+1600, [],
-                    cert, @rsa2048, OpenSSL::Digest::SHA1.new)
+                    cert, @rsa2048, OpenSSL::Digest.new('SHA1'))
     assert_equal(1, crl.version)
     assert_equal(cert.issuer.to_der, crl.issuer.to_der)
     assert_equal(now, crl.last_update)
@@ -57,7 +57,7 @@ class OpenSSL::TestX509CRL < OpenSSL::TestCase
     ]
     cert = issue_cert(@ca, @rsa2048, 1, [], nil, nil)
     crl = issue_crl(revoke_info, 1, Time.now, Time.now+1600, [],
-                    cert, @rsa2048, OpenSSL::Digest::SHA1.new)
+                    cert, @rsa2048, OpenSSL::Digest.new('SHA1'))
     revoked = crl.revoked
     assert_equal(5, revoked.size)
     assert_equal(1, revoked[0].serial)
@@ -98,7 +98,7 @@ class OpenSSL::TestX509CRL < OpenSSL::TestCase
 
     revoke_info = (1..1000).collect{|i| [i, now, 0] }
     crl = issue_crl(revoke_info, 1, Time.now, Time.now+1600, [],
-                    cert, @rsa2048, OpenSSL::Digest::SHA1.new)
+                    cert, @rsa2048, OpenSSL::Digest.new('SHA1'))
     revoked = crl.revoked
     assert_equal(1000, revoked.size)
     assert_equal(1, revoked[0].serial)
@@ -124,7 +124,7 @@ class OpenSSL::TestX509CRL < OpenSSL::TestCase
 
     cert = issue_cert(@ca, @rsa2048, 1, cert_exts, nil, nil)
     crl = issue_crl([], 1, Time.now, Time.now+1600, crl_exts,
-                    cert, @rsa2048, OpenSSL::Digest::SHA1.new)
+                    cert, @rsa2048, OpenSSL::Digest.new('SHA1'))
     exts = crl.extensions
     assert_equal(3, exts.size)
     assert_equal("1", exts[0].value)
@@ -160,24 +160,24 @@ class OpenSSL::TestX509CRL < OpenSSL::TestCase
     assert_equal(false, exts[2].critical?)
 
     no_ext_crl = issue_crl([], 1, Time.now, Time.now+1600, [],
-      cert, @rsa2048, OpenSSL::Digest::SHA1.new)
+      cert, @rsa2048, OpenSSL::Digest.new('SHA1'))
     assert_equal nil, no_ext_crl.authority_key_identifier
   end
 
   def test_crlnumber
     cert = issue_cert(@ca, @rsa2048, 1, [], nil, nil)
     crl = issue_crl([], 1, Time.now, Time.now+1600, [],
-                    cert, @rsa2048, OpenSSL::Digest::SHA1.new)
+                    cert, @rsa2048, OpenSSL::Digest.new('SHA1'))
     assert_match(1.to_s, crl.extensions[0].value)
     assert_match(/X509v3 CRL Number:\s+#{1}/m, crl.to_text)
 
     crl = issue_crl([], 2**32, Time.now, Time.now+1600, [],
-                    cert, @rsa2048, OpenSSL::Digest::SHA1.new)
+                    cert, @rsa2048, OpenSSL::Digest.new('SHA1'))
     assert_match((2**32).to_s, crl.extensions[0].value)
     assert_match(/X509v3 CRL Number:\s+#{2**32}/m, crl.to_text)
 
     crl = issue_crl([], 2**100, Time.now, Time.now+1600, [],
-                    cert, @rsa2048, OpenSSL::Digest::SHA1.new)
+                    cert, @rsa2048, OpenSSL::Digest.new('SHA1'))
     assert_match(/X509v3 CRL Number:\s+#{2**100}/m, crl.to_text)
     assert_match((2**100).to_s, crl.extensions[0].value)
   end
@@ -185,7 +185,7 @@ class OpenSSL::TestX509CRL < OpenSSL::TestCase
   def test_sign_and_verify
     cert = issue_cert(@ca, @rsa2048, 1, [], nil, nil)
     crl = issue_crl([], 1, Time.now, Time.now+1600, [],
-                    cert, @rsa2048, OpenSSL::Digest::SHA1.new)
+                    cert, @rsa2048, OpenSSL::Digest.new('SHA1'))
     assert_equal(false, crl.verify(@rsa1024))
     assert_equal(true,  crl.verify(@rsa2048))
     assert_equal(false, crl_error_returns_false { crl.verify(@dsa256) })
@@ -195,7 +195,7 @@ class OpenSSL::TestX509CRL < OpenSSL::TestCase
 
     cert = issue_cert(@ca, @dsa512, 1, [], nil, nil)
     crl = issue_crl([], 1, Time.now, Time.now+1600, [],
-                    cert, @dsa512, OpenSSL::Digest::SHA1.new)
+                    cert, @dsa512, OpenSSL::Digest.new('SHA1'))
     assert_equal(false, crl_error_returns_false { crl.verify(@rsa1024) })
     assert_equal(false, crl_error_returns_false { crl.verify(@rsa2048) })
     assert_equal(false, crl.verify(@dsa256))

--- a/test/openssl/test_x509name.rb
+++ b/test/openssl/test_x509name.rb
@@ -432,13 +432,13 @@ class OpenSSL::TestX509Name < OpenSSL::TestCase
   def test_hash
     dn = "/DC=org/DC=ruby-lang/CN=www.ruby-lang.org"
     name = OpenSSL::X509::Name.parse(dn)
-    d = OpenSSL::Digest::MD5.digest(name.to_der)
+    d = OpenSSL::Digest.digest('MD5', name.to_der)
     expected = (d[0].ord & 0xff) | (d[1].ord & 0xff) << 8 | (d[2].ord & 0xff) << 16 | (d[3].ord & 0xff) << 24
     assert_equal(expected, name_hash(name))
     #
     dn = "/DC=org/DC=ruby-lang/CN=baz.ruby-lang.org"
     name = OpenSSL::X509::Name.parse(dn)
-    d = OpenSSL::Digest::MD5.digest(name.to_der)
+    d = OpenSSL::Digest.digest('MD5', name.to_der)
     expected = (d[0].ord & 0xff) | (d[1].ord & 0xff) << 8 | (d[2].ord & 0xff) << 16 | (d[3].ord & 0xff) << 24
     assert_equal(expected, name_hash(name))
   end

--- a/test/openssl/test_x509req.rb
+++ b/test/openssl/test_x509req.rb
@@ -23,31 +23,31 @@ class OpenSSL::TestX509Request < OpenSSL::TestCase
   end
 
   def test_public_key
-    req = issue_csr(0, @dn, @rsa1024, OpenSSL::Digest::SHA1.new)
+    req = issue_csr(0, @dn, @rsa1024, OpenSSL::Digest.new('SHA1'))
     assert_equal(@rsa1024.public_key.to_der, req.public_key.to_der)
     req = OpenSSL::X509::Request.new(req.to_der)
     assert_equal(@rsa1024.public_key.to_der, req.public_key.to_der)
 
-    req = issue_csr(0, @dn, @dsa512, OpenSSL::Digest::SHA1.new)
+    req = issue_csr(0, @dn, @dsa512, OpenSSL::Digest.new('SHA1'))
     assert_equal(@dsa512.public_key.to_der, req.public_key.to_der)
     req = OpenSSL::X509::Request.new(req.to_der)
     assert_equal(@dsa512.public_key.to_der, req.public_key.to_der)
   end
 
   def test_version
-    req = issue_csr(0, @dn, @rsa1024, OpenSSL::Digest::SHA1.new)
+    req = issue_csr(0, @dn, @rsa1024, OpenSSL::Digest.new('SHA1'))
     assert_equal(0, req.version)
     req = OpenSSL::X509::Request.new(req.to_der)
     assert_equal(0, req.version)
 
-    req = issue_csr(1, @dn, @rsa1024, OpenSSL::Digest::SHA1.new)
+    req = issue_csr(1, @dn, @rsa1024, OpenSSL::Digest.new('SHA1'))
     assert_equal(1, req.version)
     req = OpenSSL::X509::Request.new(req.to_der)
     assert_equal(1, req.version)
   end
 
   def test_subject
-    req = issue_csr(0, @dn, @rsa1024, OpenSSL::Digest::SHA1.new)
+    req = issue_csr(0, @dn, @rsa1024, OpenSSL::Digest.new('SHA1'))
     assert_equal(@dn.to_der, req.subject.to_der)
     req = OpenSSL::X509::Request.new(req.to_der)
     assert_equal(@dn.to_der, req.subject.to_der)
@@ -78,9 +78,9 @@ class OpenSSL::TestX509Request < OpenSSL::TestCase
       OpenSSL::X509::Attribute.new("msExtReq", attrval),
     ]
 
-    req0 = issue_csr(0, @dn, @rsa1024, OpenSSL::Digest::SHA1.new)
+    req0 = issue_csr(0, @dn, @rsa1024, OpenSSL::Digest.new('SHA1'))
     attrs.each{|attr| req0.add_attribute(attr) }
-    req1 = issue_csr(0, @dn, @rsa1024, OpenSSL::Digest::SHA1.new)
+    req1 = issue_csr(0, @dn, @rsa1024, OpenSSL::Digest.new('SHA1'))
     req1.attributes = attrs
     assert_equal(req0.to_der, req1.to_der)
 
@@ -101,7 +101,7 @@ class OpenSSL::TestX509Request < OpenSSL::TestCase
   end
 
   def test_sign_and_verify_rsa_sha1
-    req = issue_csr(0, @dn, @rsa1024, OpenSSL::Digest::SHA1.new)
+    req = issue_csr(0, @dn, @rsa1024, OpenSSL::Digest.new('SHA1'))
     assert_equal(true,  req.verify(@rsa1024))
     assert_equal(false, req.verify(@rsa2048))
     assert_equal(false, request_error_returns_false { req.verify(@dsa256) })
@@ -111,7 +111,7 @@ class OpenSSL::TestX509Request < OpenSSL::TestCase
   end
 
   def test_sign_and_verify_rsa_md5
-    req = issue_csr(0, @dn, @rsa2048, OpenSSL::Digest::MD5.new)
+    req = issue_csr(0, @dn, @rsa2048, OpenSSL::Digest.new('MD5'))
     assert_equal(false, req.verify(@rsa1024))
     assert_equal(true,  req.verify(@rsa2048))
     assert_equal(false, request_error_returns_false { req.verify(@dsa256) })
@@ -122,7 +122,7 @@ class OpenSSL::TestX509Request < OpenSSL::TestCase
   end
 
   def test_sign_and_verify_dsa
-    req = issue_csr(0, @dn, @dsa512, OpenSSL::Digest::SHA1.new)
+    req = issue_csr(0, @dn, @dsa512, OpenSSL::Digest.new('SHA1'))
     assert_equal(false, request_error_returns_false { req.verify(@rsa1024) })
     assert_equal(false, request_error_returns_false { req.verify(@rsa2048) })
     assert_equal(false, req.verify(@dsa256))
@@ -133,11 +133,11 @@ class OpenSSL::TestX509Request < OpenSSL::TestCase
 
   def test_sign_and_verify_dsa_md5
     assert_raise(OpenSSL::X509::RequestError){
-      issue_csr(0, @dn, @dsa512, OpenSSL::Digest::MD5.new) }
+      issue_csr(0, @dn, @dsa512, OpenSSL::Digest.new('MD5')) }
   end
 
   def test_dup
-    req = issue_csr(0, @dn, @rsa1024, OpenSSL::Digest::SHA1.new)
+    req = issue_csr(0, @dn, @rsa1024, OpenSSL::Digest.new('SHA1'))
     assert_equal(req.to_der, req.dup.to_der)
   end
 

--- a/test/openssl/test_x509store.rb
+++ b/test/openssl/test_x509store.rb
@@ -72,16 +72,16 @@ class OpenSSL::TestX509Store < OpenSSL::TestCase
 
     revoke_info = []
     crl1   = issue_crl(revoke_info, 1, now, now+1800, [],
-                       ca1_cert, @rsa2048, OpenSSL::Digest::SHA1.new)
+                       ca1_cert, @rsa2048, OpenSSL::Digest.new('SHA1'))
     revoke_info = [ [2, now, 1], ]
     crl1_2 = issue_crl(revoke_info, 2, now, now+1800, [],
-                       ca1_cert, @rsa2048, OpenSSL::Digest::SHA1.new)
+                       ca1_cert, @rsa2048, OpenSSL::Digest.new('SHA1'))
     revoke_info = [ [20, now, 1], ]
     crl2   = issue_crl(revoke_info, 1, now, now+1800, [],
-                       ca2_cert, @rsa1024, OpenSSL::Digest::SHA1.new)
+                       ca2_cert, @rsa1024, OpenSSL::Digest.new('SHA1'))
     revoke_info = []
     crl2_2 = issue_crl(revoke_info, 2, now-100, now-1, [],
-                       ca2_cert, @rsa1024, OpenSSL::Digest::SHA1.new)
+                       ca2_cert, @rsa1024, OpenSSL::Digest.new('SHA1'))
 
     assert_equal(true, ca1_cert.verify(ca1_cert.public_key))   # self signed
     assert_equal(true, ca2_cert.verify(ca1_cert.public_key))   # issued by ca1
@@ -220,10 +220,10 @@ class OpenSSL::TestX509Store < OpenSSL::TestCase
 
     revoke_info = []
     crl1 = issue_crl(revoke_info, 1, now, now+1800, [],
-                     ca1_cert, @rsa2048, OpenSSL::Digest::SHA1.new)
+                     ca1_cert, @rsa2048, OpenSSL::Digest.new('SHA1'))
     revoke_info = [ [2, now, 1], ]
     crl2 = issue_crl(revoke_info, 2, now+1800, now+3600, [],
-                     ca1_cert, @rsa2048, OpenSSL::Digest::SHA1.new)
+                     ca1_cert, @rsa2048, OpenSSL::Digest.new('SHA1'))
     store.add_crl(crl1)
     assert_raise(OpenSSL::X509::StoreError){
       store.add_crl(crl2) # add CRL issued by same CA twice.

--- a/test/openssl/utils.rb
+++ b/test/openssl/utils.rb
@@ -126,7 +126,7 @@ module OpenSSL::TestUtils
     pkinfo    = tbscert.value[6]
     publickey = pkinfo.value[1]
     pkvalue   = publickey.value
-    digest = OpenSSL::Digest::SHA1.digest(pkvalue)
+    digest = OpenSSL::Digest.digest('SHA1', pkvalue)
     if hex
       digest.unpack("H2"*20).join(":").upcase
     else


### PR DESCRIPTION
As discussed in https://github.com/ruby/openssl/issues/304 this updates documentation and tests to show the new preferred usage. I also took the liberty of updating the Digest documentation a little.

The same constants as today in version 2.1.2 work for backwards compatibility, minus `OpenSSL::Digest::MDCS2` as that was removed in 11aba35204259a9ee20c0b162e237b933a7ad478 already.

I can contribute a PR to Rubocop for autocorrecting these changes if this is merged.