### PR TITLE
OpenSSL::PKey::PKey#sign etc. with wrong type option causes SEGV

### DIFF
--- a/ext/openssl/ossl_pkey.c
+++ b/ext/openssl/ossl_pkey.c
@@ -200,6 +200,7 @@ static VALUE
 pkey_ctx_apply_options0(VALUE args_v)
 {
     VALUE *args = (VALUE *)args_v;
+    Check_Type(args[1], T_HASH);
 
     rb_block_call(args[1], rb_intern("each"), 0, NULL,
                   pkey_ctx_apply_options_i, args[0]);

--- a/test/openssl/test_pkey_rsa.rb
+++ b/test/openssl/test_pkey_rsa.rb
@@ -108,6 +108,11 @@ class OpenSSL::TestPKeyRSA < OpenSSL::PKeyTestCase
                                       salt_length: 20, mgf1_hash: "SHA1")
     # Defaults to PKCS #1 v1.5 padding => verification failure
     assert_equal false, key.verify("SHA256", sig_pss, data)
+
+    # option type check
+    assert_raise_with_message(TypeError, /expected Hash/) {
+      key.sign("SHA256", data, ["x"])
+    }
   end
 
   def test_sign_verify_raw


### PR DESCRIPTION
The following script causes SEGV:

```ruby
require "openssl"

OpenSSL::PKey::RSA.generate(2048).sign("SHA256", "", ["x"])
```

I confirmed that it seems that SEGV occurs if the last optional argument (normally a Hash) finally processed by `pkey_ctx_apply_options` is an Array or something like that.

Since a non-nil check has done at each method function (e.g. `ossl_pkey_sign`) prior to call `pkey_ctx_apply_options`, I added `Check_Type` at the beginning of that function. It might be more efficient to check much earlier.
