### PR TITLE
require OpenSSL >= 1.0.2 and LibreSSL >= 3.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,11 +71,9 @@ jobs:
         os: [ ubuntu-latest ]
         ruby: [ "3.0" ]
         openssl:
-          - openssl-1.0.1u # EOL
           - openssl-1.0.2u # EOL
           - openssl-1.1.0l # EOL
           - openssl-1.1.1j
-          - libressl-2.9.2 # EOL
           - libressl-3.1.5
           - libressl-3.2.4
     steps:

--- a/ext/openssl/extconf.rb
+++ b/ext/openssl/extconf.rb
@@ -130,7 +130,6 @@ engines.each { |name|
 if !have_struct_member("SSL", "ctx", "openssl/ssl.h") || is_libressl
   $defs.push("-DHAVE_OPAQUE_OPENSSL")
 end
-have_func("CRYPTO_lock") || $defs.push("-DHAVE_OPENSSL_110_THREADING_API")
 have_func("BN_GENCB_new")
 have_func("BN_GENCB_free")
 have_func("BN_GENCB_get_arg")

--- a/ext/openssl/extconf.rb
+++ b/ext/openssl/extconf.rb
@@ -33,9 +33,6 @@ if $mswin || $mingw
   have_library("ws2_32")
 end
 
-Logging::message "=== Checking for required stuff... ===\n"
-result = pkg_config("openssl") && have_header("openssl/ssl.h")
-
 if $mingw
   append_cflags '-D_FORTIFY_SOURCE=2'
   append_ldflags '-fstack-protector'
@@ -92,19 +89,32 @@ def find_openssl_library
   return false
 end
 
-unless result
-  unless find_openssl_library
-    Logging::message "=== Checking for required stuff failed. ===\n"
-    Logging::message "Makefile wasn't created. Fix the errors above.\n"
-    raise "OpenSSL library could not be found. You might want to use " \
-      "--with-openssl-dir=<dir> option to specify the prefix where OpenSSL " \
-      "is installed."
-  end
+Logging::message "=== Checking for required stuff... ===\n"
+pkg_config_found = pkg_config("openssl") && have_header("openssl/ssl.h")
+
+if !pkg_config_found && !find_openssl_library
+  Logging::message "=== Checking for required stuff failed. ===\n"
+  Logging::message "Makefile wasn't created. Fix the errors above.\n"
+  raise "OpenSSL library could not be found. You might want to use " \
+    "--with-openssl-dir=<dir> option to specify the prefix where OpenSSL " \
+    "is installed."
 end
 
-unless checking_for("OpenSSL version is 1.0.1 or later") {
-    try_static_assert("OPENSSL_VERSION_NUMBER >= 0x10001000L", "openssl/opensslv.h") }
-  raise "OpenSSL >= 1.0.1 or LibreSSL is required"
+version_ok = if have_macro("LIBRESSL_VERSION_NUMBER", "openssl/opensslv.h")
+  is_libressl = true
+  checking_for("LibreSSL version >= 3.1.0") {
+    try_static_assert("LIBRESSL_VERSION_NUMBER >= 0x30100000L", "openssl/opensslv.h") }
+else
+  checking_for("OpenSSL version >= 1.0.2") {
+    try_static_assert("OPENSSL_VERSION_NUMBER >= 0x10002000L", "openssl/opensslv.h") }
+end
+unless version_ok
+  raise "OpenSSL >= 1.0.2 or LibreSSL >= 3.1.0 is required"
+end
+
+# Prevent wincrypt.h from being included, which defines conflicting macro with openssl/x509.h
+if is_libressl && ($mswin || $mingw)
+  $defs.push("-DNOCRYPT")
 end
 
 Logging::message "=== Checking for OpenSSL features... ===\n"
@@ -116,23 +126,8 @@ engines.each { |name|
   have_func("ENGINE_load_#{name}()", "openssl/engine.h")
 }
 
-if ($mswin || $mingw) && have_macro("LIBRESSL_VERSION_NUMBER", "openssl/opensslv.h")
-  $defs.push("-DNOCRYPT")
-end
-
-# added in 1.0.2
-have_func("EC_curve_nist2nid")
-have_func("X509_REVOKED_dup")
-have_func("X509_STORE_CTX_get0_store")
-have_func("SSL_CTX_set_alpn_select_cb")
-have_func("SSL_CTX_set1_curves_list(NULL, NULL)", "openssl/ssl.h")
-have_func("SSL_CTX_set_ecdh_auto(NULL, 0)", "openssl/ssl.h")
-have_func("SSL_get_server_tmp_key(NULL, NULL)", "openssl/ssl.h")
-have_func("SSL_is_server")
-
 # added in 1.1.0
-if !have_struct_member("SSL", "ctx", "openssl/ssl.h") ||
-    try_static_assert("LIBRESSL_VERSION_NUMBER >= 0x2070000fL", "openssl/opensslv.h")
+if !have_struct_member("SSL", "ctx", "openssl/ssl.h") || is_libressl
   $defs.push("-DHAVE_OPAQUE_OPENSSL")
 end
 have_func("CRYPTO_lock") || $defs.push("-DHAVE_OPENSSL_110_THREADING_API")

--- a/ext/openssl/openssl_missing.c
+++ b/ext/openssl/openssl_missing.c
@@ -17,43 +17,6 @@
 
 #include "openssl_missing.h"
 
-/* added in 1.0.2 */
-#if !defined(OPENSSL_NO_EC)
-#if !defined(HAVE_EC_CURVE_NIST2NID)
-static struct {
-    const char *name;
-    int nid;
-} nist_curves[] = {
-    {"B-163", NID_sect163r2},
-    {"B-233", NID_sect233r1},
-    {"B-283", NID_sect283r1},
-    {"B-409", NID_sect409r1},
-    {"B-571", NID_sect571r1},
-    {"K-163", NID_sect163k1},
-    {"K-233", NID_sect233k1},
-    {"K-283", NID_sect283k1},
-    {"K-409", NID_sect409k1},
-    {"K-571", NID_sect571k1},
-    {"P-192", NID_X9_62_prime192v1},
-    {"P-224", NID_secp224r1},
-    {"P-256", NID_X9_62_prime256v1},
-    {"P-384", NID_secp384r1},
-    {"P-521", NID_secp521r1}
-};
-
-int
-ossl_EC_curve_nist2nid(const char *name)
-{
-    size_t i;
-    for (i = 0; i < (sizeof(nist_curves) / sizeof(nist_curves[0])); i++) {
-	if (!strcmp(nist_curves[i].name, name))
-	    return nist_curves[i].nid;
-    }
-    return NID_undef;
-}
-#endif
-#endif
-
 /*** added in 1.1.0 ***/
 #if !defined(HAVE_X509_CRL_GET0_SIGNATURE)
 void

--- a/ext/openssl/openssl_missing.h
+++ b/ext/openssl/openssl_missing.h
@@ -12,27 +12,6 @@
 
 #include "ruby/config.h"
 
-/* added in 1.0.2 */
-#if !defined(OPENSSL_NO_EC)
-#if !defined(HAVE_EC_CURVE_NIST2NID)
-int ossl_EC_curve_nist2nid(const char *);
-#  define EC_curve_nist2nid ossl_EC_curve_nist2nid
-#endif
-#endif
-
-#if !defined(HAVE_X509_REVOKED_DUP)
-# define X509_REVOKED_dup(rev) (X509_REVOKED *)ASN1_dup((i2d_of_void *)i2d_X509_REVOKED, \
-	(d2i_of_void *)d2i_X509_REVOKED, (char *)(rev))
-#endif
-
-#if !defined(HAVE_X509_STORE_CTX_GET0_STORE)
-#  define X509_STORE_CTX_get0_store(x) ((x)->ctx)
-#endif
-
-#if !defined(HAVE_SSL_IS_SERVER)
-#  define SSL_is_server(s) ((s)->server)
-#endif
-
 /* added in 1.1.0 */
 #if !defined(HAVE_BN_GENCB_NEW)
 #  define BN_GENCB_new() ((BN_GENCB *)OPENSSL_malloc(sizeof(BN_GENCB)))
