### PR TITLE
change a way of buffering for large data

### DIFF
--- a/lib/openssl/buffering.rb
+++ b/lib/openssl/buffering.rb
@@ -348,15 +348,19 @@ module OpenSSL::Buffering
     @wbuffer << s
     @wbuffer.force_encoding(Encoding::BINARY)
     @sync ||= false
+    @offset ||= 0
+
     if @sync or @wbuffer.size > BLOCK_SIZE
-      until @wbuffer.empty?
+      while @offset < @wbuffer.size
         begin
-          nwrote = syswrite(@wbuffer)
+          @offset += syswrite(@wbuffer[@offset, BLOCK_SIZE])
         rescue Errno::EAGAIN
           retry
         end
-        @wbuffer[0, nwrote] = ""
       end
+
+      @wbuffer.clear
+      @offset = 0
     end
   end
 


### PR DESCRIPTION
This pull request implements #484
I think the memory allocation has significantly improved.

### Result of investigation

#### Environment

```
vscode ➜ /workspaces/openssl (test-improve-for-large-data ✗) $ ruby -v
ruby 3.0.3p157 (2021-11-24 revision 3fb7d2cadc) [x86_64-linux]
vscode ➜ /workspaces/openssl (test-improve-for-large-data ✗) $ uname -a
Linux b7fd770ae703 5.10.25-linuxkit #1 SMP Tue Mar 23 09:27:39 UTC 2021 x86_64 GNU/Linux
vscode ➜ /workspaces/openssl (test-improve-for-large-data ✗) $ 
```

#### Test Code

here is the test code.
https://github.com/h-r-k-matsumoto/openssl/commit/4daf387544c427c229d33a62d40997ec6c2f9f94

```ruby
  def test_write_large_bytes
    len = 1024 * 1024  * 10
    data = '1' * len + "\n"

    start_server { |port|
      begin
        sock = TCPSocket.new("127.0.0.1", port)
        ssl = OpenSSL::SSL::SSLSocket.new(sock)
        ssl.connect

        MemoryProfiler.report do
          ssl.write data
        end.pretty_print
        assert_equal data, ssl.gets
      ensure
        sock&.close
      end
    }
  end
```

#### Before

```
Total allocated: 3393069117 bytes (1789 objects)
Total retained:  11535026 bytes (6 objects)

...

Finished in 2.7077402 seconds.
-----------------------------------------------------------------------------------------------------------------------------------------------------
1 tests, 2 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
-----------------------------------------------------------------------------------------------------------------------------------------------------
0.37 tests/s, 0.74 assertions/s
```

#### After

```
Total allocated: 29004136 bytes (1712 objects)
Total retained:  11551451 bytes (7 objects)
...
Finished in 0.9382068 seconds.
-----------------------------------------------------------------------------------------------------------------------------------------------------
1 tests, 2 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
-----------------------------------------------------------------------------------------------------------------------------------------------------
1.07 tests/s, 2.13 assertions/s
```

