### PR TITLE
Allow TLSv1_3 method

### DIFF
--- a/lib/openssl/ssl.rb
+++ b/lib/openssl/ssl.rb
@@ -220,6 +220,7 @@ YoaOffgTf5qxiwkjnlVZQc3whgnEt9FpVMvQ9eknyeGB5KHfayAc3+hUAvI3/Cr3
         TLSv1: OpenSSL::SSL::TLS1_VERSION,
         TLSv1_1: OpenSSL::SSL::TLS1_1_VERSION,
         TLSv1_2: OpenSSL::SSL::TLS1_2_VERSION,
+        TLSv1_3: OpenSSL::SSL::TLS1_3_VERSION
       }.freeze
       private_constant :METHODS_MAP
 
@@ -236,7 +237,7 @@ YoaOffgTf5qxiwkjnlVZQc3whgnEt9FpVMvQ9eknyeGB5KHfayAc3+hUAvI3/Cr3
       def fileno
         to_io.fileno
       end
-      
+
       def addr
         to_io.addr
       end


### PR DESCRIPTION
Currently specifying TLS version `TLSv1_3 ` throws an error : `ArgumentError (unknown SSL method `TLSv1_3')`
I am using this via the Net-LDAP gem with `Net::LDAP.new({host: '127.0.0.1', port: 636, encryption: {method: :simple_tls, tls_options: {cert: $cert, ssl_version: 'TLS1_3', verify_mode: OpenSSL::SSL::VERIFY_PEER}}})`