### PR TITLE
[CI] add Ubuntu-22.04 and update mswin, all are OpenSSL 3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,8 +10,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
         ruby: [ head, "3.1", "3.0", "2.7", "2.6" ]
+        include:
+          - { os: windows-latest, ruby: mswin }
+          - { os: ubuntu-22.04, ruby: head }
+          - { os: ubuntu-22.04, ruby: "3.1" }
     steps:
       - name: repo checkout
         uses: actions/checkout@v3
@@ -26,38 +30,6 @@ jobs:
 
       - name: compile
         run:  rake compile -- --enable-debug
-
-      - name: test
-        run:  rake test TESTOPTS="-v --no-show-detail-immediately" OSSL_MDEBUG=1
-
-  test-windows:
-    name: >-
-      ${{ matrix.os }} ${{ matrix.ruby }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ windows-latest ]
-        ruby: [ mswin, mingw, "3.1", "3.0", "2.7", "2.6" ]
-    steps:
-      - name: repo checkout
-        uses: actions/checkout@v3
-
-      - name: load ruby, install/update gcc, install openssl
-        uses: MSP-Greg/setup-ruby-pkgs@v1
-        with:
-          ruby-version: ${{ matrix.ruby }}
-          mingw: ${{ matrix.ruby != 'mswin' && '_upgrade_ openssl' || '' }}
-          vcpkg: ${{ matrix.ruby == 'mswin' && 'openssl' || '' }}
-
-      - name: depends
-        run:  bundle install
-
-      # pkg-config is disabled because it can pick up the different OpenSSL installation
-      # SSL_DIR is set as needed by MSP-Greg/setup-ruby-pkgs
-      # only used with mswin
-      - name: compile
-        run:  rake compile -- --enable-debug --without-pkg-config $env:SSL_DIR
 
       - name: test
         run:  rake test TESTOPTS="-v --no-show-detail-immediately" OSSL_MDEBUG=1


### PR DESCRIPTION
Due to recent changes in Actions, along with changes in ruby/setup-ruby, Ubuntu 22.04 Rubies and the Windows mswin Ruby are all built with OpenSSL 3.0.x.

Update CI to use them.

Closes #510