### PR TITLE
fix segv in Timestamp::{Request,Response,TokenInfo}.new

### DIFF
--- a/ext/openssl/ossl_ts.c
+++ b/ext/openssl/ossl_ts.c
@@ -205,8 +205,10 @@ ossl_ts_req_initialize(int argc, VALUE *argv, VALUE self)
     in = ossl_obj2bio(&arg);
     ts_req = d2i_TS_REQ_bio(in, &ts_req);
     BIO_free(in);
-    if (!ts_req)
+    if (!ts_req) {
+        DATA_PTR(self) = NULL;
         ossl_raise(eTimestampError, "Error when decoding the timestamp request");
+    }
     DATA_PTR(self) = ts_req;
 
     return self;
@@ -529,8 +531,10 @@ ossl_ts_resp_initialize(VALUE self, VALUE der)
     in  = ossl_obj2bio(&der);
     ts_resp = d2i_TS_RESP_bio(in, &ts_resp);
     BIO_free(in);
-    if (!ts_resp)
+    if (!ts_resp) {
+        DATA_PTR(self) = NULL;
         ossl_raise(eTimestampError, "Error when decoding the timestamp response");
+    }
     DATA_PTR(self) = ts_resp;
 
     return self;
@@ -871,8 +875,10 @@ ossl_ts_token_info_initialize(VALUE self, VALUE der)
     in  = ossl_obj2bio(&der);
     info = d2i_TS_TST_INFO_bio(in, &info);
     BIO_free(in);
-    if (!info)
+    if (!info) {
+        DATA_PTR(self) = NULL;
         ossl_raise(eTimestampError, "Error when decoding the timestamp token info");
+    }
     DATA_PTR(self) = info;
 
     return self;

--- a/test/openssl/test_ts.rb
+++ b/test/openssl/test_ts.rb
@@ -181,6 +181,12 @@ _end_of_pem_
     assert_equal(42, qer2.nonce)
   end
 
+  def test_request_invalid_asn1
+    assert_raise(OpenSSL::Timestamp::TimestampError) do
+      OpenSSL::Timestamp::Request.new("*" * 44)
+    end
+  end
+
   def test_response_constants
     assert_equal(0, OpenSSL::Timestamp::Response::GRANTED)
     assert_equal(1, OpenSSL::Timestamp::Response::GRANTED_WITH_MODS)
@@ -330,6 +336,12 @@ _end_of_pem_
 
     assert_raise(OpenSSL::Timestamp::TimestampError) do
       fac.create_timestamp(ee_key, intermediate_cert, req)
+    end
+  end
+
+  def test_response_invalid_asn1
+    assert_raise(OpenSSL::Timestamp::TimestampError) do
+      OpenSSL::Timestamp::Response.new("*" * 44)
     end
   end
 
@@ -583,6 +595,12 @@ _end_of_pem_
     assert_equal(time.to_i, info.gen_time.to_i)
     assert_equal(false, info.ordering)
     assert_equal(123, info.nonce)
+  end
+
+  def test_token_info_invalid_asn1
+    assert_raise(OpenSSL::Timestamp::TimestampError) do
+      OpenSSL::Timestamp::TokenInfo.new("*" * 44)
+    end
   end
 
   private


### PR DESCRIPTION
prevent `ossl_ts_*_free()` from calling when `d2i_TS_*_bio()` failed.

See #405  