### PR TITLE
[CI] Add Ruby 3.1, OS to numeric, Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,8 +10,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest ]
-        ruby: [ head, "3.0", "2.7", "2.6" ]
+        os: [ ubuntu-20.04, macos-11 ]
+        ruby: [ head, "3.1", "3.0", "2.7", "2.6" ]
     steps:
       - name: repo checkout
         uses: actions/checkout@v2
@@ -37,17 +37,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ windows-latest ]
-        ruby: [ mswin, mingw, "3.0", "2.7", "2.6" ]
+        os: [ windows-2022 ]
+        ruby: [ ucrt, mingw, "3.1", "3.0", "2.7", "2.6" ]
+        include:
+          # as of 2022-Jan, mswin will not build on windows-2022
+          - { os: windows-2019, ruby: mswin }
     steps:
       - name: repo checkout
         uses: actions/checkout@v2
 
-      - name: load ruby, install/update gcc, install openssl
-        uses: MSP-Greg/setup-ruby-pkgs@v1
+      - name: load ruby
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-          mingw: _upgrade_ openssl
 
       - name: depends
         run:  bundle install
@@ -56,7 +58,14 @@ jobs:
       # SSL_DIR is set as needed by MSP-Greg/setup-ruby-pkgs
       # only used with mswin
       - name: compile
-        run:  rake compile -- --enable-debug --without-pkg-config $env:SSL_DIR
+        run:  |
+          if ('${{ matrix.ruby }}' -eq 'mswin') {
+            choco install --no-progress openssl
+            New-Item  -Path C:/OpenSSL-Win64 -ItemType Junction -Value "C:/Program Files/OpenSSL-Win64" 1> $null
+            rake compile -- --enable-debug --without-pkg-config --with-openssl-dir=C:/OpenSSL-Win64
+          } else {
+            rake compile -- --enable-debug
+          }
 
       - name: test
         run:  rake test TESTOPTS="-v --no-show-detail-immediately" OSSL_MDEBUG=1


### PR DESCRIPTION
The Actions windows-2016 & 2019 images have mingw build tools installed.  The new windows-2022 image only has a bash shell and pacman installed.

So, when using the windows-2022 image, ruby/setup-ruby now installs the mingw64 or ucrt64 toolsets.  Since the additional size of the packages needed to build Ruby is negligible, those packages are also installed.  This means that the only reason for using MSP-Greg/setup-ruby-pkgs is the Windows mswin build.

Since the code for that is rather simple (install openssl-dev, etc), I switched to ruby/setup-ruby and added a short PowerShell script to account for the mswin job.

**EDIT:** There are some excepts to the above, but only with Windows Rubies 2.4 and earlier.  If one needs to build with OpenSSL on 2.4, MSP-Greg/setup-ruby-pkgs needs to be used, as 2.4 was built with OpenSSL 1.0.2.  Windows Ruby 2.3 and earlier need MSP-Greg/setup-ruby-pkgs for all package installations, and there are very few available (they were built with MSYS, not MSYS2).