### PR TITLE
Make tests pass on LibreSSL 3.5 and 3.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,8 +77,10 @@ jobs:
           - openssl-1.1.1l
           - openssl-3.0.1
           - libressl-3.1.5 # EOL
-          - libressl-3.2.6
-          - libressl-3.3.4
+          - libressl-3.2.7
+          - libressl-3.3.5
+          - libressl-3.4.2
+          - libressl-3.5.0
     steps:
       - name: repo checkout
         uses: actions/checkout@v2

--- a/ext/openssl/ossl.h
+++ b/ext/openssl/ossl.h
@@ -43,13 +43,13 @@
 #ifndef LIBRESSL_VERSION_NUMBER
 # define OSSL_IS_LIBRESSL 0
 # define OSSL_OPENSSL_PREREQ(maj, min, pat) \
-      (OPENSSL_VERSION_NUMBER >= (maj << 28) | (min << 20) | (pat << 12))
+      (OPENSSL_VERSION_NUMBER >= ((maj << 28) | (min << 20) | (pat << 12)))
 # define OSSL_LIBRESSL_PREREQ(maj, min, pat) 0
 #else
 # define OSSL_IS_LIBRESSL 1
 # define OSSL_OPENSSL_PREREQ(maj, min, pat) 0
 # define OSSL_LIBRESSL_PREREQ(maj, min, pat) \
-      (LIBRESSL_VERSION_NUMBER >= (maj << 28) | (min << 20) | (pat << 12))
+      (LIBRESSL_VERSION_NUMBER >= ((maj << 28) | (min << 20) | (pat << 12)))
 #endif
 
 #if !defined(OPENSSL_NO_ENGINE) && !OSSL_OPENSSL_PREREQ(3, 0, 0)

--- a/ext/openssl/ossl_pkey.c
+++ b/ext/openssl/ossl_pkey.c
@@ -670,7 +670,7 @@ ossl_pkey_export_traditional(int argc, VALUE *argv, VALUE self, int to_der)
 	}
     }
     else {
-#if OPENSSL_VERSION_NUMBER >= 0x10100000 && !defined(LIBRESSL_VERSION_NUMBER)
+#if OSSL_OPENSSL_PREREQ(1, 1, 0) || OSSL_LIBRESSL_PREREQ(3, 5, 0)
 	if (!PEM_write_bio_PrivateKey_traditional(bio, pkey, enc, NULL, 0,
 						  ossl_pem_passwd_cb,
 						  (void *)pass)) {

--- a/test/openssl/test_ssl.rb
+++ b/test/openssl/test_ssl.rb
@@ -1586,7 +1586,11 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
 
         server_connect(port, cli_ctx) do |ssl|
           assert_equal('TLSv1.3', ssl.ssl_version)
-          assert_equal(csuite[0], ssl.cipher[0])
+          if libressl?(3, 4, 0) && !libressl?(3, 5, 0)
+            assert_equal("AEAD-AES128-GCM-SHA256", ssl.cipher[0]) 
+          else
+            assert_equal(csuite[0], ssl.cipher[0]) 
+          end
           ssl.puts('abc'); assert_equal("abc\n", ssl.gets)
         end
       end


### PR DESCRIPTION
The openssl extension stopped building on LibreSSL 3.5. #499 attempts
to address this, but also includes some new features.  This pull request
is strictly limited to fixing bugs.

While trying to get tests to pass, I noticed OSSL_OPENSSL_PREREQ and
OSSL_LIBRESSL_PREREQ were broken due to operator precedence issues,
so this fixes those.

The remaining fix was a small test fix to allow tests to pass on LibreSSL 3.4,
due to a non-standard cipher name (changed to match OpenSSL in
LibreSSL 3.5).