### PR TITLE
pkey/dsa: let PKey::DSA.generate choose appropriate q size

### DIFF
--- a/lib/openssl/pkey.rb
+++ b/lib/openssl/pkey.rb
@@ -167,8 +167,16 @@ module OpenSSL::PKey
       # +size+::
       #   The desired key size in bits.
       def generate(size, &blk)
+        # FIPS 186-4 specifies four (L,N) pairs: (1024,160), (2048,224),
+        # (2048,256), and (3072,256).
+        #
+        # q size is derived here with compatibility with
+        # DSA_generator_parameters_ex() which previous versions of ruby/openssl
+        # used to call.
+        qsize = size >= 2048 ? 256 : 160
         dsaparams = OpenSSL::PKey.generate_parameters("DSA", {
           "dsa_paramgen_bits" => size,
+          "dsa_paramgen_q_bits" => qsize,
         }, &blk)
         OpenSSL::PKey.generate_key(dsaparams)
       end

--- a/test/openssl/test_pkey_dsa.rb
+++ b/test/openssl/test_pkey_dsa.rb
@@ -28,6 +28,25 @@ class OpenSSL::TestPKeyDSA < OpenSSL::PKeyTestCase
     end
   end
 
+  def test_generate
+    # DSA.generate used to call DSA_generate_parameters_ex(), which adjusts the
+    # size of q according to the size of p
+    key1024 = OpenSSL::PKey::DSA.generate(1024)
+    assert_predicate key1024, :private?
+    assert_equal 1024, key1024.p.num_bits
+    assert_equal 160, key1024.q.num_bits
+
+    key2048 = OpenSSL::PKey::DSA.generate(2048)
+    assert_equal 2048, key2048.p.num_bits
+    assert_equal 256, key2048.q.num_bits
+
+    if ENV["OSSL_TEST_ALL"] == "1" # slow
+      key3072 = OpenSSL::PKey::DSA.generate(3072)
+      assert_equal 3072, key3072.p.num_bits
+      assert_equal 256, key3072.q.num_bits
+    end
+  end
+
   def test_sign_verify
     dsa512 = Fixtures.pkey("dsa512")
     data = "Sign me!"


### PR DESCRIPTION
DSA parameters generation via EVP_PKEY_paramgen() will not automatically
adjust the size of q value but uses 224 bits by default unless specified
explicitly. This behavior is different from the now-deprecated
DSA_generate_parameters_ex(), which PKey::DSA.generate used to call.

Fixes https://github.com/ruby/openssl/issues/483

Fixes: 1800a8d5ebaf ("pkey/dsa: use high level EVP interface to generate parameters and keys", 2020-05-17)