### PR TITLE
digest: load digest library using Kernel#require

### DIFF
--- a/ext/openssl/ossl_digest.c
+++ b/ext/openssl/ossl_digest.c
@@ -313,8 +313,6 @@ ossl_digest_block_length(VALUE self)
 void
 Init_ossl_digest(void)
 {
-    rb_require("digest");
-
 #if 0
     mOSSL = rb_define_module("OpenSSL");
     eOSSLError = rb_define_class_under(mOSSL, "OpenSSLError", rb_eStandardError);
@@ -433,6 +431,12 @@ Init_ossl_digest(void)
      *   digest2 = sha256.digest(data2)
      *
      */
+
+    /*
+     * Digest::Class is defined by the digest library. rb_require() cannot be
+     * used here because it bypasses RubyGems.
+     */
+    rb_funcall(Qnil, rb_intern_const("require"), 1, rb_str_new_cstr("digest"));
     cDigest = rb_define_class_under(mOSSL, "Digest", rb_path2class("Digest::Class"));
     /* Document-class: OpenSSL::Digest::DigestError
      *


### PR DESCRIPTION
The digest library is a default gem now, too. Therefore we can't simply
use rb_require() to load it, but we should use Kernel#require instead.

This change is based on the suggestion by David Rodríguez in
https://github.com/ruby/digest/commit/16172612d56ac42f57e5788465791329303ac5d0#commitcomment-57778397