### PR TITLE
pkey: use RSTRING_LENINT() instead of casting to int

### DIFF
--- a/ext/openssl/ossl_pkey_ec.c
+++ b/ext/openssl/ossl_pkey_ec.c
@@ -653,15 +653,15 @@ static VALUE ossl_ec_key_dsa_verify_asn1(VALUE self, VALUE data, VALUE sig)
     StringValue(data);
     StringValue(sig);
 
-    switch (ECDSA_verify(0, (unsigned char *) RSTRING_PTR(data), RSTRING_LENINT(data), (unsigned char *) RSTRING_PTR(sig), (int)RSTRING_LEN(sig), ec)) {
-    case 1:	return Qtrue;
-    case 0:	return Qfalse;
-    default:	break;
+    switch (ECDSA_verify(0, (unsigned char *)RSTRING_PTR(data), RSTRING_LENINT(data),
+                         (unsigned char *)RSTRING_PTR(sig), RSTRING_LENINT(sig), ec)) {
+      case 1:
+        return Qtrue;
+      case 0:
+        return Qfalse;
+      default:
+        ossl_raise(eECError, "ECDSA_verify");
     }
-
-    ossl_raise(eECError, "ECDSA_verify");
-
-    UNREACHABLE;
 }
 
 /*


### PR DESCRIPTION
RSTRING_LENINT() checks the range of int and raises an exception as
necessary. OpenSSL::PKey::EC#dsa_verify_asn1 currently does not do this,
and giving a too big string to it can trigger a surprising behavior:

    ec.dsa_verify_asn1(digest, signature)               #=> true
    ec.dsa_verify_asn1(digest, signature + "x" * 2**32) #=> true

Reference: https://hackerone.com/reports/1246050