### PR TITLE
pkey: add PKey#inspect and #oid

### DIFF
--- a/ext/openssl/ossl_pkey.c
+++ b/ext/openssl/ossl_pkey.c
@@ -299,6 +299,42 @@ ossl_pkey_initialize(VALUE self)
     return self;
 }
 
+/*
+ * call-seq:
+ *    pkey.oid -> string
+ *
+ * Returns the short name of the OID associated with _pkey_.
+ */
+static VALUE
+ossl_pkey_oid(VALUE self)
+{
+    EVP_PKEY *pkey;
+    int nid;
+
+    GetPKey(self, pkey);
+    nid = EVP_PKEY_id(pkey);
+    return rb_str_new_cstr(OBJ_nid2sn(nid));
+}
+
+/*
+ * call-seq:
+ *    pkey.inspect -> string
+ *
+ * Returns a string describing the PKey object.
+ */
+static VALUE
+ossl_pkey_inspect(VALUE self)
+{
+    EVP_PKEY *pkey;
+    int nid;
+
+    GetPKey(self, pkey);
+    nid = EVP_PKEY_id(pkey);
+    return rb_sprintf("#<%"PRIsVALUE":%p oid=%s>",
+                      rb_class_name(CLASS_OF(self)), (void *)self,
+                      OBJ_nid2sn(nid));
+}
+
 static VALUE
 do_pkcs8_export(int argc, VALUE *argv, VALUE self, int to_der)
 {
@@ -615,6 +651,8 @@ Init_ossl_pkey(void)
 
     rb_define_alloc_func(cPKey, ossl_pkey_alloc);
     rb_define_method(cPKey, "initialize", ossl_pkey_initialize, 0);
+    rb_define_method(cPKey, "oid", ossl_pkey_oid, 0);
+    rb_define_method(cPKey, "inspect", ossl_pkey_inspect, 0);
     rb_define_method(cPKey, "private_to_der", ossl_pkey_private_to_der, -1);
     rb_define_method(cPKey, "private_to_pem", ossl_pkey_private_to_pem, -1);
     rb_define_method(cPKey, "public_to_der", ossl_pkey_public_to_der, 0);

--- a/test/openssl/test_pkey.rb
+++ b/test/openssl/test_pkey.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+require_relative "utils"
+
+class OpenSSL::TestPKey < OpenSSL::PKeyTestCase
+  def test_generic_oid_inspect
+    # RSA private key
+    rsa = Fixtures.pkey("rsa-1")
+    assert_instance_of OpenSSL::PKey::RSA, rsa
+    assert_equal "rsaEncryption", rsa.oid
+    assert_match %r{oid=rsaEncryption}, rsa.inspect
+
+    # X25519 private key
+    x25519_pem = <<~EOF
+    -----BEGIN PRIVATE KEY-----
+    MC4CAQAwBQYDK2VuBCIEIHcHbQpzGKV9PBbBclGyZkXfTC+H68CZKrF3+6UduSwq
+    -----END PRIVATE KEY-----
+    EOF
+    begin
+      x25519 = OpenSSL::PKey.read(x25519_pem)
+    rescue OpenSSL::PKey::PKeyError
+      # OpenSSL < 1.1.0
+      pend "X25519 is not implemented"
+    end
+    assert_instance_of OpenSSL::PKey::PKey, x25519
+    assert_equal "X25519", x25519.oid
+    assert_match %r{oid=X25519}, x25519.inspect
+  end
+end


### PR DESCRIPTION
Implement OpenSSL::PKey::PKey#oid as a wrapper around EVP_PKEY_id().
This allows user code to check the type of a PKey object.

EVP_PKEY can have a pkey type for which we do not provide a dedicated
subclass. In other words, an EVP_PKEY that is not any of {RSA,DSA,DH,EC}
can exist. It is currently not possible to distinguish such a pkey.

Also, implement PKey#inspect to include the key type for convenience.