### PR TITLE
pkey: track whether pkey is private key or not

### DIFF
--- a/ext/openssl/openssl_missing.h
+++ b/ext/openssl/openssl_missing.h
@@ -140,6 +140,7 @@ IMPL_KEY_ACCESSOR3(RSA, crt_params, dmp1, dmq1, iqmp, (dmp1 == obj->dmp1 || dmq1
 IMPL_PKEY_GETTER(DSA, dsa)
 IMPL_KEY_ACCESSOR2(DSA, key, pub_key, priv_key, (pub_key == obj->pub_key || (obj->priv_key && priv_key == obj->priv_key)))
 IMPL_KEY_ACCESSOR3(DSA, pqg, p, q, g, (p == obj->p || q == obj->q || g == obj->g))
+static inline ENGINE *DSA_get0_engine(DSA *dsa) { return dsa->engine; }
 #endif
 
 #if !defined(OPENSSL_NO_DH)

--- a/ext/openssl/ossl.h
+++ b/ext/openssl/ossl.h
@@ -56,6 +56,10 @@
 # define OSSL_USE_ENGINE
 #endif
 
+#if OSSL_OPENSSL_PREREQ(3, 0, 0)
+# define OSSL_HAVE_PROVIDER
+#endif
+
 /*
  * Common Module
  */

--- a/ext/openssl/ossl_engine.c
+++ b/ext/openssl/ossl_engine.c
@@ -373,8 +373,7 @@ ossl_engine_load_privkey(int argc, VALUE *argv, VALUE self)
     GetEngine(self, e);
     pkey = ENGINE_load_private_key(e, sid, NULL, sdata);
     if (!pkey) ossl_raise(eEngineError, NULL);
-    obj = ossl_pkey_new(pkey);
-    OSSL_PKEY_SET_PRIVATE(obj);
+    obj = ossl_pkey_new(pkey, OSSL_PKEY_HAS_PRIVATE);
 
     return obj;
 }
@@ -403,7 +402,7 @@ ossl_engine_load_pubkey(int argc, VALUE *argv, VALUE self)
     pkey = ENGINE_load_public_key(e, sid, NULL, sdata);
     if (!pkey) ossl_raise(eEngineError, NULL);
 
-    return ossl_pkey_new(pkey);
+    return ossl_pkey_new(pkey, OSSL_PKEY_HAS_PUBLIC);
 }
 
 /*

--- a/ext/openssl/ossl_ns_spki.c
+++ b/ext/openssl/ossl_ns_spki.c
@@ -190,7 +190,7 @@ ossl_spki_get_public_key(VALUE self)
 	ossl_raise(eSPKIError, NULL);
     }
 
-    return ossl_pkey_new(pkey); /* NO DUP - OK */
+    return ossl_pkey_new(pkey, OSSL_PKEY_HAS_PUBLIC); /* NO DUP - OK */
 }
 
 /*

--- a/ext/openssl/ossl_pkcs12.c
+++ b/ext/openssl/ossl_pkcs12.c
@@ -152,7 +152,7 @@ ossl_pkcs12_s_create(int argc, VALUE *argv, VALUE self)
 static VALUE
 ossl_pkey_new_i(VALUE arg)
 {
-    return ossl_pkey_new((EVP_PKEY *)arg);
+    return ossl_pkey_new((EVP_PKEY *)arg, OSSL_PKEY_HAS_PRIVATE);
 }
 
 static VALUE

--- a/ext/openssl/ossl_pkey.c
+++ b/ext/openssl/ossl_pkey.c
@@ -79,7 +79,7 @@ ossl_pkey_new(EVP_PKEY *pkey)
     return obj;
 }
 
-#if OSSL_OPENSSL_PREREQ(3, 0, 0)
+#ifdef OSSL_HAVE_PROVIDER
 # include <openssl/decoder.h>
 
 EVP_PKEY *
@@ -484,7 +484,7 @@ ossl_pkey_s_generate_key(int argc, VALUE *argv, VALUE self)
 void
 ossl_pkey_check_public_key(const EVP_PKEY *pkey)
 {
-#if OSSL_OPENSSL_PREREQ(3, 0, 0)
+#ifdef OSSL_HAVE_PROVIDER
     if (EVP_PKEY_missing_parameters(pkey))
         ossl_raise(ePKeyError, "parameters missing");
 #else

--- a/ext/openssl/ossl_pkey.h
+++ b/ext/openssl/ossl_pkey.h
@@ -29,7 +29,7 @@ extern const rb_data_type_t ossl_evp_pkey_type;
 /* Takes ownership of the EVP_PKEY */
 VALUE ossl_pkey_new(EVP_PKEY *);
 void ossl_pkey_check_public_key(const EVP_PKEY *);
