### PR TITLE
ssl: retry write on EPROTOTYPE on macOS

### DIFF
--- a/ext/openssl/ossl_ssl.c
+++ b/ext/openssl/ossl_ssl.c
@@ -1685,6 +1685,11 @@ ossl_start_ssl(VALUE self, int (*func)(), const char *funcname, VALUE opts)
             rb_io_wait_readable(fptr->fd);
             continue;
 	case SSL_ERROR_SYSCALL:
+#ifdef __APPLE__
+            /* See ossl_ssl_write_internal() */
+            if (errno == EPROTOTYPE)
+                continue;
+#endif
 	    if (errno) rb_sys_fail(funcname);
 	    ossl_raise(eSSLError, "%s SYSCALL returned=%d errno=%d state=%s", funcname, ret2, errno, SSL_state_string_long(ssl));
 #if defined(SSL_R_CERTIFICATE_VERIFY_FAILED)
@@ -1975,6 +1980,16 @@ ossl_ssl_write_internal(VALUE self, VALUE str, VALUE opts)
                 rb_io_wait_readable(fptr->fd);
                 continue;
 	    case SSL_ERROR_SYSCALL:
+#ifdef __APPLE__
+                /*
+                 * It appears that send syscall can return EPROTOTYPE if the
+                 * socket is being torn down. Retry to get a proper errno to
+                 * make the error handling in line with the socket library.
+                 * [Bug #14713] https://bugs.ruby-lang.org/issues/14713
+                 */
+                if (errno == EPROTOTYPE)
+                    continue;
+#endif
 		if (errno) rb_sys_fail(0);
 	    default:
 		ossl_raise(eSSLError, "SSL_write");


### PR DESCRIPTION
Errno::EPROTOTYPE is not supposed to be raised by SSLSocket#write.
However, on macOS, send(2) which is called via SSL_write() can
occasionally return EPROTOTYPE. Retry SSL_write() so that we get a
proper error, just as ext/socket does.

Reference: https://bugs.ruby-lang.org/issues/14713
Closes: https://github.com/ruby/openssl/issues/227

This totally slipped my mind, but it seems this is still needed.

 - master's test suite failing https://github.com/ruby/openssl/runs/975270914