@@ -141,8 +120,7 @@ void ossl_X509_REQ_get0_signature(const X509_REQ *, const ASN1_BIT_STRING **, co
 	CRYPTO_add(&(x)->references, 1, CRYPTO_LOCK_EVP_PKEY);
 #endif
 
-#if !defined(HAVE_OPAQUE_OPENSSL) && \
-    (!defined(LIBRESSL_VERSION_NUMBER) || LIBRESSL_VERSION_NUMBER < 0x2070000fL)
+#if !defined(HAVE_OPAQUE_OPENSSL)
 #define IMPL_PKEY_GETTER(_type, _name) \
 static inline _type *EVP_PKEY_get0_##_type(EVP_PKEY *pkey) { \
 	return pkey->pkey._name; }

--- a/ext/openssl/ossl.c
+++ b/ext/openssl/ossl.c
@@ -9,7 +9,13 @@
  */
 #include "ossl.h"
 #include <stdarg.h> /* for ossl_raise */
-#include <ruby/thread_native.h> /* for OpenSSL < 1.1.0 locks */
+
+/* OpenSSL >= 1.1.0 and LibreSSL >= 2.9.0 */
+#if defined(LIBRESSL_VERSION_NUMBER) || OPENSSL_VERSION_NUMBER >= 0x10100000
+# define HAVE_OPENSSL_110_THREADING_API
+#else
+# include <ruby/thread_native.h>
+#endif
 
 /*
  * Data Conversion

--- a/ext/openssl/ossl_ocsp.c
+++ b/ext/openssl/ossl_ocsp.c
@@ -1069,55 +1069,7 @@ ossl_ocspbres_verify(int argc, VALUE *argv, VALUE self)
     x509st = GetX509StorePtr(store);
     flg = NIL_P(flags) ? 0 : NUM2INT(flags);
     x509s = ossl_x509_ary2sk(certs);
-#if (OPENSSL_VERSION_NUMBER < 0x1000202fL) || defined(LIBRESSL_VERSION_NUMBER)
-    /*
-     * OpenSSL had a bug that it doesn't use the certificates in x509s for
-     * verifying the chain. This can be a problem when the response is signed by
-     * a certificate issued by an intermediate CA.
-     *
-     *       root_ca
-     *         |
-     *   intermediate_ca
-     *         |-------------|
-     *     end_entity    ocsp_signer
-     *
-     * When the certificate hierarchy is like this, and the response contains
-     * only ocsp_signer certificate, the following code wrongly fails.
-     *
-     *   store = OpenSSL::X509::Store.new; store.add_cert(root_ca)
-     *   basic_response.verify([intermediate_ca], store)
-     *
-     * So add the certificates in x509s to the embedded certificates list first.
-     *
-     * This is fixed in OpenSSL 0.9.8zg, 1.0.0s, 1.0.1n, 1.0.2b. But it still
-     * exists in LibreSSL 2.1.10, 2.2.9, 2.3.6, 2.4.1.
-     */
-    if (!(flg & (OCSP_NOCHAIN | OCSP_NOVERIFY)) &&
-	sk_X509_num(x509s) && sk_X509_num(bs->certs)) {
-	int i;
-
-	bs = ASN1_item_dup(ASN1_ITEM_rptr(OCSP_BASICRESP), bs);
-	if (!bs) {
-	    sk_X509_pop_free(x509s, X509_free);
-	    ossl_raise(eOCSPError, "ASN1_item_dup");
-	}
-
-	for (i = 0; i < sk_X509_num(x509s); i++) {
-	    if (!OCSP_basic_add1_cert(bs, sk_X509_value(x509s, i))) {
-		sk_X509_pop_free(x509s, X509_free);
-		OCSP_BASICRESP_free(bs);
-		ossl_raise(eOCSPError, "OCSP_basic_add1_cert");
-	    }
-	}
-	result = OCSP_basic_verify(bs, x509s, x509st, flg);
-	OCSP_BASICRESP_free(bs);
-    }
-    else {
-	result = OCSP_basic_verify(bs, x509s, x509st, flg);
-    }
-#else
     result = OCSP_basic_verify(bs, x509s, x509st, flg);
