### PR TITLE
[WIP] Support OpenSSL 3.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,3 +94,40 @@ jobs:
 
       - name: test
         run:  rake test TESTOPTS="-v --no-show-detail-immediately" OSSL_MDEBUG=1
+
+  test-openssl-master:
+    name: OpenSSL master
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest ]
+        ruby: [ 2.7 ]
+    steps:
+      - name: repo checkout
+        uses: actions/checkout@v2
+
+      - name: prepare openssl
+        run: |
+          mkdir -p tmp/build-openssl && cd tmp/build-openssl
+          git clone https://github.com/openssl/openssl.git --depth=1
+          cd openssl
+          ./Configure --prefix=$HOME/.openssl/master --libdir=lib \
+              linux-x86_64
+          make depend
+          make -j4
+          make install_sw
+
+      - name: load ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+
+      - name: depends
+        run:  bundle install
+
+      - name: compile
+        run:  rake compile -- --enable-debug --with-openssl-dir=$HOME/.openssl/master
+
+      - name: test
+        run:  rake test TESTOPTS="-v --no-show-detail-immediately"

--- a/ext/openssl/extconf.rb
+++ b/ext/openssl/extconf.rb
@@ -181,6 +181,7 @@ have_func("EVP_MD_CTX_get0_md")
 have_func("EVP_MD_CTX_get_pkey_ctx")
 have_func("EVP_PKEY_eq")
 have_func("EVP_PKEY_dup")
+have_func("EVP_PKEY_todata")
 
 Logging::message "=== Checking done. ===\n"
 

--- a/ext/openssl/ossl_bn.c
+++ b/ext/openssl/ossl_bn.c
@@ -74,6 +74,23 @@ ossl_bn_new(const BIGNUM *bn)
     return obj;
 }
 