-EVP_PKEY *ossl_pkey_read_generic(BIO *, VALUE);
+EVP_PKEY *ossl_pkey_read_generic(BIO *bio, VALUE pass, const char *input_type);
 EVP_PKEY *GetPKeyPtr(VALUE);
 EVP_PKEY *DupPKeyPtr(VALUE);
 EVP_PKEY *GetPrivPKeyPtr(VALUE);

--- a/ext/openssl/ossl_pkey.h
+++ b/ext/openssl/ossl_pkey.h
@@ -116,7 +116,7 @@ static VALUE ossl_##_keytype##_get_##_name(VALUE self)			\
 	OSSL_PKEY_BN_DEF_GETTER0(_keytype, _type, a2,			\
 		_type##_get0_##_group(obj, NULL, &bn))
 
-#if !OSSL_OPENSSL_PREREQ(3, 0, 0)
+#ifndef OSSL_HAVE_PROVIDER
 #define OSSL_PKEY_BN_DEF_SETTER3(_keytype, _type, _group, a1, a2, a3)	\
 /*									\
  *  call-seq:								\
@@ -174,7 +174,7 @@ static VALUE ossl_##_keytype##_set_##_group(VALUE self, VALUE v1, VALUE v2) \
 	}								\
 	return self;							\
 }
-#else
+#else /* OSSL_HAVE_PROVIDER */
 #define OSSL_PKEY_BN_DEF_SETTER3(_keytype, _type, _group, a1, a2, a3)	\
 static VALUE ossl_##_keytype##_set_##_group(VALUE self, VALUE v1, VALUE v2, VALUE v3) \
 {									\
@@ -188,7 +188,7 @@ static VALUE ossl_##_keytype##_set_##_group(VALUE self, VALUE v1, VALUE v2) \
         rb_raise(ePKeyError,						\
                  #_keytype"#set_"#_group"= is incompatible with OpenSSL 3.0"); \
 }
-#endif
+#endif /* OSSL_HAVE_PROVIDER */
 
 #define OSSL_PKEY_BN_DEF3(_keytype, _type, _group, a1, a2, a3)		\
 	OSSL_PKEY_BN_DEF_GETTER3(_keytype, _type, _group, a1, a2, a3)	\

--- a/ext/openssl/ossl_pkey_dh.c
+++ b/ext/openssl/ossl_pkey_dh.c
@@ -73,7 +73,6 @@ static VALUE
 ossl_dh_initialize(int argc, VALUE *argv, VALUE self)
 {
     EVP_PKEY *pkey;
-    int type;
 #ifndef OSSL_HAVE_PROVIDER
     DH *dh;
 #endif
@@ -110,16 +109,10 @@ ossl_dh_initialize(int argc, VALUE *argv, VALUE self)
     OSSL_BIO_reset(in);
 #endif
 
-    pkey = ossl_pkey_read_generic(in, Qnil);
+    pkey = ossl_pkey_read_generic(in, Qnil, "DH");
     BIO_free(in);
     if (!pkey)
         ossl_raise(eDHError, "could not parse pkey");
-
-    type = EVP_PKEY_base_id(pkey);
-    if (type != EVP_PKEY_DH) {
-        EVP_PKEY_free(pkey);
-        rb_raise(eDHError, "incorrect pkey type: %s", OBJ_nid2sn(type));
-    }
     RTYPEDDATA_DATA(self) = pkey;
     return self;
 

--- a/ext/openssl/ossl_pkey_dsa.c
+++ b/ext/openssl/ossl_pkey_dsa.c
@@ -89,7 +89,6 @@ ossl_dsa_initialize(int argc, VALUE *argv, VALUE self)
 #endif
     BIO *in = NULL;
     VALUE arg, pass;
-    int type;
 
     TypedData_Get_Struct(self, EVP_PKEY, &ossl_evp_pkey_type, pkey);
     if (pkey)
@@ -122,16 +121,10 @@ ossl_dsa_initialize(int argc, VALUE *argv, VALUE self)
     OSSL_BIO_reset(in);
 #endif
 
-    pkey = ossl_pkey_read_generic(in, pass);
+    pkey = ossl_pkey_read_generic(in, pass, "DSA");
     BIO_free(in);
     if (!pkey)
         ossl_raise(eDSAError, "Neither PUB key nor PRIV key");
-
-    type = EVP_PKEY_base_id(pkey);
-    if (type != EVP_PKEY_DSA) {
-        EVP_PKEY_free(pkey);
-        rb_raise(eDSAError, "incorrect pkey type: %s", OBJ_nid2sn(type));
-    }
     RTYPEDDATA_DATA(self) = pkey;
     return self;
 

--- a/ext/openssl/ossl_pkey_ec.c
+++ b/ext/openssl/ossl_pkey_ec.c
@@ -248,7 +248,7 @@ ossl_ec_key_get_group(VALUE self)
 static VALUE
 ossl_ec_key_set_group(VALUE self, VALUE group_v)
 {
-#if OSSL_OPENSSL_PREREQ(3, 0, 0)
+#ifdef OSSL_HAVE_PROVIDER
     rb_raise(ePKeyError, "pkeys are immutable on OpenSSL 3.0");
 #else
     EC_KEY *ec;
@@ -290,7 +290,7 @@ static VALUE ossl_ec_key_get_private_key(VALUE self)
  */
 static VALUE ossl_ec_key_set_private_key(VALUE self, VALUE private_key)
 {
-#if OSSL_OPENSSL_PREREQ(3, 0, 0)
+#ifdef OSSL_HAVE_PROVIDER
     rb_raise(ePKeyError, "pkeys are immutable on OpenSSL 3.0");
 #else
     EC_KEY *ec;
@@ -341,7 +341,7 @@ static VALUE ossl_ec_key_get_public_key(VALUE self)
  */
 static VALUE ossl_ec_key_set_public_key(VALUE self, VALUE public_key)
 {
-#if OSSL_OPENSSL_PREREQ(3, 0, 0)
+#ifdef OSSL_HAVE_PROVIDER
     rb_raise(ePKeyError, "pkeys are immutable on OpenSSL 3.0");
 #else
     EC_KEY *ec;
@@ -457,7 +457,7 @@ ossl_ec_key_to_der(VALUE self)
  */
 static VALUE ossl_ec_key_generate_key(VALUE self)
 {
-#if OSSL_OPENSSL_PREREQ(3, 0, 0)
+#ifdef OSSL_HAVE_PROVIDER
     rb_raise(ePKeyError, "pkeys are immutable on OpenSSL 3.0");
 #else
     EC_KEY *ec;

--- a/ext/openssl/ossl_pkey_ec.c
+++ b/ext/openssl/ossl_pkey_ec.c
@@ -142,7 +142,6 @@ static VALUE ossl_ec_key_initialize(int argc, VALUE *argv, VALUE self)
     EC_KEY *ec;
     BIO *in;
     VALUE arg, pass;
-    int type;
 
     TypedData_Get_Struct(self, EVP_PKEY, &ossl_evp_pkey_type, pkey);
     if (pkey)
@@ -163,18 +162,12 @@ static VALUE ossl_ec_key_initialize(int argc, VALUE *argv, VALUE self)
     arg = ossl_to_der_if_possible(arg);
     in = ossl_obj2bio(&arg);
 
-    pkey = ossl_pkey_read_generic(in, pass);
+    pkey = ossl_pkey_read_generic(in, pass, "EC");
     BIO_free(in);
     if (!pkey) {
         ossl_clear_error();
         ec = ec_key_new_from_group(arg);
         goto legacy;
-    }
-
-    type = EVP_PKEY_base_id(pkey);
-    if (type != EVP_PKEY_EC) {
-        EVP_PKEY_free(pkey);
-        rb_raise(eDSAError, "incorrect pkey type: %s", OBJ_nid2sn(type));
     }
     RTYPEDDATA_DATA(self) = pkey;
     return self;

--- a/ext/openssl/ossl_pkey_rsa.c
+++ b/ext/openssl/ossl_pkey_rsa.c
@@ -82,7 +82,6 @@ ossl_rsa_initialize(int argc, VALUE *argv, VALUE self)
 #endif
     BIO *in = NULL;
     VALUE arg, pass;
-    int type;
 
     TypedData_Get_Struct(self, EVP_PKEY, &ossl_evp_pkey_type, pkey);
     if (pkey)
@@ -118,16 +117,10 @@ ossl_rsa_initialize(int argc, VALUE *argv, VALUE self)
 #endif
 
     /* Use the generic routine */
-    pkey = ossl_pkey_read_generic(in, pass);
+    pkey = ossl_pkey_read_generic(in, pass, "RSA");
     BIO_free(in);
     if (!pkey)
         ossl_raise(eRSAError, "Neither PUB key nor PRIV key");
-
-    type = EVP_PKEY_base_id(pkey);
-    if (type != EVP_PKEY_RSA) {
-        EVP_PKEY_free(pkey);
-        rb_raise(eRSAError, "incorrect pkey type: %s", OBJ_nid2sn(type));
-    }
     RTYPEDDATA_DATA(self) = pkey;
     return self;
 

--- a/ext/openssl/ossl_ssl.c
+++ b/ext/openssl/ossl_ssl.c
@@ -2541,7 +2541,7 @@ ossl_ssl_export_keying_material(int argc, VALUE *argv, VALUE self)
  * call-seq:
  *    ssl.tmp_key => PKey or nil
  *
- * Returns the ephemeral key used in case of forward secrecy cipher.
+ * Returns the temporary key provided by the peer and used during key exchange.
  */
 static VALUE
 ossl_ssl_tmp_key(VALUE self)
@@ -2552,7 +2552,7 @@ ossl_ssl_tmp_key(VALUE self)
     GetSSL(self, ssl);
     if (!SSL_get_server_tmp_key(ssl, &key))
 	return Qnil;
-    return ossl_pkey_new(key);
+    return ossl_pkey_new(key, OSSL_PKEY_HAS_PUBLIC);
 }
 #endif /* !defined(OPENSSL_NO_SOCK) */
 

--- a/ext/openssl/ossl_x509cert.c
+++ b/ext/openssl/ossl_x509cert.c
@@ -506,7 +506,7 @@ ossl_x509_get_public_key(VALUE self)
 	ossl_raise(eX509CertError, NULL);
     }
 
-    return ossl_pkey_new(pkey); /* NO DUP - OK */
+    return ossl_pkey_new(pkey, OSSL_PKEY_HAS_PUBLIC); /* NO DUP - OK */
 }
 
 /*

--- a/ext/openssl/ossl_x509req.c
+++ b/ext/openssl/ossl_x509req.c
@@ -286,7 +286,7 @@ ossl_x509req_get_public_key(VALUE self)
 	ossl_raise(eX509ReqError, NULL);
     }
 
-    return ossl_pkey_new(pkey); /* NO DUP - OK */
+    return ossl_pkey_new(pkey, OSSL_PKEY_HAS_PUBLIC); /* NO DUP - OK */
 }
 
 static VALUE

--- a/test/openssl/test_pkey_dh.rb
+++ b/test/openssl/test_pkey_dh.rb
@@ -10,7 +10,7 @@ class OpenSSL::TestPKeyDH < OpenSSL::PKeyTestCase
     dh = OpenSSL::PKey::DH.new
     assert_equal nil, dh.p
     assert_equal nil, dh.priv_key
-  end
+  end if !openssl?(3, 0, 0)
 
   def test_new_generate
     # This test is slow

--- a/test/openssl/test_pkey_rsa.rb
+++ b/test/openssl/test_pkey_rsa.rb
@@ -172,7 +172,7 @@ class OpenSSL::TestPKeyRSA < OpenSSL::PKeyTestCase
     assert_raise(OpenSSL::PKey::PKeyError, "[Bug #12783]") {
       rsa.verify("SHA1", "a", "b")
     }
-  end
+  end if !openssl?(3, 0, 0)
 
   def test_sign_verify_pss
     key = Fixtures.pkey("rsa1024")
@@ -395,7 +395,7 @@ class OpenSSL::TestPKeyRSA < OpenSSL::PKeyTestCase
     EOF
     key = OpenSSL::PKey::RSA.new(pem)
     assert_same_rsa rsa1024pub, key
-  end
+  end if !openssl?(3, 0, 0) # RSAPublicKey is not available on OpenSSL 3.0
 
   def test_PUBKEY
     rsa1024 = Fixtures.pkey("rsa1024")


### PR DESCRIPTION
There are multiple places where it's necessary to know whether a pkey
is a private key, a public key, or just key parameters. Unfortunately,
OpenSSL doesn't expose an API for this purpose (even though it has one
for its internal use).

Currently, we drill down into the backing object, such as RSA, and see
if the corresponding fields are set or not to determine it. This doesn't
work on OpenSSL 3.0 because of the architecture changes.

Let's manually track this information in an instance variable for now.
This has been partly done for ENGINE-backed pkeys. Now all pkeys get
this flag.

PKeys are immutable on OpenSSL 3.0, so it just needs to be stored once
on initialization. On OpenSSL 1.1 or before (including LibreSSL), it
must be updated whenever a modification is made to the object.

This comes with a slight behavior change. PKey returned by following
method will be explicitly marked as "public", even if it happens to
point at an EVP_PKEY struct containing private key components. I expect
the effect is minimum since these methods explicitly say "public key".

 - OpenSSL::X509::Certificate#public_key
 - OpenSSL::X509::Request#public_key
 - OpenSSL::Netscape::SPKI#public_key