### PR TITLE
OpenSSL::PKey convenience methods

### DIFF
--- a/ext/openssl/ossl_pkey.c
+++ b/ext/openssl/ossl_pkey.c
@@ -568,6 +568,25 @@ ossl_pkey_inspect(VALUE self)
                       OBJ_nid2sn(nid));
 }
 
+/*
+ *  call-seq:
+ *     key.private? => true or false
+ *
+ *  Returns whether this PKey instance has a private key. The private key can
+ *  be retrieved with PKey#private_to_{der,pem,raw}.
+ */
+static VALUE ossl_pkey_is_private(VALUE self)
+{
+    EVP_PKEY *pkey;
+    size_t len;
+
+    GetPKey(self, pkey);
+    len = EVP_PKEY_size(pkey);
+    unsigned char str[len];
+
+    return EVP_PKEY_get_raw_private_key(pkey, str, &len) == 1 ? Qtrue : Qfalse;
+}
+
 VALUE
 ossl_pkey_export_traditional(int argc, VALUE *argv, VALUE self, int to_der)
 {
@@ -706,6 +725,25 @@ ossl_pkey_export_spki(VALUE self, int to_der)
 	}
     }
     return ossl_membio2str(bio);
+}
+
+/*
+ *  call-seq:
+ *     key.public? => true or false
+ *
+ *  Returns whether this PKey instance has a public key. The public key can
+ *  be retrieved with PKey#public_to_{der,pem,raw}.
+ */
+static VALUE ossl_pkey_is_public(VALUE self)
+{
+    EVP_PKEY *pkey;
+    size_t len;
+
+    GetPKey(self, pkey);
+    len = EVP_PKEY_size(pkey);
+    unsigned char str[len];
+
+    return EVP_PKEY_get_raw_public_key(pkey, str, &len) == 1 ? Qtrue : Qfalse;
 }
 
 /*
@@ -1027,8 +1065,10 @@ Init_ossl_pkey(void)
     rb_define_method(cPKey, "initialize", ossl_pkey_initialize, 0);
     rb_define_method(cPKey, "oid", ossl_pkey_oid, 0);
     rb_define_method(cPKey, "inspect", ossl_pkey_inspect, 0);
+    rb_define_method(cPKey, "private?", ossl_pkey_is_private, 0);
     rb_define_method(cPKey, "private_to_der", ossl_pkey_private_to_der, -1);
     rb_define_method(cPKey, "private_to_pem", ossl_pkey_private_to_pem, -1);
+    rb_define_method(cPKey, "public?", ossl_pkey_is_public, 0);
     rb_define_method(cPKey, "public_to_der", ossl_pkey_public_to_der, 0);
     rb_define_method(cPKey, "public_to_pem", ossl_pkey_public_to_pem, 0);
 

--- a/lib/openssl/pkey.rb
+++ b/lib/openssl/pkey.rb
@@ -69,6 +69,20 @@ module OpenSSL::PKey
   end
   end
 
+  class PKey
+    def self._load(string)
+      OpenSSL::PKey.read(string)
+    end
+
+    def _dump(_level)
+      if private?
+        private_to_der
+      else
+        public_to_der
+      end
+    end
+  end
+
   class RSA
     include OpenSSL::Marshal
   end

--- a/test/openssl/test_pkey.rb
+++ b/test/openssl/test_pkey.rb
@@ -107,6 +107,10 @@ class OpenSSL::TestPKey < OpenSSL::PKeyTestCase
     assert_equal true, priv.public?
     priv_deserialized = Marshal.load(Marshal.dump(priv))
     assert_equal priv.private_to_der, priv_deserialized.private_to_der
+    assert_equal "4ccd089b28ff96da9db6c346ec114e0f5b8a319f35aba624da8cf6ed4fb8a6fb",
+      priv.private_to_raw.unpack1("H*")
+    assert_equal OpenSSL::PKey.private_new("ED25519", priv.private_to_raw).private_to_pem,
+      priv.private_to_pem
 
     assert_equal pub_pem, priv.public_to_pem
     assert_equal pub_pem, pub.public_to_pem
@@ -114,6 +118,10 @@ class OpenSSL::TestPKey < OpenSSL::PKeyTestCase
     assert_equal true, pub.public?
     pub_deserialized = Marshal.load(Marshal.dump(pub))
     assert_equal pub.public_to_der, pub_deserialized.public_to_der
+    assert_equal "3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c",
+      priv.public_to_raw.unpack1("H*")
+    assert_equal OpenSSL::PKey.public_new("ED25519", priv.public_to_raw).public_to_pem,
+      pub.public_to_pem
 
 
     sig = [<<~EOF.gsub(/[^0-9a-f]/, "")].pack("H*")
@@ -164,5 +172,22 @@ class OpenSSL::TestPKey < OpenSSL::PKeyTestCase
     assert_equal alice.private_to_der, alice_deserialized.private_to_der
     bob_deserialized = Marshal.load(Marshal.dump(bob))
     assert_equal bob.public_to_der, bob_deserialized.public_to_der
+    assert_equal "77076d0a7318a57d3c16c17251b26645df4c2f87ebc0992ab177fba51db92c2a",
+      alice.private_to_raw.unpack1("H*")
+    assert_equal OpenSSL::PKey.private_new("X25519", alice.private_to_raw).private_to_pem,
+      alice.private_to_pem
+    assert_equal "de9edb7d7b7dc1b4d35b61c2ece435373f8343c85b78674dadfc7e146f882b4f",
+      bob.public_to_raw.unpack1("H*")
+    assert_equal OpenSSL::PKey.public_new("X25519", bob.public_to_raw).public_to_pem,
+      bob.public_to_pem
+  end
+
+  def raw_initialize
+    pend "Ed25519 is not implemented" unless OpenSSL::OPENSSL_VERSION_NUMBER >= 0x10101000 && # >= v1.1.1
+
+    assert_raise(OpenSSL::PKey::PKeyError) { OpenSSL::PKey.private_new("foo123", "xxx") }
+    assert_raise(OpenSSL::PKey::PKeyError) { OpenSSL::PKey.private_new("ED25519", "xxx") }
+    assert_raise(OpenSSL::PKey::PKeyError) { OpenSSL::PKey.public_new("foo123", "xxx") }
+    assert_raise(OpenSSL::PKey::PKeyError) { OpenSSL::PKey.public_new("ED25519", "xxx") }
   end
 end

--- a/test/openssl/test_pkey.rb
+++ b/test/openssl/test_pkey.rb
@@ -103,8 +103,18 @@ class OpenSSL::TestPKey < OpenSSL::PKeyTestCase
     assert_instance_of OpenSSL::PKey::PKey, priv
     assert_instance_of OpenSSL::PKey::PKey, pub
     assert_equal priv_pem, priv.private_to_pem
+    assert_equal true, priv.private?
+    assert_equal true, priv.public?
+    priv_deserialized = Marshal.load(Marshal.dump(priv))
+    assert_equal priv.private_to_der, priv_deserialized.private_to_der
+
     assert_equal pub_pem, priv.public_to_pem
     assert_equal pub_pem, pub.public_to_pem
+    assert_equal false, pub.private?
+    assert_equal true, pub.public?
+    pub_deserialized = Marshal.load(Marshal.dump(pub))
+    assert_equal pub.public_to_der, pub_deserialized.public_to_der
+
 
     sig = [<<~EOF.gsub(/[^0-9a-f]/, "")].pack("H*")
     92a009a9f0d4cab8720e820b5f642540
@@ -150,5 +160,9 @@ class OpenSSL::TestPKey < OpenSSL::PKeyTestCase
     assert_equal alice_pem, alice.private_to_pem
     assert_equal bob_pem, bob.public_to_pem
     assert_equal [shared_secret].pack("H*"), alice.derive(bob)
+    alice_deserialized = Marshal.load(Marshal.dump(alice))
+    assert_equal alice.private_to_der, alice_deserialized.private_to_der
+    bob_deserialized = Marshal.load(Marshal.dump(bob))
+    assert_equal bob.public_to_der, bob_deserialized.public_to_der
   end
 end


### PR DESCRIPTION
Implementing https://github.com/ruby/openssl/pull/329#issuecomment-629650162 and Marshal support. I'm not very good at C, so any feedback is very welcome.