-#endif
     sk_X509_pop_free(x509s, X509_free);
     if (result <= 0)
 	ossl_clear_error();

--- a/ext/openssl/ossl_ssl.c
+++ b/ext/openssl/ossl_ssl.c
@@ -93,14 +93,15 @@ ossl_sslctx_s_alloc(VALUE klass)
     RTYPEDDATA_DATA(obj) = ctx;
     SSL_CTX_set_ex_data(ctx, ossl_sslctx_ex_ptr_idx, (void *)obj);
 
-#if !defined(OPENSSL_NO_EC)
+#if !defined(OPENSSL_NO_EC) && OPENSSL_VERSION_NUMBER < 0x10100000 && \
+    !defined(LIBRESSL_VERSION_NUMBER)
     /* We use SSL_CTX_set1_curves_list() to specify the curve used in ECDH. It
      * allows to specify multiple curve names and OpenSSL will select
      * automatically from them. In OpenSSL 1.0.2, the automatic selection has to
-     * be enabled explicitly. But OpenSSL 1.1.0 removed the knob and it is
-     * always enabled. To uniform the behavior, we enable the automatic
-     * selection also in 1.0.2. Users can still disable ECDH by removing ECDH
-     * cipher suites by SSLContext#ciphers=. */
+     * be enabled explicitly. OpenSSL 1.1.0 and LibreSSL 2.6.1 removed the knob
+     * and it is always enabled. To uniform the behavior, we enable the
+     * automatic selection also in 1.0.2. Users can still disable ECDH by
+     * removing ECDH cipher suites by SSLContext#ciphers=. */
     if (!SSL_CTX_set_ecdh_auto(ctx, 1))
 	ossl_raise(eSSLError, "SSL_CTX_set_ecdh_auto");
 #endif

--- a/ext/openssl/ossl_ssl.c
+++ b/ext/openssl/ossl_ssl.c
@@ -81,7 +81,7 @@ ossl_sslctx_s_alloc(VALUE klass)
     VALUE obj;
 
     obj = TypedData_Wrap_Struct(klass, &ossl_sslctx_type, 0);
-#if OPENSSL_VERSION_NUMBER >= 0x10100000 && !defined(LIBRESSL_VERSION_NUMBER)
+#if OPENSSL_VERSION_NUMBER >= 0x10100000 || defined(LIBRESSL_VERSION_NUMBER)
     ctx = SSL_CTX_new(TLS_method());
 #else
     ctx = SSL_CTX_new(SSLv23_method());

--- a/ext/openssl/ossl_ssl.c
+++ b/ext/openssl/ossl_ssl.c
@@ -55,19 +55,11 @@ static ID id_i_io, id_i_context, id_i_hostname;
 static int ossl_ssl_ex_vcb_idx;
 static int ossl_ssl_ex_ptr_idx;
 static int ossl_sslctx_ex_ptr_idx;
