### PR TITLE
Provides get/set for affine coordinates on OpenSSL::PKey::EC::Point

### DIFF
--- a/ext/openssl/extconf.rb
+++ b/ext/openssl/extconf.rb
@@ -174,6 +174,11 @@ have_func("TS_RESP_CTX_set_time_cb")
 have_func("EVP_PBE_scrypt")
 have_func("SSL_CTX_set_post_handshake_auth")
 
+# added in 1.1.1
+have_func("EC_POINT_get_affine_coordinates")
+have_func("EC_POINT_set_affine_coordinates")
+have_func("EC_POINT_set_compressed_coordinates")
+
 Logging::message "=== Checking done. ===\n"
 
 create_header

--- a/ext/openssl/ossl_bn.c
+++ b/ext/openssl/ossl_bn.c
@@ -119,7 +119,7 @@ integer_to_bnptr(VALUE obj, BIGNUM *orig)
     return bn;
 }
 
-VALUE try_convert_to_bn(VALUE obj)
+VALUE ossl_try_convert_to_bn(VALUE obj)
 {
     BIGNUM *bn;
     VALUE newobj = Qnil;
@@ -141,7 +141,7 @@ ossl_bn_value_ptr(volatile VALUE *ptr)
     VALUE tmp;
     BIGNUM *bn;
 
-    tmp = try_convert_to_bn(*ptr);
+    tmp = ossl_try_convert_to_bn(*ptr);
     if (NIL_P(tmp))
 	ossl_raise(rb_eTypeError, "Cannot convert into OpenSSL::BN");
     GetBN(tmp, bn);
@@ -1050,7 +1050,7 @@ ossl_bn_eq(VALUE self, VALUE other)
     BIGNUM *bn1, *bn2;
 
     GetBN(self, bn1);
-    other = try_convert_to_bn(other);
+    other = ossl_try_convert_to_bn(other);
     if (NIL_P(other))
 	return Qfalse;
     GetBN(other, bn2);

--- a/ext/openssl/ossl_bn.c
+++ b/ext/openssl/ossl_bn.c
@@ -119,8 +119,7 @@ integer_to_bnptr(VALUE obj, BIGNUM *orig)
     return bn;
 }
 
