### PR TITLE
ssl: add SSLContext#tmp_dh= 

### DIFF
--- a/ext/openssl/extconf.rb
+++ b/ext/openssl/extconf.rb
@@ -170,6 +170,9 @@ have_func("SSL_CTX_set_post_handshake_auth")
 # added in 1.1.1
 have_func("EVP_PKEY_check")
 
+# added in 3.0.0
+have_func("SSL_set0_tmp_dh_pkey")
+
 Logging::message "=== Checking done. ===\n"
 
 create_header

--- a/lib/openssl/ssl.rb
+++ b/lib/openssl/ssl.rb
@@ -432,10 +432,6 @@ YoaOffgTf5qxiwkjnlVZQc3whgnEt9FpVMvQ9eknyeGB5KHfayAc3+hUAvI3/Cr3
         @context.tmp_dh_callback || OpenSSL::SSL::SSLContext::DEFAULT_TMP_DH_CALLBACK
       end
 
-      def tmp_ecdh_callback
-        @context.tmp_ecdh_callback
-      end
-
       def session_new_cb
         @context.session_new_cb
       end

--- a/lib/openssl/ssl.rb
+++ b/lib/openssl/ssl.rb
@@ -91,15 +91,17 @@ YoaOffgTf5qxiwkjnlVZQc3whgnEt9FpVMvQ9eknyeGB5KHfayAc3+hUAvI3/Cr3
       DEFAULT_CERT_STORE.set_default_paths
       DEFAULT_CERT_STORE.flags = OpenSSL::X509::V_FLAG_CRL_CHECK_ALL
 
-      # A callback invoked when DH parameters are required.
+      # A callback invoked when DH parameters are required for ephemeral DH key
+      # exchange.
       #
-      # The callback is invoked with the Session for the key exchange, an
+      # The callback is invoked with the SSLSocket, a
       # flag indicating the use of an export cipher and the keylength
       # required.
       #
       # The callback must return an OpenSSL::PKey::DH instance of the correct
       # key length.
-
+      #
+      # <b>Deprecated in version 3.0.</b> Use #tmp_dh= instead.
       attr_accessor :tmp_dh_callback
 
       # A callback invoked at connect time to distinguish between multiple


### PR DESCRIPTION
Provide a wrapper of SSL_set0_tmp_dh_pkey()/SSL_CTX_set_tmp_dh(), which
sets the DH parameters used for ephemeral DH key exchange.

SSLContext#tmp_dh_callback= already exists for this purpose, as a
wrapper around SSL_CTX_set_tmp_dh_callback(), but it is considered
obsolete and the OpenSSL API is deprecated for future removal. There is
no practical use case where an application needs to use different DH
parameters nowadays. This was originally introduced to support export
grade ciphers.

RDoc for #tmp_dh_callback= is updated to recommend the new #tmp_dh=.

Note that current versions of OpenSSL support automatic ECDHE curve
selection which is enabled by default. SSLContext#tmp_dh= should only be
necessary if you must allow ancient clients which don't support ECDHE.

This is part of #369.