### PR TITLE
Added 'ciphersuites=' method to allow setting of TLSv1.3 cipher suites along with some unit tests

### DIFF
--- a/ext/openssl/extconf.rb
+++ b/ext/openssl/extconf.rb
@@ -169,6 +169,7 @@ have_func("SSL_CTX_set_post_handshake_auth")
 
 # added in 1.1.1
 have_func("EVP_PKEY_check")
+have_func("SSL_CTX_set_ciphersuites")
 
 # added in 3.0.0
 have_func("SSL_set0_tmp_dh_pkey")

--- a/ext/openssl/ossl_ssl.c
+++ b/ext/openssl/ossl_ssl.c
@@ -1014,9 +1014,9 @@ ossl_sslctx_set_ciphers(VALUE self, VALUE v)
 #ifdef HAVE_SSL_CTX_SET_CIPHERSUITES
 /*
  * call-seq:
- *    ctx.tls13_ciphers = "cipher1:cipher2:..."
- *    ctx.tls13_ciphers = [name, ...]
- *    ctx.tls13_ciphers = [[name, version, bits, alg_bits], ...]
+ *    ctx.ciphersuites = "cipher1:cipher2:..."
+ *    ctx.ciphersuites = [name, ...]
+ *    ctx.ciphersuites = [[name, version, bits, alg_bits], ...]
  *
  * Sets the list of available TLSv1.3 cipher suites for this context.
  */
@@ -2740,8 +2740,8 @@ Init_ossl_ssl(void)
     rb_define_alias(cSSLContext, "ssl_timeout=", "timeout=");
     rb_define_private_method(cSSLContext, "set_minmax_proto_version",
 			     ossl_sslctx_set_minmax_proto_version, 2);
-    rb_define_method(cSSLContext, "ciphers",        ossl_sslctx_get_ciphers, 0);
-    rb_define_method(cSSLContext, "ciphers=",       ossl_sslctx_set_ciphers, 1);
+    rb_define_method(cSSLContext, "ciphers",     ossl_sslctx_get_ciphers, 0);
+    rb_define_method(cSSLContext, "ciphers=",    ossl_sslctx_set_ciphers, 1);
 #ifdef HAVE_SSL_CTX_SET_CIPHERSUITES
     rb_define_method(cSSLContext, "ciphersuites=", ossl_sslctx_set_ciphersuites, 1);
 #endif

--- a/ext/openssl/ossl_ssl.c
+++ b/ext/openssl/ossl_ssl.c
@@ -959,6 +959,29 @@ ossl_sslctx_get_ciphers(VALUE self)
     return ary;
 }
 
