### PR TITLE
ignore pkgconfig when openssl-dir option is specified

### DIFF
--- a/ext/openssl/extconf.rb
+++ b/ext/openssl/extconf.rb
@@ -14,7 +14,7 @@
 require "mkmf"
 require File.expand_path('../deprecation', __FILE__)
 
-dir_config("openssl")
+dir_config_given = dir_config("openssl").any?
 dir_config("kerberos")
 
 Logging::message "=== OpenSSL for Ruby configurator ===\n"
@@ -88,7 +88,7 @@ def find_openssl_library
 end
 
 Logging::message "=== Checking for required stuff... ===\n"
-pkg_config_found = pkg_config("openssl") && have_header("openssl/ssl.h")
+pkg_config_found = !dir_config_given && pkg_config("openssl") && have_header("openssl/ssl.h")
 
 if !pkg_config_found && !find_openssl_library
   Logging::message "=== Checking for required stuff failed. ===\n"


### PR DESCRIPTION
When openssl is installed on a system with pkconfig files, it is impossible to compile and link against another version of the library.

This patch fixes this by ignoring pkconfig files when the option is given.