### PR TITLE
pkey/ec: deprecate OpenSSL::PKey::EC::Point#mul(ary, ary [, bn])

### DIFF
--- a/test/openssl/test_pkey_ec.rb
+++ b/test/openssl/test_pkey_ec.rb
@@ -349,21 +349,28 @@ class OpenSSL::TestEC < OpenSSL::PKeyTestCase
       # 3 * (6, 3) + 3 * (5, 1) = (7, 6)
       result_a2 = point_a.mul(3, 3)
       assert_equal B(%w{ 04 07 06 }), result_a2.to_octet_string(:uncompressed)
-      # 3 * point_a = 3 * (6, 3) = (16, 13)
-      result_b1 = point_a.mul([3], [])
-      assert_equal B(%w{ 04 10 0D }), result_b1.to_octet_string(:uncompressed)
-      # 3 * point_a + 2 * point_a = 3 * (6, 3) + 2 * (6, 3) = (7, 11)
-      begin
+      EnvUtil.suppress_warning do # Point#mul(ary, ary [, bn]) is deprecated
+        begin
+          result_b1 = point_a.mul([3], [])
+        rescue NotImplementedError
+          # LibreSSL and OpenSSL 3.0 do no longer support this form of calling
+          next
+        end
+
+        # 3 * point_a = 3 * (6, 3) = (16, 13)
+        result_b1 = point_a.mul([3], [])
+        assert_equal B(%w{ 04 10 0D }), result_b1.to_octet_string(:uncompressed)
+        # 3 * point_a + 2 * point_a = 3 * (6, 3) + 2 * (6, 3) = (7, 11)
         result_b1 = point_a.mul([3, 2], [point_a])
-      rescue OpenSSL::PKey::EC::Point::Error
-        # LibreSSL doesn't support multiple entries in first argument
-        raise if $!.message !~ /called a function you should not call/
-      else
         assert_equal B(%w{ 04 07 0B }), result_b1.to_octet_string(:uncompressed)
+        # 3 * point_a + 5 * point_a.group.generator = 3 * (6, 3) + 5 * (5, 1) = (13, 10)
+        result_b1 = point_a.mul([3], [], 5)
+        assert_equal B(%w{ 04 0D 0A }), result_b1.to_octet_string(:uncompressed)
+
+        assert_raise(ArgumentError) { point_a.mul([1], [point_a]) }
+        assert_raise(TypeError) { point_a.mul([1], nil) }
+        assert_raise(TypeError) { point_a.mul([nil], []) }
       end
-      # 3 * point_a + 5 * point_a.group.generator = 3 * (6, 3) + 5 * (5, 1) = (13, 10)
-      result_b1 = point_a.mul([3], [], 5)
-      assert_equal B(%w{ 04 0D 0A }), result_b1.to_octet_string(:uncompressed)
     rescue OpenSSL::PKey::EC::Group::Error
       # CentOS patches OpenSSL to reject curves defined over Fp where p < 256 bits
       raise if $!.message !~ /unsupported field/
@@ -376,9 +383,6 @@ class OpenSSL::TestEC < OpenSSL::PKeyTestCase
     # invalid argument
     point = p256_key.public_key
     assert_raise(TypeError) { point.mul(nil) }
-    assert_raise(ArgumentError) { point.mul([1], [point]) }
-    assert_raise(TypeError) { point.mul([1], nil) }
-    assert_raise(TypeError) { point.mul([nil], []) }
   end
 
 # test Group: asn1_flag, point_conversion


### PR DESCRIPTION
Deprecate it for future removal. However, I do not expect any
application is affected by this.

The other form of calling it, PKey::EC::Point#mul(bn [, bn]) remains
untouched.

PKey::EC::Point#mul calls EC_POINTs_mul(3) when multiple BNs
are given as an array. LibreSSL 2.8.0 released on 2018-08 removed the
feature and OpenSSL 3.0 which is planned to be released in 2020 will
also deprecate the function as there is no real use-case.

Part of #369