### PR TITLE
libressl build fix warning TS_time_cb on libressl expects an long lon…

### DIFF
--- a/ext/openssl/ossl_ts.c
+++ b/ext/openssl/ossl_ts.c
@@ -1074,7 +1074,11 @@ ossl_tsfac_serial_cb(struct TS_resp_ctx *ctx, void *data)
 }
 
 static int
+#if !defined(LIBRESSL_VERSION_NUMBER)
 ossl_tsfac_time_cb(struct TS_resp_ctx *ctx, void *data, long *sec, long *usec)
+#else
+ossl_tsfac_time_cb(struct TS_resp_ctx *ctx, void *data, time_t *sec, long *usec)
+#endif
 {
     *sec = *((long *)data);
     *usec = 0;


### PR DESCRIPTION
…g/time_t 64 bits long instead.