### PR TITLE
Update actions at 2022/3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest ]
-        ruby: [ head, "3.0", "2.7", "2.6" ]
+        ruby: [ head, "3.1", "3.0", "2.7", "2.6" ]
     steps:
       - name: repo checkout
         uses: actions/checkout@v2
@@ -38,7 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ windows-latest ]
-        ruby: [ mswin, mingw, "3.0", "2.7", "2.6" ]
+        ruby: [ mswin, mingw, "3.1", "3.0", "2.7", "2.6" ]
     steps:
       - name: repo checkout
         uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
         ruby: [ head, "3.1", "3.0", "2.7", "2.6" ]
     steps:
       - name: repo checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: load ruby
         uses: ruby/setup-ruby@v1
@@ -41,7 +41,7 @@ jobs:
         ruby: [ mswin, mingw, "3.1", "3.0", "2.7", "2.6" ]
     steps:
       - name: repo checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: load ruby, install/update gcc, install openssl
         uses: MSP-Greg/setup-ruby-pkgs@v1


### PR DESCRIPTION
Simply added 3.1 and update `actions/checkout@v3`.

This PR has some of duplicated section with https://github.com/ruby/openssl/pull/491