### PR TITLE
Use SHA256 for OCSP BasicResponse and Request

### DIFF
--- a/ext/openssl/ossl_ocsp.c
+++ b/ext/openssl/ossl_ocsp.c
@@ -382,7 +382,7 @@ ossl_ocspreq_sign(int argc, VALUE *argv, VALUE self)
     if (!NIL_P(flags))
 	flg = NUM2INT(flags);
     if (NIL_P(digest))
-	md = EVP_sha1();
+	md = NULL;
     else
 	md = ossl_evp_get_digestbyname(digest);
     if (NIL_P(certs))

--- a/ext/openssl/ossl_ocsp.c
+++ b/ext/openssl/ossl_ocsp.c
@@ -1033,7 +1033,7 @@ ossl_ocspbres_sign(int argc, VALUE *argv, VALUE self)
     if (!NIL_P(flags))
 	flg = NUM2INT(flags);
     if (NIL_P(digest))
-	md = EVP_sha1();
+	md = NULL;
     else
 	md = ossl_evp_get_digestbyname(digest);
     if (NIL_P(certs))

--- a/test/openssl/test_ocsp.rb
+++ b/test/openssl/test_ocsp.rb
@@ -99,7 +99,7 @@ class OpenSSL::TestOCSP < OpenSSL::TestCase
     request.sign(@cert, @cert_key, [@ca_cert], 0)
     asn1 = OpenSSL::ASN1.decode(request.to_der)
     assert_equal cid.to_der, asn1.value[0].value.find { |a| a.tag_class == :UNIVERSAL }.value[0].value[0].to_der
-    assert_equal OpenSSL::ASN1.ObjectId("sha1WithRSAEncryption").to_der, asn1.value[1].value[0].value[0].value[0].to_der
+    assert_equal OpenSSL::ASN1.ObjectId("sha256WithRSAEncryption").to_der, asn1.value[1].value[0].value[0].value[0].to_der
     assert_equal @cert.to_der, asn1.value[1].value[0].value[2].value[0].value[0].to_der
     assert_equal @ca_cert.to_der, asn1.value[1].value[0].value[2].value[0].value[1].to_der
     assert_equal asn1.to_der, OpenSSL::OCSP::Request.new(asn1.to_der).to_der


### PR DESCRIPTION
SHA1 is not considered a safe cipher, and as such, it is by default disabled by a system-wide crypto policy on c9s and RHEL 9.

Calling the `sign` method of described classes on described OS raises an `InvalidDigest` exception.

This PR adjusts the behavior to use SHA256 by default instead of SHA1. Tests passed locally on this change.

An example of failing tests from the Ruby 3.1 test suite on such systems:
```
 13) Error:
OpenSSL::TestOCSP#test_basic_response_der:
OpenSSL::OCSP::OCSPError: invalid digest
    /builddir/build/BUILD/ruby-3.1.1/test/openssl/test_ocsp.rb:170:in `sign'
    /builddir/build/BUILD/ruby-3.1.1/test/openssl/test_ocsp.rb:170:in `test_basic_response_der'
 14) Error:
OpenSSL::TestOCSP#test_request_sign_verify:
OpenSSL::OCSP::OCSPError: invalid digest
    /builddir/build/BUILD/ruby-3.1.1/test/openssl/test_ocsp.rb:114:in `sign'
    /builddir/build/BUILD/ruby-3.1.1/test/openssl/test_ocsp.rb:114:in `test_request_sign_verify'
 15) Error:
OpenSSL::TestOCSP#test_basic_response_sign_verify:
OpenSSL::OCSP::OCSPError: invalid digest
    /builddir/build/BUILD/ruby-3.1.1/test/openssl/test_ocsp.rb:200:in `sign'
    /builddir/build/BUILD/ruby-3.1.1/test/openssl/test_ocsp.rb:200:in `test_basic_response_sign_verify'
 16) Error:
OpenSSL::TestOCSP#test_response_dup:
OpenSSL::OCSP::OCSPError: invalid digest
    /builddir/build/BUILD/ruby-3.1.1/test/openssl/test_ocsp.rb:298:in `sign'
    /builddir/build/BUILD/ruby-3.1.1/test/openssl/test_ocsp.rb:298:in `test_response_dup'
 17) Error:
OpenSSL::TestOCSP#test_request_is_signed:
OpenSSL::OCSP::OCSPError: invalid digest
    /builddir/build/BUILD/ruby-3.1.1/test/openssl/test_ocsp.rb:139:in `sign'
    /builddir/build/BUILD/ruby-3.1.1/test/openssl/test_ocsp.rb:139:in `test_request_is_signed'
 18) Error:
OpenSSL::TestOCSP#test_basic_response_dup:
OpenSSL::OCSP::OCSPError: invalid digest
    /builddir/build/BUILD/ruby-3.1.1/test/openssl/test_ocsp.rb:212:in `sign'
    /builddir/build/BUILD/ruby-3.1.1/test/openssl/test_ocsp.rb:212:in `test_basic_response_dup'
 19) Error:
OpenSSL::TestOCSP#test_request_der:
OpenSSL::OCSP::OCSPError: invalid digest
    /builddir/build/BUILD/ruby-3.1.1/test/openssl/test_ocsp.rb:99:in `sign'
    /builddir/build/BUILD/ruby-3.1.1/test/openssl/test_ocsp.rb:99:in `test_request_der'
 20) Error:
OpenSSL::TestOCSP#test_response:
OpenSSL::OCSP::OCSPError: invalid digest
    /builddir/build/BUILD/ruby-3.1.1/test/openssl/test_ocsp.rb:275:in `sign'
    /builddir/build/BUILD/ruby-3.1.1/test/openssl/test_ocsp.rb:275:in `test_response'
 21) Error:
OpenSSL::TestOCSP#test_response_der:
OpenSSL::OCSP::OCSPError: invalid digest
    /builddir/build/BUILD/ruby-3.1.1/test/openssl/test_ocsp.rb:286:in `sign'
    /builddir/build/BUILD/ruby-3.1.1/test/openssl/test_ocsp.rb:286:in `test_response_der'
```