+#ifdef HAVE_EVP_PKEY_TODATA
+VALUE
+ossl_bn_new_from_native(const void *data, size_t data_size)
+{
+    BIGNUM *bn;
+    VALUE obj;
+
+    obj = NewBN(cBN);
+    bn = BN_native2bn(data, data_size, NULL);
+    if (!bn)
+        ossl_raise(eBNError, "BN_native2bn");
+    SetBN(obj, bn);
+
+    return obj;
+}
+#endif
+
 static BIGNUM *
 integer_to_bnptr(VALUE obj, BIGNUM *orig)
 {

--- a/ext/openssl/ossl_bn.h
+++ b/ext/openssl/ossl_bn.h
@@ -19,6 +19,9 @@ BN_CTX *ossl_bn_ctx_get(void);
 #define GetBNPtr(obj) ossl_bn_value_ptr(&(obj))
 
 VALUE ossl_bn_new(const BIGNUM *);
+#ifdef HAVE_EVP_PKEY_TODATA
+VALUE ossl_bn_new_from_native(const void *data, size_t data_size);
+#endif
 BIGNUM *ossl_bn_value_ptr(volatile VALUE *);
 void Init_ossl_bn(void);
 

--- a/ext/openssl/ossl_pkey.h
+++ b/ext/openssl/ossl_pkey.h
@@ -85,37 +85,6 @@ extern VALUE eEC_POINT;
 VALUE ossl_ec_new(EVP_PKEY *);
 void Init_ossl_ec(void);
 
-#define OSSL_PKEY_BN_DEF_GETTER0(_keytype, _type, _name, _get)		\
-/*									\
- *  call-seq:								\
- *     _keytype##.##_name -> aBN					\
- */									\
-static VALUE ossl_##_keytype##_get_##_name(VALUE self)			\
-{									\
-	_type *obj;							\
-	const BIGNUM *bn;						\
-									\
-	Get##_type(self, obj);						\
-	_get;								\
-	if (bn == NULL)							\
-		return Qnil;						\
-	return ossl_bn_new(bn);						\
-}
-
-#define OSSL_PKEY_BN_DEF_GETTER3(_keytype, _type, _group, a1, a2, a3)	\
-	OSSL_PKEY_BN_DEF_GETTER0(_keytype, _type, a1,			\
-		_type##_get0_##_group(obj, &bn, NULL, NULL))		\
-	OSSL_PKEY_BN_DEF_GETTER0(_keytype, _type, a2,			\
-		_type##_get0_##_group(obj, NULL, &bn, NULL))		\
-	OSSL_PKEY_BN_DEF_GETTER0(_keytype, _type, a3,			\
-		_type##_get0_##_group(obj, NULL, NULL, &bn))
-
-#define OSSL_PKEY_BN_DEF_GETTER2(_keytype, _type, _group, a1, a2)	\
-	OSSL_PKEY_BN_DEF_GETTER0(_keytype, _type, a1,			\
-		_type##_get0_##_group(obj, &bn, NULL))			\
-	OSSL_PKEY_BN_DEF_GETTER0(_keytype, _type, a2,			\
-		_type##_get0_##_group(obj, NULL, &bn))
-
 #if !OSSL_OPENSSL_PREREQ(3, 0, 0)
 #define OSSL_PKEY_BN_DEF_SETTER3(_keytype, _type, _group, a1, a2, a3)	\
 /*									\
@@ -191,14 +160,9 @@ static VALUE ossl_##_keytype##_set_##_group(VALUE self, VALUE v1, VALUE v2) \
 #endif
 
 #define OSSL_PKEY_BN_DEF3(_keytype, _type, _group, a1, a2, a3)		\
-	OSSL_PKEY_BN_DEF_GETTER3(_keytype, _type, _group, a1, a2, a3)	\
 	OSSL_PKEY_BN_DEF_SETTER3(_keytype, _type, _group, a1, a2, a3)
 
 #define OSSL_PKEY_BN_DEF2(_keytype, _type, _group, a1, a2)		\
-	OSSL_PKEY_BN_DEF_GETTER2(_keytype, _type, _group, a1, a2)	\
 	OSSL_PKEY_BN_DEF_SETTER2(_keytype, _type, _group, a1, a2)
-
-#define DEF_OSSL_PKEY_BN(class, keytype, name)				\
-	rb_define_method((class), #name, ossl_##keytype##_get_##name, 0)
 
 #endif /* OSSL_PKEY_H */

--- a/ext/openssl/ossl_pkey_dh.c
+++ b/ext/openssl/ossl_pkey_dh.c
@@ -416,11 +416,6 @@ Init_ossl_dh(void)
     rb_define_method(cDH, "to_der", ossl_dh_to_der, 0);
     rb_define_method(cDH, "params_ok?", ossl_dh_check_params, 0);
 
-    DEF_OSSL_PKEY_BN(cDH, dh, p);
-    DEF_OSSL_PKEY_BN(cDH, dh, q);
-    DEF_OSSL_PKEY_BN(cDH, dh, g);
-    DEF_OSSL_PKEY_BN(cDH, dh, pub_key);
-    DEF_OSSL_PKEY_BN(cDH, dh, priv_key);
     rb_define_method(cDH, "set_pqg", ossl_dh_set_pqg, 3);
     rb_define_method(cDH, "set_key", ossl_dh_set_key, 2);
 

--- a/ext/openssl/ossl_pkey_dsa.c
+++ b/ext/openssl/ossl_pkey_dsa.c
@@ -335,11 +335,6 @@ Init_ossl_dsa(void)
     rb_define_alias(cDSA, "to_s", "export");
     rb_define_method(cDSA, "to_der", ossl_dsa_to_der, 0);
 
-    DEF_OSSL_PKEY_BN(cDSA, dsa, p);
-    DEF_OSSL_PKEY_BN(cDSA, dsa, q);
-    DEF_OSSL_PKEY_BN(cDSA, dsa, g);
-    DEF_OSSL_PKEY_BN(cDSA, dsa, pub_key);
-    DEF_OSSL_PKEY_BN(cDSA, dsa, priv_key);
     rb_define_method(cDSA, "set_pqg", ossl_dsa_set_pqg, 3);
     rb_define_method(cDSA, "set_key", ossl_dsa_set_key, 2);
 

--- a/ext/openssl/ossl_pkey_rsa.c
+++ b/ext/openssl/ossl_pkey_rsa.c
@@ -439,19 +439,10 @@ ossl_rsa_verify_pss(int argc, VALUE *argv, VALUE self)
     ossl_raise(eRSAError, NULL);
 }
 
-/*
- * call-seq:
- *   rsa.params => hash
- *
- * THIS METHOD IS INSECURE, PRIVATE INFORMATION CAN LEAK OUT!!!
- *
- * Stores all parameters of key to the hash.  The hash has keys 'n', 'e', 'd',
- * 'p', 'q', 'dmp1', 'dmq1', 'iqmp'.
- *
- * Don't use :-)) (It's up to you)
- */
+#ifndef HAVE_EVP_PKEY_TODATA
+/* :nodoc: */
 static VALUE
-ossl_rsa_get_params(VALUE self)
+ossl_rsa_to_data(VALUE self)
 {
     RSA *rsa;
     VALUE hash;
@@ -463,17 +454,18 @@ ossl_rsa_get_params(VALUE self)
     RSA_get0_crt_params(rsa, &dmp1, &dmq1, &iqmp);
 
     hash = rb_hash_new();
-    rb_hash_aset(hash, rb_str_new2("n"), ossl_bn_new(n));
-    rb_hash_aset(hash, rb_str_new2("e"), ossl_bn_new(e));
-    rb_hash_aset(hash, rb_str_new2("d"), ossl_bn_new(d));
-    rb_hash_aset(hash, rb_str_new2("p"), ossl_bn_new(p));
-    rb_hash_aset(hash, rb_str_new2("q"), ossl_bn_new(q));
-    rb_hash_aset(hash, rb_str_new2("dmp1"), ossl_bn_new(dmp1));
-    rb_hash_aset(hash, rb_str_new2("dmq1"), ossl_bn_new(dmq1));
-    rb_hash_aset(hash, rb_str_new2("iqmp"), ossl_bn_new(iqmp));
+    rb_hash_aset(hash, ID2SYM(rb_intern("n")), n ? ossl_bn_new(n) : Qnil);
+    rb_hash_aset(hash, ID2SYM(rb_intern("e")), e ? ossl_bn_new(e) : Qnil);
+    rb_hash_aset(hash, ID2SYM(rb_intern("d")), d ? ossl_bn_new(d) : Qnil);
+    rb_hash_aset(hash, ID2SYM(rb_intern("rsa-factor1")), p ? ossl_bn_new(p) : Qnil);
+    rb_hash_aset(hash, ID2SYM(rb_intern("rsa-factor2")), q ? ossl_bn_new(q) : Qnil);
+    rb_hash_aset(hash, ID2SYM(rb_intern("rsa-exponent1")), dmp1 ? ossl_bn_new(dmp1) : Qnil);
+    rb_hash_aset(hash, ID2SYM(rb_intern("rsa-exponent2")), dmq1 ? ossl_bn_new(dmq1) : Qnil);
+    rb_hash_aset(hash, ID2SYM(rb_intern("rsa-coefficient1")), iqmp ? ossl_bn_new(iqmp) : Qnil);
 
     return hash;
 }
+#endif
 
 /*
  * Document-method: OpenSSL::PKey::RSA#set_key
@@ -562,7 +554,9 @@ Init_ossl_rsa(void)
     rb_define_method(cRSA, "set_factors", ossl_rsa_set_factors, 2);
     rb_define_method(cRSA, "set_crt_params", ossl_rsa_set_crt_params, 3);
 
-    rb_define_method(cRSA, "params", ossl_rsa_get_params, 0);
+#ifndef HAVE_EVP_PKEY_TODATA
+    rb_define_method(cRSA, "to_data", ossl_rsa_to_data, 0);
+#endif
 
 /*
  * TODO: Test it

--- a/ext/openssl/ossl_pkey_rsa.c
+++ b/ext/openssl/ossl_pkey_rsa.c
@@ -542,14 +542,6 @@ Init_ossl_rsa(void)
     rb_define_method(cRSA, "sign_pss", ossl_rsa_sign_pss, -1);
     rb_define_method(cRSA, "verify_pss", ossl_rsa_verify_pss, -1);
 
-    DEF_OSSL_PKEY_BN(cRSA, rsa, n);
-    DEF_OSSL_PKEY_BN(cRSA, rsa, e);
-    DEF_OSSL_PKEY_BN(cRSA, rsa, d);
-    DEF_OSSL_PKEY_BN(cRSA, rsa, p);
-    DEF_OSSL_PKEY_BN(cRSA, rsa, q);
-    DEF_OSSL_PKEY_BN(cRSA, rsa, dmp1);
-    DEF_OSSL_PKEY_BN(cRSA, rsa, dmq1);
-    DEF_OSSL_PKEY_BN(cRSA, rsa, iqmp);
     rb_define_method(cRSA, "set_key", ossl_rsa_set_key, 3);
     rb_define_method(cRSA, "set_factors", ossl_rsa_set_factors, 2);
     rb_define_method(cRSA, "set_crt_params", ossl_rsa_set_crt_params, 3);

--- a/lib/openssl/pkey.rb
+++ b/lib/openssl/pkey.rb
@@ -10,6 +10,17 @@ module OpenSSL::PKey
   class DH
     include OpenSSL::Marshal
 
+    def params
+      data = to_data
+      {
+        "p" => data[:p] || 0.to_bn,
+        "q" => data[:q] || 0.to_bn,
+        "g" => data[:g] || 0.to_bn,
+        "pub_key" => data[:pub] || 0.to_bn,
+        "priv_key" => data[:priv] || 0.to_bn,
+      }
+    end
+
     # :call-seq:
     #    dh.public_key -> dhnew
     #
@@ -137,6 +148,17 @@ module OpenSSL::PKey
 
   class DSA
     include OpenSSL::Marshal
+
+    def params
+      data = to_data
+      {
+        "p" => data[:p] || 0.to_bn,
+        "q" => data[:q] || 0.to_bn,
+        "g" => data[:g] || 0.to_bn,
+        "pub_key" => data[:pub] || 0.to_bn,
+        "priv_key" => data[:priv] || 0.to_bn,
+      }
+    end
 
     # :call-seq:
     #    dsa.public_key -> dsanew
@@ -304,6 +326,20 @@ module OpenSSL::PKey
 
   class RSA
     include OpenSSL::Marshal
+
+    def params
+      data = to_data
+      {
+        "n" => data[:n] || 0.to_bn,
+        "e" => data[:e] || 0.to_bn,
+        "d" => data[:d] || 0.to_bn,
+        "p" => data[:"rsa-factor1"] || 0.to_bn,
+        "q" => data[:"rsa-factor2"] || 0.to_bn,
+        "dmp1" => data[:"rsa-exponent1"] || 0.to_bn,
+        "dmq1" => data[:"rsa-exponent2"] || 0.to_bn,
+        "iqmp" => data[:"rsa-coefficient1"] || 0.to_bn,
+      }
+    end
 
     # :call-seq:
     #    rsa.public_key -> rsanew

--- a/lib/openssl/pkey.rb
+++ b/lib/openssl/pkey.rb
@@ -21,6 +21,14 @@ module OpenSSL::PKey
       }
     end
 
+    def p; get_bn_param(:p) end
+    def q; get_bn_param(:q) end
+    def g; get_bn_param(:g) end
+    def pub_key; get_bn_param(:pub) end
+    def priv_key; get_bn_param(:priv) end
+    def get_pqg; [p, q, g] end
+    def get_key; [pub_key, priv_key] end
+
     # :call-seq:
     #    dh.public_key -> dhnew
     #
@@ -159,6 +167,14 @@ module OpenSSL::PKey
         "priv_key" => data[:priv] || 0.to_bn,
       }
     end
+
+    def p; get_bn_param(:p) end
+    def q; get_bn_param(:q) end
+    def g; get_bn_param(:g) end
+    def pub_key; get_bn_param(:pub) end
+    def priv_key; get_bn_param(:priv) end
+    def get_pqg; [p, q, g] end
+    def get_key; [pub_key, priv_key] end
 
     # :call-seq:
     #    dsa.public_key -> dsanew
@@ -340,6 +356,18 @@ module OpenSSL::PKey
         "iqmp" => data[:"rsa-coefficient1"] || 0.to_bn,
       }
     end
+
+    def n; get_bn_param(:n) end
+    def e; get_bn_param(:e) end
+    def d; get_bn_param(:d) end
+    def p; get_bn_param(:"rsa-factor1") end
+    def q; get_bn_param(:"rsa-factor2") end
+    def dmp1; get_bn_param(:"rsa-exponent1") end
+    def dmq1; get_bn_param(:"rsa-exponent2") end
+    def iqmp; get_bn_param(:"rsa-coefficient1") end
+    def get_key; [n, e, d] end
+    def get_factors; [p, q] end
+    def get_crt_params; [dmp1, dmq1, iqmp] end
 
     # :call-seq:
     #    rsa.public_key -> rsanew

--- a/test/openssl/test_pkey_dsa.rb
+++ b/test/openssl/test_pkey_dsa.rb
@@ -223,6 +223,35 @@ fWLOqqkzFeRrYMDzUpl36XktY6Yq8EJYlW9pCMmBVNy/dQ==
     assert_equal key.to_der, deserialized.to_der
   end
 
+  def test_to_data
+    dsa = Fixtures.pkey("dsa1024")
+
+    # #params and gettters
+    params_keys = %w{p q g pub_key priv_key}
+    params = dsa.params
+    assert_equal [], params_keys - params.keys
+
+    # #to_data; may contain additional entries
+    data_keys = %w{p q g pub priv}
+    data = dsa.to_data
+    assert_equal [], data_keys.map(&:intern) - data.keys
+
+    # Check value
+    assert_equal dsa.p, params["p"]
+    assert_equal dsa.p, data[:p]
+    assert_equal 1024, dsa.p.num_bits
+    assert_equal true, dsa.p.prime?
+
+    params_keys.each_with_index do |pk, i|
+      dk = data_keys[i]
+      getter_value = dsa.public_send(pk)
+
+      assert_kind_of OpenSSL::BN, getter_value
+      assert_equal getter_value, params[pk]
+      assert_equal getter_value, data[dk.intern]
+    end
+  end
+
   private
   def assert_same_dsa(expected, key)
     check_component(expected, key, [:p, :q, :g, :pub_key, :priv_key])

--- a/test/openssl/test_pkey_ec.rb
+++ b/test/openssl/test_pkey_ec.rb
@@ -72,6 +72,14 @@ class OpenSSL::TestEC < OpenSSL::PKeyTestCase
     assert_equal key.to_der, deserialized.to_der
   end
 
+  def test_to_data
+    p256 = Fixtures.pkey("p256")
+
+    data = p256.to_data
+    assert_equal "prime256v1", data[:group]
+    assert_equal p256.private_key, data[:priv]
+  end
+
   def test_check_key
     key0 = Fixtures.pkey("p256")
     assert_equal(true, key0.check_key)

--- a/test/openssl/test_pkey_rsa.rb
+++ b/test/openssl/test_pkey_rsa.rb
@@ -583,6 +583,12 @@ class OpenSSL::TestPKeyRSA < OpenSSL::PKeyTestCase
     assert_equal nil, rsa.d
   end
 
+  def test_from_data
+    pkey = Fixtures.pkey("rsa2048")
+
+    rsa1 = OpenSSL::PKey.from_data("RSA", OpenSSL::PKey::KEYPAIR, data)
+  end
+
   private
   def assert_same_rsa(expected, key)
     check_component(expected, key, [:n, :e, :d, :p, :q, :dmp1, :dmq1, :iqmp])


### PR DESCRIPTION
A collection of patches to support OpenSSL 3.0 API.

Currently, as of 2021-05-25, it compiles with OpenSSL's master branch (3.0.0-alpha17), but many things are known to be broken and test suite does not pass.

See also the tracking issue #369 (Support OpenSSL 3.0) for the summary.

<details>

These test failures are as of 2020-08, which may or may not be relevant today.

Test suite does not pass yet - some are due to unresolved issues in OpenSSL, which have open issues on openssl/openssl:

 - OpenSSL::PKey.generate_key with HMAC pkey
 - OpenSSL::PKey.read with a passphrase with a null character in the middle

I haven't dug into others, yet:

 - OpenSSL::PKey::PKey.sign_raw against RSA with 'none' padding
 - test_connect_certificate_verify_failed_exception_message(OpenSSL::TestSSL)
 - test_post_connection_check(OpenSSL::TestSSL)
 - test_ciphers(OpenSSL::TestCipher)
 - test_reset(OpenSSL::TestCipher)
 - test_verify_callback(OpenSSL::TestX509Store)