-#if !defined(HAVE_X509_STORE_UP_REF)
-static int ossl_sslctx_ex_store_p;
-#endif
 
 static void
 ossl_sslctx_free(void *ptr)
 {
-    SSL_CTX *ctx = ptr;
-#if !defined(HAVE_X509_STORE_UP_REF)
-    if (ctx && SSL_CTX_get_ex_data(ctx, ossl_sslctx_ex_store_p))
-	ctx->cert_store = NULL;
-#endif
-    SSL_CTX_free(ctx);
+    SSL_CTX_free(ptr);
 }
 
 static const rb_data_type_t ossl_sslctx_type = {
@@ -101,7 +93,7 @@ ossl_sslctx_s_alloc(VALUE klass)
     RTYPEDDATA_DATA(obj) = ctx;
     SSL_CTX_set_ex_data(ctx, ossl_sslctx_ex_ptr_idx, (void *)obj);
 
-#if !defined(OPENSSL_NO_EC) && defined(HAVE_SSL_CTX_SET_ECDH_AUTO)
+#if !defined(OPENSSL_NO_EC)
     /* We use SSL_CTX_set1_curves_list() to specify the curve used in ECDH. It
      * allows to specify multiple curve names and OpenSSL will select
      * automatically from them. In OpenSSL 1.0.2, the automatic selection has to
@@ -363,7 +355,7 @@ ossl_call_session_get_cb(VALUE ary)
 }
 
 static SSL_SESSION *
-#if (!defined(LIBRESSL_VERSION_NUMBER) ? OPENSSL_VERSION_NUMBER >= 0x10100000 : LIBRESSL_VERSION_NUMBER >= 0x2080000f)
+#if defined(LIBRESSL_VERSION_NUMBER) || OPENSSL_VERSION_NUMBER >= 0x10100000
 ossl_sslctx_session_get_cb(SSL *ssl, const unsigned char *buf, int len, int *copy)
 #else
 ossl_sslctx_session_get_cb(SSL *ssl, unsigned char *buf, int len, int *copy)
@@ -572,8 +564,6 @@ ssl_renegotiation_cb(const SSL *ssl)
     rb_funcallv(cb, id_call, 1, &ssl_obj);
 }
 
-#if !defined(OPENSSL_NO_NEXTPROTONEG) || \
-    defined(HAVE_SSL_CTX_SET_ALPN_SELECT_CB)
 static VALUE
 ssl_npn_encode_protocol_i(RB_BLOCK_CALL_FUNC_ARGLIST(cur, encoded))
 {
@@ -655,7 +645,6 @@ ssl_npn_select_cb_common(SSL *ssl, VALUE cb, const unsigned char **out,
 
     return SSL_TLSEXT_ERR_OK;
 }
-#endif
 
 #ifndef OPENSSL_NO_NEXTPROTONEG
 static int
@@ -684,7 +673,6 @@ ssl_npn_select_cb(SSL *ssl, unsigned char **out, unsigned char *outlen,
 }
 #endif
 
-#ifdef HAVE_SSL_CTX_SET_ALPN_SELECT_CB
 static int
 ssl_alpn_select_cb(SSL *ssl, const unsigned char **out, unsigned char *outlen,
 		   const unsigned char *in, unsigned int inlen, void *arg)
@@ -696,7 +684,6 @@ ssl_alpn_select_cb(SSL *ssl, const unsigned char **out, unsigned char *outlen,
 
     return ssl_npn_select_cb_common(ssl, cb, out, outlen, in, inlen);
 }
-#endif
 
 /* This function may serve as the entry point to support further callbacks. */
 static void
@@ -781,17 +768,7 @@ ossl_sslctx_setup(VALUE self)
     if (!NIL_P(val)) {
 	X509_STORE *store = GetX509StorePtr(val); /* NO NEED TO DUP */
 	SSL_CTX_set_cert_store(ctx, store);
-#if !defined(HAVE_X509_STORE_UP_REF)
-	/*
-         * WORKAROUND:
-	 *   X509_STORE can count references, but
-	 *   X509_STORE_free() doesn't care it.
-	 *   So we won't increment it but mark it by ex_data.
-	 */
-        SSL_CTX_set_ex_data(ctx, ossl_sslctx_ex_store_p, ctx);
-#else /* Fixed in OpenSSL 1.0.2; bff9ce4db38b (master), 5b4b9ce976fc (1.0.2) */
 	X509_STORE_up_ref(store);
-#endif
     }
 
     val = rb_attr_get(self, id_i_extra_chain_cert);
@@ -873,7 +850,6 @@ ossl_sslctx_setup(VALUE self)
     }
 #endif
 
-#ifdef HAVE_SSL_CTX_SET_ALPN_SELECT_CB
     val = rb_attr_get(self, id_i_alpn_protocols);
     if (!NIL_P(val)) {
 	VALUE rprotos = ssl_encode_npn_protocols(val);
@@ -888,7 +864,6 @@ ossl_sslctx_setup(VALUE self)
 	SSL_CTX_set_alpn_select_cb(ctx, ssl_alpn_select_cb, (void *) self);
 	OSSL_Debug("SSL ALPN select callback added");
     }
-#endif
 
     rb_obj_freeze(self);
 
@@ -1021,9 +996,6 @@ ossl_sslctx_set_ciphers(VALUE self, VALUE v)
  * Extension. For a server, the list is used by OpenSSL to determine the set of
  * shared curves. OpenSSL will pick the most appropriate one from it.
  *
- * Note that this works differently with old OpenSSL (<= 1.0.1). Only one curve
- * can be set, and this has no effect for TLS clients.
- *
  * === Example
  *   ctx1 = OpenSSL::SSL::SSLContext.new
  *   ctx1.ecdh_curves = "X25519:P-256:P-224"
@@ -1047,48 +1019,8 @@ ossl_sslctx_set_ecdh_curves(VALUE self, VALUE arg)
     GetSSLCTX(self, ctx);
     StringValueCStr(arg);
 
-#if defined(HAVE_SSL_CTX_SET1_CURVES_LIST)
     if (!SSL_CTX_set1_curves_list(ctx, RSTRING_PTR(arg)))
 	ossl_raise(eSSLError, NULL);
-#else
-    /* OpenSSL does not have SSL_CTX_set1_curves_list()... Fallback to
-     * SSL_CTX_set_tmp_ecdh(). So only the first curve is used. */
-    {
-	VALUE curve, splitted;
-	EC_KEY *ec;
-	int nid;
-
-	splitted = rb_str_split(arg, ":");
-	if (!RARRAY_LEN(splitted))
-	    ossl_raise(eSSLError, "invalid input format");
-	curve = RARRAY_AREF(splitted, 0);
-	StringValueCStr(curve);
-
-	/* SSL_CTX_set1_curves_list() accepts NIST names */
-	nid = EC_curve_nist2nid(RSTRING_PTR(curve));
-	if (nid == NID_undef)
-	    nid = OBJ_txt2nid(RSTRING_PTR(curve));
-	if (nid == NID_undef)
-	    ossl_raise(eSSLError, "unknown curve name");
-
-	ec = EC_KEY_new_by_curve_name(nid);
-	if (!ec)
-	    ossl_raise(eSSLError, NULL);
-	EC_KEY_set_asn1_flag(ec, OPENSSL_EC_NAMED_CURVE);
-	if (!SSL_CTX_set_tmp_ecdh(ctx, ec)) {
-	    EC_KEY_free(ec);
-	    ossl_raise(eSSLError, "SSL_CTX_set_tmp_ecdh");
-	}
-	EC_KEY_free(ec);
-# if defined(HAVE_SSL_CTX_SET_ECDH_AUTO)
-	/* tmp_ecdh and ecdh_auto conflict. tmp_ecdh is ignored when ecdh_auto
-	 * is enabled. So disable ecdh_auto. */
-	if (!SSL_CTX_set_ecdh_auto(ctx, 0))
-	    ossl_raise(eSSLError, "SSL_CTX_set_ecdh_auto");
-# endif
-    }
-#endif
-
     return arg;
 }
 #else
