### PR TITLE
Remove 'ruby 2' limitation in documentation

### DIFF
--- a/ext/openssl/extconf.rb
+++ b/ext/openssl/extconf.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 =begin
 = Info
-  'OpenSSL for Ruby 2' project
+  'OpenSSL for Ruby' project
   Copyright (C) 2002  Michal Rokos <m.rokos@sh.cvut.cz>
   All rights reserved.
 

--- a/lib/openssl.rb
+++ b/lib/openssl.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 =begin
 = Info
-  'OpenSSL for Ruby 2' project
+  'OpenSSL for Ruby' project
   Copyright (C) 2002  Michal Rokos <m.rokos@sh.cvut.cz>
   All rights reserved.
 

--- a/lib/openssl/bn.rb
+++ b/lib/openssl/bn.rb
@@ -4,7 +4,7 @@
 # = Ruby-space definitions that completes C-space funcs for BN
 #
 # = Info
-# 'OpenSSL for Ruby 2' project
+# 'OpenSSL for Ruby' project
 # Copyright (C) 2002  Michal Rokos <m.rokos@sh.cvut.cz>
 # All rights reserved.
 #

--- a/lib/openssl/buffering.rb
+++ b/lib/openssl/buffering.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 #--
 #= Info
-#  'OpenSSL for Ruby 2' project
+#  'OpenSSL for Ruby' project
 #  Copyright (C) 2001 GOTOU YUUZOU <gotoyuzo@notwork.org>
 #  All rights reserved.
 #

--- a/lib/openssl/cipher.rb
+++ b/lib/openssl/cipher.rb
@@ -3,7 +3,7 @@
 # = Ruby-space predefined Cipher subclasses
 #
 # = Info
-# 'OpenSSL for Ruby 2' project
+# 'OpenSSL for Ruby' project
 # Copyright (C) 2002  Michal Rokos <m.rokos@sh.cvut.cz>
 # All rights reserved.
 #

--- a/lib/openssl/digest.rb
+++ b/lib/openssl/digest.rb
@@ -3,7 +3,7 @@
 # = Ruby-space predefined Digest subclasses
 #
 # = Info
-# 'OpenSSL for Ruby 2' project
+# 'OpenSSL for Ruby' project
 # Copyright (C) 2002  Michal Rokos <m.rokos@sh.cvut.cz>
 # All rights reserved.
 #

--- a/lib/openssl/marshal.rb
+++ b/lib/openssl/marshal.rb
@@ -3,7 +3,7 @@
 # = Ruby-space definitions to add DER (de)serialization to classes
 #
 # = Info
-# 'OpenSSL for Ruby 2' project
+# 'OpenSSL for Ruby' project
 # Copyright (C) 2002  Michal Rokos <m.rokos@sh.cvut.cz>
 # All rights reserved.
 #

--- a/lib/openssl/ssl.rb
+++ b/lib/openssl/ssl.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 =begin
 = Info
-  'OpenSSL for Ruby 2' project
+  'OpenSSL for Ruby' project
   Copyright (C) 2001 GOTOU YUUZOU <gotoyuzo@notwork.org>
   All rights reserved.
 

--- a/lib/openssl/x509.rb
+++ b/lib/openssl/x509.rb
@@ -3,7 +3,7 @@
 # = Ruby-space definitions that completes C-space funcs for X509 and subclasses
 #
 # = Info
-# 'OpenSSL for Ruby 2' project
+# 'OpenSSL for Ruby' project
 # Copyright (C) 2002  Michal Rokos <m.rokos@sh.cvut.cz>
 # All rights reserved.
 #


### PR DESCRIPTION
This project has presumably grown beyond solely supporting ruby 2 with it also working in ruby 3. 

Quick update in the comments to reflect this reality.