### PR TITLE
Use Bundler for dependency management and Rake gem tasks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
 
       - name: depends
-        run:  rake install_dependencies
+        run:  bundle install
 
       - name: compile
         run:  rake compile -- --enable-debug
@@ -50,7 +50,7 @@ jobs:
           mingw: _upgrade_ openssl
 
       - name: depends
-        run:  rake install_dependencies
+        run:  bundle install
 
       # pkg-config is disabled because it can pick up the different OpenSSL installation
       # SSL_DIR is set as needed by MSP-Greg/setup-ruby-pkgs
@@ -110,7 +110,7 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
 
       - name: depends
-        run:  rake install_dependencies
+        run:  bundle install
 
       - name: compile
         run:  rake compile -- --enable-debug --with-openssl-dir=$HOME/.openssl/${{ matrix.openssl }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+/.bundle
+/Gemfile.lock
 /doc/
 /pkg/
 /tmp/

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,8 @@
+source "https://rubygems.org"
+
+gemspec
+
+gem "rake"
+gem "rake-compiler"
+gem "test-unit", "~> 3.0"
+gem "rdoc"

--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,5 @@ gemspec
 
 gem "rake"
 gem "rake-compiler"
-gem "test-unit", "~> 3.0"
+gem "test-unit", "~> 3.0", ">= 3.4.3"
 gem "rdoc"

--- a/Rakefile
+++ b/Rakefile
@@ -1,12 +1,12 @@
-require 'rake'
 require 'rake/testtask'
 require 'rdoc/task'
+require 'bundler/gem_tasks'
 
 begin
   require 'rake/extensiontask'
   Rake::ExtensionTask.new('openssl')
 rescue LoadError
-  warn "rake-compiler not installed. Run 'rake install_dependencies' to " \
+  warn "rake-compiler not installed. Run 'bundle install' to " \
     "install testing dependency gems."
 end
 
@@ -24,26 +24,6 @@ end
 task :test => [:compile, :debug]
 task :debug do
   ruby "-I./lib -ropenssl -ve'puts OpenSSL::OPENSSL_VERSION, OpenSSL::OPENSSL_LIBRARY_VERSION'"
-end
-
-task :install_dependencies do
-  if ENV["USE_HTTP_RUBYGEMS_ORG"] == "1"
-    Gem.sources.replace([Gem::Source.new("http://rubygems.org")])
-  end
-
-  Gem.configuration.verbose = false
-  gemspec = Gem::Specification.load('openssl.gemspec')
-
-  gemspec.development_dependencies.each do |dep|
-    print "Installing #{dep.name} (#{dep.requirement}) ... "
-    installed = dep.matching_specs
-    if installed.empty?
-      installed = Gem.install(dep.name, dep.requirement)
-      puts "#{installed[0].version}"
-    else
-      puts "(found #{installed[0].version})"
-    end
-  end
 end
 
 namespace :sync do

--- a/openssl.gemspec
+++ b/openssl.gemspec
@@ -17,10 +17,5 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.3.0"
 
-  spec.add_development_dependency "rake"
-  spec.add_development_dependency "rake-compiler"
-  spec.add_development_dependency "test-unit", "~> 3.0"
-  spec.add_development_dependency "rdoc"
-
   spec.metadata["msys2_mingw_dependencies"] = "openssl"
 end

--- a/test/openssl/envutil.rb
+++ b/test/openssl/envutil.rb
@@ -282,58 +282,6 @@ eom
         end
         values
       end
-
-      def mu_pp(obj) #:nodoc:
-        obj.pretty_inspect.chomp
-      end
-
-      # :call-seq:
-      #   assert_raise_with_message(exception, expected, msg = nil, &block)
-      #
-      #Tests if the given block raises an exception with the expected
-      #message.
-      #
-      #    assert_raise_with_message(RuntimeError, "foo") do
-      #      nil #Fails, no Exceptions are raised
-      #    end
-      #
-      #    assert_raise_with_message(RuntimeError, "foo") do
-      #      raise ArgumentError, "foo" #Fails, different Exception is raised
-      #    end
-      #
-      #    assert_raise_with_message(RuntimeError, "foo") do
-      #      raise "bar" #Fails, RuntimeError is raised but the message differs
-      #    end
-      #
-      #    assert_raise_with_message(RuntimeError, "foo") do
-      #      raise "foo" #Raises RuntimeError with the message, so assertion succeeds
-      #    end
-      def assert_raise_with_message(exception, expected, msg = nil, &block)
-        case expected
-        when String
-          assert = :assert_equal
-        when Regexp
-          assert = :assert_match
-        else
-          raise TypeError, "Expected #{expected.inspect} to be a kind of String or Regexp, not #{expected.class}"
-        end
-
-        ex = m = nil
-        ex = assert_raise(exception, msg || "Exception(#{exception}) with message matches to #{expected.inspect}") do
-          yield
-        end
-        m = ex.message
-        msg = message(msg, "") {"Expected Exception(#{exception}) was raised, but the message doesn't match"}
-
-        if assert == :assert_equal
-          assert_equal(expected, m, msg)
-        else
-          msg = message(msg) { "Expected #{mu_pp expected} to match #{mu_pp m}" }
-          assert expected =~ m, msg
-          block.binding.eval("proc{|_|$~=_}").call($~)
-        end
-        ex
-      end
     end
   end
 end


### PR DESCRIPTION
Back in 2016, we chose not to use Bundler in Ruby/OpenSSL development
because Bundler depended on openssl and could not be used for testing
openssl itself - "bundle exec rake test" would end up with loading two
different versions of openssl at the same time.

This was resolved long time ago and is not relevant anymore. We can now
safely use it for development dependency management and for Rake tasks
for simplicity.