@@ -1211,10 +1143,6 @@ ossl_sslctx_enable_fallback_scsv(VALUE self)
  *   ecdsa_pkey = ...
  *   another_ca_cert = ...
  *   ctx.add_certificate(ecdsa_cert, ecdsa_pkey, [another_ca_cert])
- *
- * === Note
- * OpenSSL before the version 1.0.2 could handle only one extra chain across
- * all key types. Calling this method discards the chain set previously.
  */
 static VALUE
 ossl_sslctx_add_certificate(int argc, VALUE *argv, VALUE self)
@@ -1253,34 +1181,9 @@ ossl_sslctx_add_certificate(int argc, VALUE *argv, VALUE self)
 	sk_X509_pop_free(extra_chain, X509_free);
 	ossl_raise(eSSLError, "SSL_CTX_use_PrivateKey");
     }
-
-    if (extra_chain) {
-#if OPENSSL_VERSION_NUMBER >= 0x10002000 && !defined(LIBRESSL_VERSION_NUMBER)
-	if (!SSL_CTX_set0_chain(ctx, extra_chain)) {
-	    sk_X509_pop_free(extra_chain, X509_free);
-	    ossl_raise(eSSLError, "SSL_CTX_set0_chain");
-	}
-#else
-	STACK_OF(X509) *orig_extra_chain;
-	X509 *x509_tmp;
-
-	/* First, clear the existing chain */
-	SSL_CTX_get_extra_chain_certs(ctx, &orig_extra_chain);
-	if (orig_extra_chain && sk_X509_num(orig_extra_chain)) {
-	    rb_warning("SSL_CTX_set0_chain() is not available; " \
-		       "clearing previously set certificate chain");
-	    SSL_CTX_clear_extra_chain_certs(ctx);
-	}
-	while ((x509_tmp = sk_X509_shift(extra_chain))) {
-	    /* Transfers ownership */
-	    if (!SSL_CTX_add_extra_chain_cert(ctx, x509_tmp)) {
-		X509_free(x509_tmp);
-		sk_X509_pop_free(extra_chain, X509_free);
-		ossl_raise(eSSLError, "SSL_CTX_add_extra_chain_cert");
-	    }
-	}
-	sk_X509_free(extra_chain);
-#endif
+    if (extra_chain && !SSL_CTX_set0_chain(ctx, extra_chain)) {
+        sk_X509_pop_free(extra_chain, X509_free);
+        ossl_raise(eSSLError, "SSL_CTX_set0_chain");
     }
     return self;
 }
@@ -2381,7 +2284,6 @@ ossl_ssl_npn_protocol(VALUE self)
 }
 # endif
 
-# ifdef HAVE_SSL_CTX_SET_ALPN_SELECT_CB
 /*
  * call-seq:
  *    ssl.alpn_protocol => String | nil
@@ -2404,9 +2306,7 @@ ossl_ssl_alpn_protocol(VALUE self)
     else
 	return rb_str_new((const char *) out, outlen);
 }
-# endif
 
-# ifdef HAVE_SSL_GET_SERVER_TMP_KEY
 /*
  * call-seq:
  *    ssl.tmp_key => PKey or nil
@@ -2424,7 +2324,6 @@ ossl_ssl_tmp_key(VALUE self)
 	return Qnil;
     return ossl_pkey_new(key);
 }
-# endif /* defined(HAVE_SSL_GET_SERVER_TMP_KEY) */
 #endif /* !defined(OPENSSL_NO_SOCK) */
 
 void
@@ -2449,11 +2348,6 @@ Init_ossl_ssl(void)
     ossl_sslctx_ex_ptr_idx = SSL_CTX_get_ex_new_index(0, (void *)"ossl_sslctx_ex_ptr_idx", 0, 0, 0);
     if (ossl_sslctx_ex_ptr_idx < 0)
 	ossl_raise(rb_eRuntimeError, "SSL_CTX_get_ex_new_index");
-#if !defined(HAVE_X509_STORE_UP_REF)
-    ossl_sslctx_ex_store_p = SSL_CTX_get_ex_new_index(0, (void *)"ossl_sslctx_ex_store_p", 0, 0, 0);
-    if (ossl_sslctx_ex_store_p < 0)
-	ossl_raise(rb_eRuntimeError, "SSL_CTX_get_ex_new_index");
-#endif
 
     /* Document-module: OpenSSL::SSL
      *
@@ -2690,7 +2584,6 @@ Init_ossl_ssl(void)
     rb_attr(cSSLContext, rb_intern_const("npn_select_cb"), 1, 1, Qfalse);
 #endif
 
-#ifdef HAVE_SSL_CTX_SET_ALPN_SELECT_CB
     /*
      * An Enumerable of Strings. Each String represents a protocol to be
      * advertised as the list of supported protocols for Application-Layer
@@ -2720,7 +2613,6 @@ Init_ossl_ssl(void)
      *   end
      */
     rb_attr(cSSLContext, rb_intern_const("alpn_select_cb"), 1, 1, Qfalse);
-#endif
 
     rb_define_alias(cSSLContext, "ssl_timeout", "timeout");
     rb_define_alias(cSSLContext, "ssl_timeout=", "timeout=");
@@ -2834,12 +2726,8 @@ Init_ossl_ssl(void)
     rb_define_method(cSSLSocket, "hostname=", ossl_ssl_set_hostname, 1);
     rb_define_method(cSSLSocket, "finished_message", ossl_ssl_get_finished, 0);
     rb_define_method(cSSLSocket, "peer_finished_message", ossl_ssl_get_peer_finished, 0);
