### PR TITLE
pkey: use OSSL_DECODER to load encrypted PEM on OpenSSL 3.0

### DIFF
--- a/test/openssl/test_pkey_rsa.rb
+++ b/test/openssl/test_pkey_rsa.rb
@@ -306,6 +306,12 @@ class OpenSSL::TestPKeyRSA < OpenSSL::PKeyTestCase
 
     assert_equal asn1.to_der, rsa1024.to_der
     assert_equal pem, rsa1024.export
+
+    # Unknown PEM prepended
+    cert = issue_cert(OpenSSL::X509::Name.new([["CN", "nobody"]]), rsa1024, 1, [], nil, nil)
+    str = cert.to_text + cert.to_pem + rsa1024.to_pem
+    key = OpenSSL::PKey::RSA.new(str)
+    assert_same_rsa rsa1024, key
   end
 
   def test_RSAPrivateKey_encrypted


### PR DESCRIPTION
OpenSSL 3.0 has rewritten routines to load pkeys (PEM_read_bio_* and
d2i_* functions) around the newly introduced OSSL_DECODER API.

This comes with a slight behavior change. They now decrypt and parse
each encountered PEM block, then check the kind of the block. This used
to be the reverse: they checked the PEM header to see the kind, and then
decrypted the content. This means that the password callback may now be
called repeatedly.

Let's use the OSSL_DECODER API directly on OpenSSL 3.0 so that the
return value from the password callback will be reused automatically.

This is part of #369 (Support OpenSSL 3.0). The patch was originally submitted in #399.