### PR TITLE
Add test cases to OpenSSL::BN using ractor

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,5 @@ gemspec
 
 gem "rake"
 gem "rake-compiler"
-gem "test-unit", "~> 3.0", ">= 3.4.3"
+gem "test-unit", "~> 3.0", ">= 3.4.6"
 gem "rdoc"

--- a/test/openssl/test_bn.rb
+++ b/test/openssl/test_bn.rb
@@ -334,6 +334,31 @@ class OpenSSL::TestBN < OpenSSL::TestCase
     e.set_flags(0)
     assert_equal(4, e.get_flags(OpenSSL::BN::CONSTTIME))
   end
+
+  if respond_to?(:ractor)
+    ractor
+    def test_ractor
+      assert_equal(@e1, Ractor.new { OpenSSL::BN.new("999") }.take)
+      assert_equal(@e3, Ractor.new { OpenSSL::BN.new("\a\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF", 2) }.take)
+      assert_equal("999", Ractor.new(@e1) { |e1| e1.to_s }.take)
+      assert_equal("07FFFFFFFFFFFFFFFFFFFFFFFFFF", Ractor.new(@e3) { |e3| e3.to_s(16) }.take)
+      assert_equal(2**107-1, Ractor.new(@e3) { _1.to_i }.take)
+      assert_equal([1000, -999], Ractor.new(@e2) { _1.coerce(1000) }.take)
+      assert_equal(false, Ractor.new  { 1.to_bn.zero? }.take)
+      assert_equal(true, Ractor.new { 1.to_bn.one? }.take)
+      assert_equal(true, Ractor.new(@e2) { _1.negative? }.take)
+      assert_equal("-03E7", Ractor.new(@e2) { _1.to_s(16) }.take)
+      assert_equal(2**107-1, Ractor.new(@e3) { _1.to_i }.take)
+      assert_equal([1000, -999], Ractor.new(@e2) { _1.coerce(1000) }.take)
+      assert_equal(true, Ractor.new { 0.to_bn.zero? }.take)
+      assert_equal(true, Ractor.new { 1.to_bn.one? }.take )
+      assert_equal(false,Ractor.new { 2.to_bn.odd? }.take)
+      assert_equal(true, Ractor.new(@e2) { _1.negative? }.take)
+      assert_include(128..255, Ractor.new { OpenSSL::BN.rand(8)}.take)
+      assert_include(0...2**32, Ractor.new { OpenSSL::BN.generate_prime(32) }.take)
+      assert_equal(0, Ractor.new { OpenSSL::BN.new(999).get_flags(OpenSSL::BN::CONSTTIME) }.take)
+    end
+  end
 end
 
 end


### PR DESCRIPTION
`OpenSSL::BN` has been made ractor-safed in 9e7cf9e , but there was no test.

To write tests, I picked up some cases from other cases. If it is not enough, please tell me.