-# ifdef HAVE_SSL_GET_SERVER_TMP_KEY
     rb_define_method(cSSLSocket, "tmp_key", ossl_ssl_tmp_key, 0);
-# endif
-# ifdef HAVE_SSL_CTX_SET_ALPN_SELECT_CB
     rb_define_method(cSSLSocket, "alpn_protocol", ossl_ssl_alpn_protocol, 0);
-# endif
 # ifndef OPENSSL_NO_NEXTPROTONEG
     rb_define_method(cSSLSocket, "npn_protocol", ossl_ssl_npn_protocol, 0);
 # endif
@@ -2852,12 +2740,8 @@ Init_ossl_ssl(void)
 
     rb_define_const(mSSL, "OP_ALL", ULONG2NUM(SSL_OP_ALL));
     rb_define_const(mSSL, "OP_LEGACY_SERVER_CONNECT", ULONG2NUM(SSL_OP_LEGACY_SERVER_CONNECT));
-#ifdef SSL_OP_TLSEXT_PADDING /* OpenSSL 1.0.1h and OpenSSL 1.0.2 */
     rb_define_const(mSSL, "OP_TLSEXT_PADDING", ULONG2NUM(SSL_OP_TLSEXT_PADDING));
-#endif
-#ifdef SSL_OP_SAFARI_ECDHE_ECDSA_BUG /* OpenSSL 1.0.1f and OpenSSL 1.0.2 */
     rb_define_const(mSSL, "OP_SAFARI_ECDHE_ECDSA_BUG", ULONG2NUM(SSL_OP_SAFARI_ECDHE_ECDSA_BUG));
-#endif
 #ifdef SSL_OP_ALLOW_NO_DHE_KEX /* OpenSSL 1.1.1 */
     rb_define_const(mSSL, "OP_ALLOW_NO_DHE_KEX", ULONG2NUM(SSL_OP_ALLOW_NO_DHE_KEX));
 #endif

--- a/ext/openssl/ossl_ts.c
+++ b/ext/openssl/ossl_ts.c
@@ -821,12 +821,9 @@ ossl_ts_resp_verify(int argc, VALUE *argv, VALUE self)
     TS_VERIFY_CTX_set_store(ctx, x509st);
 
     ok = TS_RESP_verify_response(ctx, resp);
-
-    /* WORKAROUND:
-     *   X509_STORE can count references, but X509_STORE_free() doesn't check
-     *   this. To prevent our X509_STORE from being freed with our
-     *   TS_VERIFY_CTX we set the store to NULL first.
-     *   Fixed in OpenSSL 1.0.2; bff9ce4db38b (master), 5b4b9ce976fc (1.0.2)
+    /*
+     * TS_VERIFY_CTX_set_store() call above does not increment the reference
+     * counter, so it must be unset before TS_VERIFY_CTX_free() is called.
      */
     TS_VERIFY_CTX_set_store(ctx, NULL);
     TS_VERIFY_CTX_free(ctx);

--- a/ext/openssl/ossl_x509.c
+++ b/ext/openssl/ossl_x509.c
@@ -115,11 +115,9 @@ Init_ossl_x509(void)
     DefX509Const(V_ERR_SUITE_B_LOS_NOT_ALLOWED);
     DefX509Const(V_ERR_SUITE_B_CANNOT_SIGN_P_384_WITH_P_256);
 #endif
-#if defined(X509_V_ERR_HOSTNAME_MISMATCH)
     DefX509Const(V_ERR_HOSTNAME_MISMATCH);
     DefX509Const(V_ERR_EMAIL_MISMATCH);
     DefX509Const(V_ERR_IP_ADDRESS_MISMATCH);
-#endif
 #if defined(X509_V_ERR_DANE_NO_MATCH)
     DefX509Const(V_ERR_DANE_NO_MATCH);
 #endif
@@ -187,12 +185,10 @@ Init_ossl_x509(void)
     /* Set by Store#flags= and StoreContext#flags=. Enables checking of the
      * signature of the root self-signed CA. */
     DefX509Const(V_FLAG_CHECK_SS_SIGNATURE);
-#if defined(X509_V_FLAG_TRUSTED_FIRST)
     /* Set by Store#flags= and StoreContext#flags=. When constructing a
      * certificate chain, search the Store first for the issuer certificate.
      * Enabled by default in OpenSSL >= 1.1.0. */
     DefX509Const(V_FLAG_TRUSTED_FIRST);
-#endif
 #if defined(X509_V_FLAG_SUITEB_128_LOS_ONLY)
     /* Set by Store#flags= and StoreContext#flags=.
      * Enables Suite B 128 bit only mode. */
@@ -208,11 +204,9 @@ Init_ossl_x509(void)
      * Enables Suite B 128 bit mode allowing 192 bit algorithms. */
     DefX509Const(V_FLAG_SUITEB_128_LOS);
 #endif
-#if defined(X509_V_FLAG_PARTIAL_CHAIN)
     /* Set by Store#flags= and StoreContext#flags=.
      * Allows partial chains if at least one certificate is in trusted store. */
     DefX509Const(V_FLAG_PARTIAL_CHAIN);
-#endif
 #if defined(X509_V_FLAG_NO_ALT_CHAINS)
     /* Set by Store#flags= and StoreContext#flags=. Suppresses searching for
      * a alternative chain. No effect in OpenSSL >= 1.1.0. */

--- a/test/openssl/test_asn1.rb
+++ b/test/openssl/test_asn1.rb
@@ -265,10 +265,9 @@ class  OpenSSL::TestASN1 < OpenSSL::TestCase
     assert_raise(OpenSSL::ASN1::ASN1Error) {
       OpenSSL::ASN1.decode(B(%w{ 03 00 }))
     }
