### PR TITLE
Remove verify_hostname requires hostname warning

### DIFF
--- a/ext/openssl/ossl_ssl.c
+++ b/ext/openssl/ossl_ssl.c
@@ -307,7 +307,6 @@ call_verify_certificate_identity(VALUE ctx_v)
     hostname = rb_attr_get(ssl_obj, id_i_hostname);
 
     if (!RTEST(hostname)) {
-	rb_warning("verify_hostname requires hostname to be set");
 	return Qtrue;
     }
 


### PR DESCRIPTION
When connecting to an IP address, you should not set hostname,
since IP addresses are not allowed as SNI server names (per RFC 6066,
section 3).  A recent change to LibreSSL made it more strict, and
LibreSSL will now raise an error if hostname= is used with an IP
address.

While SNI should not be used when connecting to an IP address, you
still want to verify that the certificate sent by the server is
valid for the IP address.  Currently, that results in a warning,
but it should not result in a warning as there is no way around
the problem in this case.