+static VALUE
+build_cipher_string(VALUE v)
+{
+    VALUE str, elem;
+    int i;
+
+    if (RB_TYPE_P(v, T_ARRAY)) {
+        str = rb_str_new(0, 0);
+        for (i = 0; i < RARRAY_LEN(v); i++) {
+            elem = rb_ary_entry(v, i);
+            if (RB_TYPE_P(elem, T_ARRAY)) elem = rb_ary_entry(elem, 0);
+            elem = rb_String(elem);
+            rb_str_append(str, elem);
+            if (i < RARRAY_LEN(v)-1) rb_str_cat2(str, ":");
+        }
+    } else {
+        str = v;
+        StringValue(str);
+    }
+
+    return str;
+}
+
 /*
  * call-seq:
  *    ctx.ciphers = "cipher1:cipher2:..."
@@ -973,33 +996,49 @@ static VALUE
 ossl_sslctx_set_ciphers(VALUE self, VALUE v)
 {
     SSL_CTX *ctx;
-    VALUE str, elem;
-    int i;
+    VALUE str;
 
     rb_check_frozen(self);
     if (NIL_P(v))
-	return v;
-    else if (RB_TYPE_P(v, T_ARRAY)) {
-        str = rb_str_new(0, 0);
-        for (i = 0; i < RARRAY_LEN(v); i++) {
-            elem = rb_ary_entry(v, i);
-            if (RB_TYPE_P(elem, T_ARRAY)) elem = rb_ary_entry(elem, 0);
-            elem = rb_String(elem);
-            rb_str_append(str, elem);
-            if (i < RARRAY_LEN(v)-1) rb_str_cat2(str, ":");
-        }
-    } else {
-        str = v;
-        StringValue(str);
-    }
+        return v;
+
+    str = build_cipher_string(v);
 
     GetSSLCTX(self, ctx);
-    if (!SSL_CTX_set_cipher_list(ctx, StringValueCStr(str))) {
+    if (!SSL_CTX_set_cipher_list(ctx, StringValueCStr(str)))
         ossl_raise(eSSLError, "SSL_CTX_set_cipher_list");
-    }
 
     return v;
 }
+
+#ifdef HAVE_SSL_CTX_SET_CIPHERSUITES
+/*
+ * call-seq:
+ *    ctx.tls13_ciphers = "cipher1:cipher2:..."
+ *    ctx.tls13_ciphers = [name, ...]
+ *    ctx.tls13_ciphers = [[name, version, bits, alg_bits], ...]
+ *
+ * Sets the list of available TLSv1.3 cipher suites for this context.
+ */
+static VALUE
+ossl_sslctx_set_ciphersuites(VALUE self, VALUE v)
+{
+    SSL_CTX *ctx;
+    VALUE str;
+
+    rb_check_frozen(self);
+    if (NIL_P(v))
+        return v;
+
+    str = build_cipher_string(v);
+
+    GetSSLCTX(self, ctx);
+    if (!SSL_CTX_set_ciphersuites(ctx, StringValueCStr(str)))
+        ossl_raise(eSSLError, "SSL_CTX_set_ciphersuites");
+
+    return v;
+}
+#endif
 
 #ifndef OPENSSL_NO_DH
 /*
@@ -2701,8 +2740,11 @@ Init_ossl_ssl(void)
     rb_define_alias(cSSLContext, "ssl_timeout=", "timeout=");
     rb_define_private_method(cSSLContext, "set_minmax_proto_version",
 			     ossl_sslctx_set_minmax_proto_version, 2);
-    rb_define_method(cSSLContext, "ciphers",     ossl_sslctx_get_ciphers, 0);
-    rb_define_method(cSSLContext, "ciphers=",    ossl_sslctx_set_ciphers, 1);
+    rb_define_method(cSSLContext, "ciphers",        ossl_sslctx_get_ciphers, 0);
+    rb_define_method(cSSLContext, "ciphers=",       ossl_sslctx_set_ciphers, 1);
+#ifdef HAVE_SSL_CTX_SET_CIPHERSUITES
+    rb_define_method(cSSLContext, "ciphersuites=", ossl_sslctx_set_ciphersuites, 1);
+#endif
 #ifndef OPENSSL_NO_DH
     rb_define_method(cSSLContext, "tmp_dh=", ossl_sslctx_set_tmp_dh, 1);
 #endif

--- a/test/openssl/test_ssl.rb
+++ b/test/openssl/test_ssl.rb
@@ -1570,8 +1570,10 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
   end
 
   def test_ciphersuites_method_tls_connection
-    pend 'TLS 1.3 not supported' unless tls13_supported?
     ssl_ctx = OpenSSL::SSL::SSLContext.new
+    if !tls13_supported? || !ssl_ctx.respond_to?(:ciphersuites=)
+      pend 'TLS 1.3 not supported'
+    end
 
     csuite = ['TLS_AES_128_GCM_SHA256', 'TLSv1.3', 128, 128]
     inputs = [csuite[0], [csuite[0]], [csuite]]

--- a/test/openssl/test_ssl.rb
+++ b/test/openssl/test_ssl.rb
@@ -1618,8 +1618,6 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
   end
 
   def test_ciphers_method_tls_connection
-    ssl_ctx = OpenSSL::SSL::SSLContext.new
-
     csuite = ['ECDHE-RSA-AES256-SHA384', 'TLSv1.2', 256, 256]
     inputs = [csuite[0], [csuite[0]], [csuite]]
 

--- a/test/openssl/test_ssl.rb
+++ b/test/openssl/test_ssl.rb
@@ -1587,6 +1587,7 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
         server_connect(port, cli_ctx) do |ssl|
           assert_equal('TLSv1.3', ssl.ssl_version)
           assert_equal(csuite[0], ssl.cipher[0])
+          ssl.puts('abc'); assert_equal("abc\n", ssl.gets)
         end
       end
     end
@@ -1630,6 +1631,7 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
         server_connect(port, cli_ctx) do |ssl|
           assert_equal('TLSv1.2', ssl.ssl_version)
           assert_equal(csuite[0], ssl.cipher[0])
+          ssl.puts('abc'); assert_equal("abc\n", ssl.gets)
         end
       end
     end

--- a/test/openssl/test_ssl.rb
+++ b/test/openssl/test_ssl.rb
@@ -1586,7 +1586,7 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
 
         server_connect(port, cli_ctx) do |ssl|
           assert_equal('TLSv1.3', ssl.ssl_version)
-          assert_equal(csuite, ssl.cipher)
+          assert_equal(csuite[0], ssl.cipher[0])
         end
       end
     end
@@ -1629,7 +1629,7 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
 
         server_connect(port, cli_ctx) do |ssl|
           assert_equal('TLSv1.2', ssl.ssl_version)
-          assert_equal(csuite, ssl.cipher)
+          assert_equal(csuite[0], ssl.cipher[0])
         end
       end
     end

--- a/test/openssl/test_ssl.rb
+++ b/test/openssl/test_ssl.rb
@@ -1618,7 +1618,7 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
   end
 
   def test_ciphers_method_tls_connection
-    csuite = ['ECDHE-RSA-AES256-SHA384', 'TLSv1.2', 256, 256]
+    csuite = ['ECDHE-RSA-AES256-GCM-SHA384', 'TLSv1.2', 256, 256]
     inputs = [csuite[0], [csuite[0]], [csuite]]
 
     start_server do |port|

--- a/test/openssl/test_ssl.rb
+++ b/test/openssl/test_ssl.rb
@@ -1625,7 +1625,7 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
 
   def test_ciphers_method_tls_connection
     ssl_ctx = OpenSSL::SSL::SSLContext.new
-    csuite = ssl_ctx.ciphers.select { |x| x[0] !~ /PSK|SRP/ && \
+    csuite = ssl_ctx.ciphers.select { |x| x[0] =~ /^(EC)?DHE?-RSA/ && \
       x[1] == 'TLSv1.0' }[-1]
 
     pend "couldn't find a TLSv1.0 cipher suite for testing" if csuite.nil?


### PR DESCRIPTION
Added an instance method, 'ciphersuites=', to OpenSSL::SSL::SSLContext which allows users to set the TLSv1.3 cipher suites. Also, added unit tests for this method and improved the test coverage for the existing 'ciphers=' method.

Resolves #476