-    # OpenSSL < OpenSSL_1_0_1k and LibreSSL ignore the error
-    # assert_raise(OpenSSL::ASN1::ASN1Error) {
-    #   OpenSSL::ASN1.decode(B(%w{ 03 03 08 FF 00 }))
-    # }
+    assert_raise(OpenSSL::ASN1::ASN1Error) {
+      OpenSSL::ASN1.decode(B(%w{ 03 03 08 FF 00 }))
+    }
     # OpenSSL does not seem to prohibit this, though X.690 8.6.2.3 (15/08) does
     # assert_raise(OpenSSL::ASN1::ASN1Error) {
     #   OpenSSL::ASN1.decode(B(%w{ 03 01 04 }))

--- a/test/openssl/test_ocsp.rb
+++ b/test/openssl/test_ocsp.rb
@@ -123,14 +123,7 @@ class OpenSSL::TestOCSP < OpenSSL::TestCase
 
     assert_equal true, req.verify([@cert], store, OpenSSL::OCSP::NOINTERN)
     ret = req.verify([@cert], store)
-    if ret || openssl?(1, 0, 2)
-      assert_equal true, ret
-    else
-      # RT2560; OCSP_request_verify() does not find signer cert from 'certs' when
-      # OCSP_NOINTERN is not specified.
-      # fixed by OpenSSL 1.0.1j, 1.0.2
-      pend "RT2560: ocsp_req_find_signer"
-    end
+    assert_equal true, ret
 
     # not signed
     req = OpenSSL::OCSP::Request.new.add_certid(cid)

--- a/test/openssl/test_ssl.rb
+++ b/test/openssl/test_ssl.rb
@@ -127,21 +127,13 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
     pend "EC is not supported" unless defined?(OpenSSL::PKey::EC)
     pend "TLS 1.2 is not supported" unless tls12_supported?
 
-    # SSL_CTX_set0_chain() is needed for setting multiple certificate chains
-    add0_chain_supported = openssl?(1, 0, 2)
-
-    if add0_chain_supported
-      ca2_key = Fixtures.pkey("rsa-3")
-      ca2_exts = [
-        ["basicConstraints", "CA:TRUE", true],
-        ["keyUsage", "cRLSign, keyCertSign", true],
-      ]
-      ca2_dn = OpenSSL::X509::Name.parse_rfc2253("CN=CA2")
-      ca2_cert = issue_cert(ca2_dn, ca2_key, 123, ca2_exts, nil, nil)
-    else
-      # Use the same CA as @svr_cert
-      ca2_key = @ca_key; ca2_cert = @ca_cert
-    end
+    ca2_key = Fixtures.pkey("rsa-3")
+    ca2_exts = [
+      ["basicConstraints", "CA:TRUE", true],
+      ["keyUsage", "cRLSign, keyCertSign", true],
+    ]
+    ca2_dn = OpenSSL::X509::Name.parse_rfc2253("CN=CA2")
+    ca2_cert = issue_cert(ca2_dn, ca2_key, 123, ca2_exts, nil, nil)
 
     ecdsa_key = Fixtures.pkey("p256")
     exts = [
@@ -150,23 +142,11 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
     ecdsa_dn = OpenSSL::X509::Name.parse_rfc2253("CN=localhost2")
     ecdsa_cert = issue_cert(ecdsa_dn, ecdsa_key, 456, exts, ca2_cert, ca2_key)
 
-    if !add0_chain_supported
-      # Testing the warning emitted when 'extra' chain is replaced
-      tctx = OpenSSL::SSL::SSLContext.new
-      tctx.add_certificate(@svr_cert, @svr_key, [@ca_cert])
-      assert_warning(/set0_chain/) {
-        tctx.add_certificate(ecdsa_cert, ecdsa_key, [ca2_cert])
-      }
-    end
-
     ctx_proc = -> ctx {
       # Unset values set by start_server
       ctx.cert = ctx.key = ctx.extra_chain_cert = nil
-      ctx.ecdh_curves = "P-256" unless openssl?(1, 0, 2)
       ctx.add_certificate(@svr_cert, @svr_key, [@ca_cert]) # RSA
-      EnvUtil.suppress_warning do # !add0_chain_supported
-        ctx.add_certificate(ecdsa_cert, ecdsa_key, [ca2_cert])
-      end
+      ctx.add_certificate(ecdsa_cert, ecdsa_key, [ca2_cert])
     }
     start_server(ctx_proc: ctx_proc) do |port|
       ctx = OpenSSL::SSL::SSLContext.new
@@ -997,10 +977,7 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
         ssl.hostname = "b.example.com"
         assert_handshake_error { ssl.connect }
         assert_equal false, verify_callback_ok
-        code_expected = openssl?(1, 0, 2) || defined?(OpenSSL::X509::V_ERR_HOSTNAME_MISMATCH) ?
-          OpenSSL::X509::V_ERR_HOSTNAME_MISMATCH :
-          OpenSSL::X509::V_ERR_CERT_REJECTED
-        assert_equal code_expected, verify_callback_err
+        assert_equal OpenSSL::X509::V_ERR_HOSTNAME_MISMATCH, verify_callback_err
       ensure
         sock&.close
       end
@@ -1290,7 +1267,6 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
     }
   end
 