-static VALUE
-try_convert_to_bn(VALUE obj)
+VALUE try_convert_to_bn(VALUE obj)
 {
     BIGNUM *bn;
     VALUE newobj = Qnil;

--- a/ext/openssl/ossl_bn.c
+++ b/ext/openssl/ossl_bn.c
@@ -448,6 +448,22 @@ BIGNUM_BOOL1(is_one)
  */
 BIGNUM_BOOL1(is_odd)
 
+static VALUE
+ossl_bn_is_even(VALUE self)
+{
+    VALUE is_odd;
+
+    is_odd = ossl_bn_is_odd(self);
+    if (is_odd == Qtrue) {
+        return Qfalse;
+    }
+    else if (is_odd == Qfalse) {
+        return Qtrue;
+    }
+
+    rb_raise(eBNError, "ossl_bn_is_odd didn't return a boolean");
+}
+
 /*
  * call-seq:
  *   bn.negative? => true | false
@@ -1260,6 +1276,7 @@ Init_ossl_bn(void)
     rb_define_method(cBN, "one?", ossl_bn_is_one, 0);
     /* is_word */
     rb_define_method(cBN, "odd?", ossl_bn_is_odd, 0);
+    rb_define_method(cBN, "even?", ossl_bn_is_even, 0);
     rb_define_method(cBN, "negative?", ossl_bn_is_negative, 0);
 
     /* zero

--- a/ext/openssl/ossl_bn.h
+++ b/ext/openssl/ossl_bn.h
@@ -19,6 +19,7 @@ BN_CTX *ossl_bn_ctx_get(void);
 #define GetBNPtr(obj) ossl_bn_value_ptr(&(obj))
 
 VALUE ossl_bn_new(const BIGNUM *);
+VALUE try_convert_to_bn(VALUE obj);
 BIGNUM *ossl_bn_value_ptr(volatile VALUE *);
 void Init_ossl_bn(void);
 

--- a/ext/openssl/ossl_bn.h
+++ b/ext/openssl/ossl_bn.h
@@ -19,7 +19,7 @@ BN_CTX *ossl_bn_ctx_get(void);
 #define GetBNPtr(obj) ossl_bn_value_ptr(&(obj))
 
 VALUE ossl_bn_new(const BIGNUM *);
-VALUE try_convert_to_bn(VALUE obj);
+VALUE ossl_try_convert_to_bn(VALUE obj);
 BIGNUM *ossl_bn_value_ptr(volatile VALUE *);
 void Init_ossl_bn(void);
 

--- a/ext/openssl/ossl_pkey_ec.c
+++ b/ext/openssl/ossl_pkey_ec.c
@@ -1245,6 +1245,14 @@ ossl_ec_point_initialize_copy(VALUE self, VALUE other)
     return self;
 }
 
+static VALUE
+ossl_ec_point_dup(VALUE self)
+{
+    VALUE other;
+    other = ossl_ec_point_alloc(eEC_POINT);
+    return ossl_ec_point_initialize_copy(other, self);
+}
+
 /*
  * call-seq:
  *   point1.eql?(point2) => true | false
@@ -1648,7 +1656,10 @@ void Init_ossl_ec(void)
     rb_define_alloc_func(cEC_POINT, ossl_ec_point_alloc);
     rb_define_method(cEC_POINT, "initialize", ossl_ec_point_initialize, -1);
     rb_define_method(cEC_POINT, "initialize_copy", ossl_ec_point_initialize_copy, 1);
+    rb_define_method(cEC_POINT, "dup", ossl_ec_point_dup, 0);
+
     rb_attr(cEC_POINT, rb_intern("group"), 1, 0, 0);
+
     rb_define_method(cEC_POINT, "eql?", ossl_ec_point_eql, 1);
     rb_define_alias(cEC_POINT, "==", "eql?");
 

--- a/ext/openssl/ossl_pkey_ec.c
+++ b/ext/openssl/ossl_pkey_ec.c
@@ -47,11 +47,13 @@ VALUE eEC_GROUP;
 VALUE cEC_POINT;
 VALUE eEC_POINT;
 
-static ID s_GFp, s_GF2m;
+static ID id_GFp, id_GF2m;
 
-static ID ID_uncompressed;
-static ID ID_compressed;
-static ID ID_hybrid;
+static ID id_odd, id_even;
+
+static ID id_uncompressed;
+static ID id_compressed;
+static ID id_hybrid;
 
 static ID id_i_group;
 
@@ -637,10 +639,10 @@ static VALUE ossl_ec_group_initialize(int argc, VALUE *argv, VALUE self)
             const BIGNUM *a = GetBNPtr(arg3);
             const BIGNUM *b = GetBNPtr(arg4);
 
-            if (id == s_GFp) {
+            if (id == id_GFp) {
                 new_curve = EC_GROUP_new_curve_GFp;
 #if !defined(OPENSSL_NO_EC2M)
-            } else if (id == s_GF2m) {
+            } else if (id == id_GF2m) {
                 new_curve = EC_GROUP_new_curve_GF2m;
 #endif
             } else {
@@ -922,9 +924,9 @@ static VALUE ossl_ec_group_get_point_conversion_form(VALUE self)
     form = EC_GROUP_get_point_conversion_form(group);
 
     switch (form) {
-    case POINT_CONVERSION_UNCOMPRESSED:	ret = ID_uncompressed; break;
-    case POINT_CONVERSION_COMPRESSED:	ret = ID_compressed; break;
-    case POINT_CONVERSION_HYBRID:	ret = ID_hybrid; break;
+    case POINT_CONVERSION_UNCOMPRESSED:	ret = id_uncompressed; break;
+    case POINT_CONVERSION_COMPRESSED:	ret = id_compressed; break;
+    case POINT_CONVERSION_HYBRID:	ret = id_hybrid; break;
     default:	ossl_raise(eEC_GROUP, "unsupported point conversion form: %d, this module should be updated", form);
     }
 
@@ -936,11 +938,11 @@ parse_point_conversion_form_symbol(VALUE sym)
 {
     ID id = SYM2ID(sym);
 
-    if (id == ID_uncompressed)
+    if (id == id_uncompressed)
 	return POINT_CONVERSION_UNCOMPRESSED;
-    else if (id == ID_compressed)
+    else if (id == id_compressed)
 	return POINT_CONVERSION_COMPRESSED;
-    else if (id == ID_hybrid)
+    else if (id == id_hybrid)
 	return POINT_CONVERSION_HYBRID;
     else
 	ossl_raise(rb_eArgError, "unsupported point conversion form %+"PRIsVALUE
@@ -1554,12 +1556,15 @@ void Init_ossl_ec(void)
     eEC_GROUP = rb_define_class_under(cEC_GROUP, "Error", eOSSLError);
     eEC_POINT = rb_define_class_under(cEC_POINT, "Error", eOSSLError);
 
-    s_GFp = rb_intern("GFp");
-    s_GF2m = rb_intern("GF2m");
+    id_GFp = rb_intern("GFp");
+    id_GF2m = rb_intern("GF2m");
 
-    ID_uncompressed = rb_intern("uncompressed");
-    ID_compressed = rb_intern("compressed");
-    ID_hybrid = rb_intern("hybrid");
+    id_even = rb_intern("even");
+    id_odd = rb_intern("odd");
+
+    id_uncompressed = rb_intern("uncompressed");
+    id_compressed = rb_intern("compressed");
+    id_hybrid = rb_intern("hybrid");
 
     rb_define_const(cEC, "NAMED_CURVE", INT2NUM(OPENSSL_EC_NAMED_CURVE));
 #if defined(OPENSSL_EC_EXPLICIT_CURVE)

--- a/ext/openssl/ossl_pkey_ec.c
+++ b/ext/openssl/ossl_pkey_ec.c
@@ -1438,8 +1438,8 @@ ossl_ec_point_set_affine_coords(VALUE self, VALUE coords)
         rb_raise(eEC_POINT, "argument must be an array of [ x, y ]");
     }
 
-    x = try_convert_to_bn(RARRAY_AREF(coords, 0));
-    y = try_convert_to_bn(RARRAY_AREF(coords, 1));
+    x = ossl_try_convert_to_bn(RARRAY_AREF(coords, 0));
+    y = ossl_try_convert_to_bn(RARRAY_AREF(coords, 1));
 
     xBN = GetBNPtr(x);
     yBN = GetBNPtr(y);

--- a/test/openssl/test_bn.rb
+++ b/test/openssl/test_bn.rb
@@ -103,6 +103,11 @@ class OpenSSL::TestBN < OpenSSL::TestCase
     assert_equal(false, 2.to_bn.odd?)
   end
 
+  def test_even_p
+    assert_equal(false, 1.to_bn.even?)
+    assert_equal(true, 2.to_bn.even?)
+  end
+
   def test_negative_p
     assert_equal(false, 0.to_bn.negative?)
     assert_equal(false, @e1.negative?)

--- a/test/openssl/test_pkey_ec.rb
+++ b/test/openssl/test_pkey_ec.rb
@@ -294,6 +294,21 @@ class OpenSSL::TestEC < OpenSSL::PKeyTestCase
       assert_equal(point2_string, point2_explicit_set.to_octet_string(:uncompressed))
     end
 
+    if point2.respond_to? :set_compressed_coords
+      point2_x, point2_y = point2.affine_coords
+
+      y_bit = point2_y.even? ? 0 : 1
+      inverse_y_bit = point2_y.odd? ? 0 : 1
+
+      point2_from_compressed = OpenSSL::PKey::EC::Point.new group
+      point2_from_compressed.set_compressed_coords point2_x, y_bit
+      assert_equal(point2, point2_from_compressed)
+
+      point2_from_compressed_inverse = OpenSSL::PKey::EC::Point.new group
+      point2_from_compressed_inverse.set_compressed_coords point2_x, inverse_y_bit
+      assert_not_equal(point2, point2_from_compressed_inverse)
+    end
+
     point3 = OpenSSL::PKey::EC::Point.new(group,
                                           point.to_octet_string(:uncompressed))
     assert_equal point, point3

--- a/test/openssl/test_pkey_ec.rb
+++ b/test/openssl/test_pkey_ec.rb
@@ -286,6 +286,14 @@ class OpenSSL::TestEC < OpenSSL::PKeyTestCase
       assert_equal(point2_y_bn, point2_y)
     end
 
+    if point2.respond_to? :affine_coords=
+      point2_explicit_set = OpenSSL::PKey::EC::Point.new group
+      point2_explicit_set.affine_coords = [point2_x_bn, point2_y_bn]
+
+      assert_equal(point2, point2_explicit_set)
+      assert_equal(point2_string, point2_explicit_set.to_octet_string(:uncompressed))
+    end
+
     point3 = OpenSSL::PKey::EC::Point.new(group,
                                           point.to_octet_string(:uncompressed))
     assert_equal point, point3

--- a/test/openssl/test_pkey_ec.rb
+++ b/test/openssl/test_pkey_ec.rb
@@ -261,6 +261,10 @@ class OpenSSL::TestEC < OpenSSL::PKeyTestCase
     assert_equal point.to_octet_string(:uncompressed),
       point2.to_octet_string(:uncompressed)
 
+    point2_dup = point2.dup
+    assert_equal point2, point2_dup
+    assert_equal false, point2.equal?(point2_dup)
+
     point3 = OpenSSL::PKey::EC::Point.new(group,
                                           point.to_octet_string(:uncompressed))
     assert_equal point, point3

--- a/test/openssl/test_pkey_ec.rb
+++ b/test/openssl/test_pkey_ec.rb
@@ -265,6 +265,27 @@ class OpenSSL::TestEC < OpenSSL::PKeyTestCase
     assert_equal point2, point2_dup
     assert_equal false, point2.equal?(point2_dup)
 
+    point2_string = point2.to_octet_string(:uncompressed)
+    assert_equal 65, point2_string.size
+    assert_equal point2_string[0], "\x04"
+    point2_x_str = point2_string[1..32]
+    point2_y_str = point2_string[33..-1]
+
+    assert_not_equal(nil, point2_x_str)
+    assert_not_equal(nil, point2_y_str)
+    assert_equal(32, point2_x_str.size)
+    assert_equal(32, point2_y_str.size)
+
+    point2_x_bn = OpenSSL::BN.new point2_x_str, 2
+    point2_y_bn = OpenSSL::BN.new point2_y_str, 2
+
+    if point2.respond_to? :affine_coords
+      point2_x, point2_y = point2.affine_coords
+
+      assert_equal(point2_x_bn, point2_x)
+      assert_equal(point2_y_bn, point2_y)
+    end
+
     point3 = OpenSSL::PKey::EC::Point.new(group,
                                           point.to_octet_string(:uncompressed))
     assert_equal point, point3


### PR DESCRIPTION
This implements #433

Provides `OpenSSL::PKey::EC::Point#affine_coords` and `OpenSSL::PKey::EC::Point#affine_coords=` for uncompressed coords taking either an `Integer` or a `OpenSSL::BN` for set and always returns an array of `OpenSSL::BN` for get.

It also implements `OpenSSL::PKey::EC::Point#set_compressed_coords` taking an `Integer` or a `OpenSSL::BN` for the value of X and an `Integer` that is directly passed to `EC_POINT_set_compressed_coordinates`.  I feel like it should be checked for `[0..1]` but was simpler to pass the value directly.