### PR TITLE
pkey: remove deprecated parameter setters

### DIFF
--- a/ext/openssl/ossl_pkey.h
+++ b/ext/openssl/ossl_pkey.h
@@ -7,8 +7,8 @@
  * This program is licensed under the same licence as Ruby.
  * (See the file 'LICENCE'.)
  */
-#if !defined(_OSSL_PKEY_H_)
-#define _OSSL_PKEY_H_
+#if !defined(OSSL_PKEY_H)
+#define OSSL_PKEY_H
 
 extern VALUE mPKey;
 extern VALUE cPKey;
@@ -182,35 +182,6 @@ static VALUE ossl_##_keytype##_set_##_group(VALUE self, VALUE v1, VALUE v2) \
 	return self;							\
 }
 
-#define OSSL_PKEY_BN_DEF_SETTER_OLD(_keytype, _type, _group, _name)	\
-/*									\
- *  call-seq:								\
- *     _keytype##.##_name = bn -> bn					\
- */									\
-static VALUE ossl_##_keytype##_set_##_name(VALUE self, VALUE bignum)	\
-{									\
-	_type *obj;							\
-	BIGNUM *bn;							\
-									\
-	rb_warning("#"#_name"= is deprecated; use #set_"#_group);	\
-	Get##_type(self, obj);						\
-	if (NIL_P(bignum)) {						\
-		BN_clear_free(obj->_name);				\
-		obj->_name = NULL;					\
-		return Qnil;						\
-	}								\
-									\
-	bn = GetBNPtr(bignum);						\
-	if (obj->_name == NULL)						\
-		obj->_name = BN_new();					\
-	if (obj->_name == NULL)						\
-		ossl_raise(eBNError, NULL);				\
-	if (BN_copy(obj->_name, bn) == NULL)				\
-		ossl_raise(eBNError, NULL);				\
-	return bignum;							\
-}
-
-#if defined(HAVE_OPAQUE_OPENSSL) /* OpenSSL 1.1.0 */
 #define OSSL_PKEY_BN_DEF3(_keytype, _type, _group, a1, a2, a3)		\
 	OSSL_PKEY_BN_DEF_GETTER3(_keytype, _type, _group, a1, a2, a3)	\
 	OSSL_PKEY_BN_DEF_SETTER3(_keytype, _type, _group, a1, a2, a3)
@@ -222,24 +193,4 @@ static VALUE ossl_##_keytype##_set_##_name(VALUE self, VALUE bignum)	\
 #define DEF_OSSL_PKEY_BN(class, keytype, name)				\
 	rb_define_method((class), #name, ossl_##keytype##_get_##name, 0)
 
-#else
-#define OSSL_PKEY_BN_DEF3(_keytype, _type, _group, a1, a2, a3)		\
-	OSSL_PKEY_BN_DEF_GETTER3(_keytype, _type, _group, a1, a2, a3)	\
-	OSSL_PKEY_BN_DEF_SETTER3(_keytype, _type, _group, a1, a2, a3)	\
-	OSSL_PKEY_BN_DEF_SETTER_OLD(_keytype, _type, _group, a1)	\
-	OSSL_PKEY_BN_DEF_SETTER_OLD(_keytype, _type, _group, a2)	\
-	OSSL_PKEY_BN_DEF_SETTER_OLD(_keytype, _type, _group, a3)
-
-#define OSSL_PKEY_BN_DEF2(_keytype, _type, _group, a1, a2)		\
-	OSSL_PKEY_BN_DEF_GETTER2(_keytype, _type, _group, a1, a2)	\
-	OSSL_PKEY_BN_DEF_SETTER2(_keytype, _type, _group, a1, a2)	\
-	OSSL_PKEY_BN_DEF_SETTER_OLD(_keytype, _type, _group, a1)	\
-	OSSL_PKEY_BN_DEF_SETTER_OLD(_keytype, _type, _group, a2)
-
-#define DEF_OSSL_PKEY_BN(class, keytype, name) do {			\
-	rb_define_method((class), #name, ossl_##keytype##_get_##name, 0);\
-	rb_define_method((class), #name "=", ossl_##keytype##_set_##name, 1);\
-} while (0)
-#endif /* HAVE_OPAQUE_OPENSSL */
-
-#endif /* _OSSL_PKEY_H_ */
+#endif /* OSSL_PKEY_H */


### PR DESCRIPTION
Remove the following methods, which have been marked as deprecated and
produced a warning since version 2.0, commit 7ea72f1f5084 ("adapt
OpenSSL::PKey to OpenSSL 1.1.0 opaque structs", 2016-06-05).

 - OpenSSL::PKey::RSA#n=, #e=, #d=, #p=, #q=, #dmp1=, #dmq1=, #iqmp=
 - OpenSSL::PKey::DSA#p=, #q=, #g=, #priv_key=, #pub_key=
 - OpenSSL::PKey::DH#p=, #g=, #priv_key=, #pub_key=

These methods could only work with OpenSSL 1.0.2 or older, which is now
EOL.