-if openssl?(1, 0, 2) || libressl?
   def test_alpn_protocol_selection_ary
     advertised = ["http/1.1", "spdy/2"]
     ctx_proc = Proc.new { |ctx|
@@ -1336,7 +1312,6 @@ if openssl?(1, 0, 2) || libressl?
     t&.kill
     t&.join
   end
-end
 
   def test_npn_protocol_selection_ary
     pend "TLS 1.2 is not supported" unless tls12_supported?
@@ -1454,11 +1429,6 @@ end
   end
 
   def test_get_ephemeral_key
-    # OpenSSL >= 1.0.2
-    unless OpenSSL::SSL::SSLSocket.method_defined?(:tmp_key)
-      pend "SSL_get_server_tmp_key() is not supported"
-    end
-
     if tls12_supported?
       # kRSA
       ctx_proc1 = proc { |ctx|
@@ -1589,9 +1559,7 @@ end
     start_server(ctx_proc: ctx_proc) do |port|
       server_connect(port) { |ssl|
         assert called, "dh callback should be called"
-        if ssl.respond_to?(:tmp_key)
-          assert_equal dh.to_der, ssl.tmp_key.to_der
-        end
+        assert_equal dh.to_der, ssl.tmp_key.to_der
       }
     end
   end
@@ -1623,34 +1591,30 @@ end
       ctx.ecdh_curves = "P-384:P-521"
     }
     start_server(ctx_proc: ctx_proc, ignore_listener_error: true) do |port|
+      # Test 1: Client=P-256:P-384, Server=P-384:P-521 --> P-384
       ctx = OpenSSL::SSL::SSLContext.new
-      ctx.ecdh_curves = "P-256:P-384" # disable P-521 for OpenSSL >= 1.0.2
-
+      ctx.ecdh_curves = "P-256:P-384"
       server_connect(port, ctx) { |ssl|
         cs = ssl.cipher[0]
         assert_match (/\AECDH/), cs
-        if ssl.respond_to?(:tmp_key)
-          assert_equal "secp384r1", ssl.tmp_key.group.curve_name
-        end
+        assert_equal "secp384r1", ssl.tmp_key.group.curve_name
         ssl.puts "abc"; assert_equal "abc\n", ssl.gets
       }
 
-      if openssl?(1, 0, 2) || libressl?(2, 5, 1)
-        ctx = OpenSSL::SSL::SSLContext.new
-        ctx.ecdh_curves = "P-256"
+      # Test 2: Client=P-256, Server=P-521:P-384 --> Fail
+      ctx = OpenSSL::SSL::SSLContext.new
+      ctx.ecdh_curves = "P-256"
+      assert_raise(OpenSSL::SSL::SSLError) {
+        server_connect(port, ctx) { }
+      }
 
-        assert_raise(OpenSSL::SSL::SSLError) {
-          server_connect(port, ctx) { }
-        }
-
-        ctx = OpenSSL::SSL::SSLContext.new
-        ctx.ecdh_curves = "P-521:P-384"
-
-        server_connect(port, ctx) { |ssl|
-          assert_equal "secp521r1", ssl.tmp_key.group.curve_name
-          ssl.puts "abc"; assert_equal "abc\n", ssl.gets
-        }
-      end
+      # Test 3: Client=P-521:P-384, Server=P-521:P-384 --> P-521
+      ctx = OpenSSL::SSL::SSLContext.new
+      ctx.ecdh_curves = "P-521:P-384"
+      server_connect(port, ctx) { |ssl|
+        assert_equal "secp521r1", ssl.tmp_key.group.curve_name
+        ssl.puts "abc"; assert_equal "abc\n", ssl.gets
+      }
     end
   end
 


### PR DESCRIPTION
OpenSSL 3.0 support (#369) will need us to add new version guards. To keep it maintainable, I would like to do some cleanup before that happens.

Nearly 4 years have passed since OpenSSL 1.0.1's EOL and I think we are good with dropping it now. FWIW, rubyci.org at the moment has one instance running OpenSSL 1.0.1 - `Ubuntu armv7l eabihf` which is Ubuntu 14.04 LTS.

The first commit updates code where we had explicit version guards. The following commits are to catch up with recent LibreSSL releases which merged features from OpenSSL.

---
**require OpenSSL >= 1.0.2 and LibreSSL >= 3.1**

Clean up old version guards in preparation for the upcoming OpenSSL 3.0
support.

OpenSSL 1.0.1 reached its EOL on 2016-12-31. However, we decided to keep
1.0.1 support as that time because many major Linux distributions were
still shipped with 1.0.1. Now, nearly 4 years later, most Linux
distributions are reaching their EOL and it should be safe to assume
nobody uses them anymore.

 - Ubuntu 14.04 is EOL since 2019-04-30
 - RHEL 6 will reach EOL on 2020-11-30

LibreSSL versions before 3.0 are no longer supported by the LibreSSL
team and 3.1 will also be unsupported by October 2020.

Note that OpenSSL 1.0.2 is also EOL since 2019-12-31 and 1.1.0 is since
2018-08-31, but we would need to keep them for some time.

---
**ssl: call SSL_CTX_set_ecdh_auto() on OpenSSL 1.0.2 only**

SSL_CTX_set_ecdh_auto() exists in OpenSSL 1.1.0 and LibreSSL 2.6.1, but
it is made no-op and the automatic curve selection cannot be disabled.
Wrap it with ifdef to make it clear that it is safe to remove it
completely when we drop support for OpenSSL 1.0.2.

---
**ssl: use TLS_method() instead of SSLv23_method() for LibreSSL**

LibreSSL 2.2.2 introduced TLS_method(), but with different semantics
from OpenSSL: TLS_method() enabled TLS >= 1.0 while SSLv23_method()
enabled all available versions, which included SSL 3.0 in addition.

However, LibreSSL 2.3.0 removed SSL 3.0 support completely and now
TLS_method() and SSLv23_method() are equivalent.

---
**ossl.c: do not set locking callbacks on LibreSSL**

Similarly to OpenSSL >= 1.1.0, LibreSSL 2.9.0 ensures thread safety
without requiring applications to set locking callbacks and related
functions are made no-op.

