### PR TITLE
hmac: implement base64digest methods

### DIFF
--- a/lib/openssl/hmac.rb
+++ b/lib/openssl/hmac.rb
@@ -10,6 +10,14 @@ module OpenSSL
       OpenSSL.fixed_length_secure_compare(self.digest, other.digest)
     end
 
+    # :call-seq:
+    #    hmac.base64digest -> string
+    #
+    # Returns the authentication code an a Base64-encoded string.
+    def base64digest
+      [digest].pack("m0")
+    end
+
     class << self
       # :call-seq:
       #    HMAC.digest(digest, key, data) -> aString
@@ -47,6 +55,23 @@ module OpenSSL
         hmac = new(key, digest)
         hmac << data
         hmac.hexdigest
+      end
+
+      # :call-seq:
+      #    HMAC.base64digest(digest, key, data) -> aString
+      #
+      # Returns the authentication code as a Base64-encoded string. The _digest_
+      # parameter specifies the digest algorithm to use. This may be a String
+      # representing the algorithm name or an instance of OpenSSL::Digest.
+      #
+      # === Example
+      #  key = 'key'
+      #  data = 'The quick brown fox jumps over the lazy dog'
+      #
+      #  hmac = OpenSSL::HMAC.base64digest('SHA1', key, data)
+      #  #=> "3nybhbi3iqa8ino29wqQcBydtNk="
+      def base64digest(digest, key, data)
+        [digest(digest, key, data)].pack("m0")
       end
     end
   end

--- a/test/openssl/test_hmac.rb
+++ b/test/openssl/test_hmac.rb
@@ -10,12 +10,14 @@ class OpenSSL::TestHMAC < OpenSSL::TestCase
     hmac.update("Hi There")
     assert_equal ["9294727a3638bb1c13f48ef8158bfc9d"].pack("H*"), hmac.digest
     assert_equal "9294727a3638bb1c13f48ef8158bfc9d", hmac.hexdigest
+    assert_equal "kpRyejY4uxwT9I74FYv8nQ==", hmac.base64digest
 
     # RFC 4231 4.2. Test Case 1
     hmac = OpenSSL::HMAC.new(["0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b"].pack("H*"), "SHA224")
     hmac.update("Hi There")
     assert_equal ["896fb1128abbdf196832107cd49df33f47b4b1169912ba4f53684b22"].pack("H*"), hmac.digest
     assert_equal "896fb1128abbdf196832107cd49df33f47b4b1169912ba4f53684b22", hmac.hexdigest
+    assert_equal "iW+xEoq73xloMhB81J3zP0e0sRaZErpPU2hLIg==", hmac.base64digest
   end
 
   def test_dup
@@ -57,6 +59,8 @@ class OpenSSL::TestHMAC < OpenSSL::TestCase
     assert_equal ["9294727a3638bb1c13f48ef8158bfc9d"].pack("H*"), digest
     hexdigest = OpenSSL::HMAC.hexdigest("MD5", key, "Hi There")
     assert_equal "9294727a3638bb1c13f48ef8158bfc9d", hexdigest
+    b64digest = OpenSSL::HMAC.base64digest("MD5", key, "Hi There")
+    assert_equal "kpRyejY4uxwT9I74FYv8nQ==", b64digest
   end
 end
 


### PR DESCRIPTION
OpenSSL::HMAC implements the similar interface as ::Digest. Let's add
base64digest methods to OpenSSL::HMAC, too, for feature parity.

Originally suggested at: https://github.com/ruby/openssl/pull/371#discussion_r429680842