### PR TITLE
Suppress printf format warnings

### DIFF
--- a/ext/openssl/ossl.c
+++ b/ext/openssl/ossl.c
@@ -265,20 +265,14 @@ ossl_to_der_if_possible(VALUE obj)
     return obj;
 }
 
-PRINTF_ARGS(static VALUE ossl_make_error(VALUE exc, const char *fmt, va_list args), 2, 0);
-
 /*
  * Errors
  */
-static VALUE
-ossl_make_error(VALUE exc, const char *fmt, va_list args)
+VALUE
+ossl_make_error(VALUE exc, VALUE str)
 {
-    VALUE str = Qnil;
     unsigned long e;
 
-    if (fmt) {
-	str = rb_vsprintf(fmt, args);
-    }
     e = ERR_peek_last_error();
     if (e) {
 	const char *msg = ERR_reason_error_string(e);
@@ -302,10 +296,17 @@ ossl_raise(VALUE exc, const char *fmt, ...)
 {
     va_list args;
     VALUE err;
-    va_start(args, fmt);
-    err = ossl_make_error(exc, fmt, args);
-    va_end(args);
-    rb_exc_raise(err);
+
+    if (fmt) {
+	va_start(args, fmt);
+	err = rb_vsprintf(fmt, args);
+	va_end(args);
+    }
+    else {
+	err = Qnil;
+    }
+
+    rb_exc_raise(ossl_make_error(exc, err));
 }
 
 void

--- a/ext/openssl/ossl.c
+++ b/ext/openssl/ossl.c
@@ -265,6 +265,8 @@ ossl_to_der_if_possible(VALUE obj)
     return obj;
 }
 
+PRINTF_ARGS(static VALUE ossl_make_error(VALUE exc, const char *fmt, va_list args), 2, 0);
+
 /*
  * Errors
  */

--- a/ext/openssl/ossl.h
+++ b/ext/openssl/ossl.h
@@ -120,7 +120,7 @@ int ossl_pem_passwd_cb(char *, int, int, void *);
 /*
  * ERRor messages
  */
-NORETURN(void ossl_raise(VALUE, const char *, ...));
+PRINTF_ARGS(NORETURN(void ossl_raise(VALUE, const char *, ...)), 2, 3);
 /* Clear OpenSSL error queue. If dOSSL is set, rb_warn() them. */
 void ossl_clear_error(void);
 

--- a/ext/openssl/ossl.h
+++ b/ext/openssl/ossl.h
@@ -121,6 +121,8 @@ int ossl_pem_passwd_cb(char *, int, int, void *);
  * ERRor messages
  */
 PRINTF_ARGS(NORETURN(void ossl_raise(VALUE, const char *, ...)), 2, 3);
+/* Make exception instance from str and OpenSSL error reason string. */
+VALUE ossl_make_error(VALUE exc, VALUE str);
 /* Clear OpenSSL error queue. If dOSSL is set, rb_warn() them. */
 void ossl_clear_error(void);
 

--- a/ext/openssl/ossl_config.c
+++ b/ext/openssl/ossl_config.c
@@ -60,7 +60,7 @@ config_load_bio(CONF *conf, BIO *bio)
         if (eline <= 0)
             ossl_raise(eConfigError, "wrong config format");
         else
-            ossl_raise(eConfigError, "error in line %d", eline);
+            ossl_raise(eConfigError, "error in line %ld", eline);
     }
     BIO_free(bio);
 

--- a/ext/openssl/ossl_pkey_ec.c
+++ b/ext/openssl/ossl_pkey_ec.c
@@ -596,8 +596,10 @@ static VALUE ossl_ec_group_initialize(int argc, VALUE *argv, VALUE self)
         ossl_raise(rb_eArgError, "wrong number of arguments");
     }
 
-    if (group == NULL)
-        ossl_raise(eEC_GROUP, "");
+#if !defined(LIKELY) && !defined(RB_LIKELY)
+#define LIKELY(x) (x)
+#endif
+    ASSUME(group);
     RTYPEDDATA_DATA(self) = group;
 
     return self;

--- a/ext/openssl/ossl_ts.c
+++ b/ext/openssl/ossl_ts.c
@@ -1223,7 +1223,7 @@ end:
     ASN1_OBJECT_free(def_policy_id_obj);
     TS_RESP_CTX_free(ctx);
     if (err_msg)
-        ossl_raise(eTimestampError, err_msg);
+        rb_exc_raise(ossl_make_error(eTimestampError, rb_str_new_cstr(err_msg)));
     if (status)
         rb_jump_tag(status);
     return ret;


### PR DESCRIPTION
* Add `printf` format attribute to `ossl_raise`.
* Fix a format specifier in `config_load_bio`.
* Use `ASSUME` for the unreachable condition.
