### PR TITLE
ssl: initialize verify_mode and verify_hostname with default values

### DIFF
--- a/lib/openssl/ssl.rb
+++ b/lib/openssl/ssl.rb
@@ -122,6 +122,8 @@ YoaOffgTf5qxiwkjnlVZQc3whgnEt9FpVMvQ9eknyeGB5KHfayAc3+hUAvI3/Cr3
       def initialize(version = nil)
         self.options |= OpenSSL::SSL::OP_ALL
         self.ssl_version = version if version
+        self.verify_mode = OpenSSL::SSL::VERIFY_NONE
+        self.verify_hostname = false
       end
 
       ##

--- a/test/openssl/test_ssl.rb
+++ b/test/openssl/test_ssl.rb
@@ -246,6 +246,11 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
     end
   end
 
+  def test_verify_mode_default
+    ctx = OpenSSL::SSL::SSLContext.new
+    assert_equal OpenSSL::SSL::VERIFY_NONE, ctx.verify_mode
+  end
+
   def test_verify_mode_server_cert
     start_server(ignore_listener_error: true) { |port|
       populated_store = OpenSSL::X509::Store.new
@@ -919,6 +924,7 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
 
     start_server(ctx_proc: ctx_proc, ignore_listener_error: true) do |port|
       ctx = OpenSSL::SSL::SSLContext.new
+      assert_equal false, ctx.verify_hostname
       ctx.verify_hostname = true
       ctx.cert_store = OpenSSL::X509::Store.new
       ctx.cert_store.add_cert(@ca_cert)


### PR DESCRIPTION
**test/openssl/test_ssl: revise a test case for client_cert_cb**

The current test_client_auth_public_key test case checks that supplying
a PKey containing only public components through client_cert_cb will
cause handshake to fail. While this is a correct behavior as a whole,
the assertions are misleading in the sense that giving a public key is
causing the failure. Actually, the handshake fails because a client
certificate is not supplied at all, as a result of ArgumentError that is
silently ignored.

Rename the test case to test_client_cert_cb_ignore_error and simplify it
to clarify what it is testing.

---

**test/openssl/test_ssl: revise verify_mode test cases**

Add explicit test cases for the behaviors with different verify_mode.
If we made a bug in verify_mode, we would notice it by failures of other
test cases, but there were no dedicated test cases for verify_mode.

---

**ssl: initialize verify_mode and verify_hostname with default values**

SSLContext's verify_mode expects an SSL_VERIFY_* constant (an integer)
and verify_hostname expects either true or false. However, they are set
to nil after calling OpenSSL::SSL::SSLContext.new, which is surprising.

Set a proper value to them by default: verify_mode is set to
OpenSSL::SSL::VERIFY_NONE and verify_hostname is set to false by
default.

Note that this does not change the default behavior. The certificate
verification was never performed unless verify_mode is set to
OpenSSL::SSL::VERIFY_PEER by a user. The same applies to
verify_hostname.
