### PR TITLE
pkey/ec: check existence of public key component before exporting

### DIFF
--- a/ext/openssl/ossl_pkey_ec.c
+++ b/ext/openssl/ossl_pkey_ec.c
@@ -414,6 +414,8 @@ ossl_ec_key_export(int argc, VALUE *argv, VALUE self)
     EC_KEY *ec;
 
     GetEC(self, ec);
+    if (EC_KEY_get0_public_key(ec) == NULL)
+        ossl_raise(eECError, "can't export - no public key set");
     if (EC_KEY_get0_private_key(ec))
         return ossl_pkey_export_traditional(argc, argv, self, 0);
     else
@@ -432,6 +434,8 @@ ossl_ec_key_to_der(VALUE self)
     EC_KEY *ec;
 
     GetEC(self, ec);
+    if (EC_KEY_get0_public_key(ec) == NULL)
+        ossl_raise(eECError, "can't export - no public key set");
     if (EC_KEY_get0_private_key(ec))
         return ossl_pkey_export_traditional(0, NULL, self, 1);
     else

--- a/test/openssl/test_pkey_ec.rb
+++ b/test/openssl/test_pkey_ec.rb
@@ -61,8 +61,10 @@ class OpenSSL::TestEC < OpenSSL::PKeyTestCase
   def test_generate_key
     ec = OpenSSL::PKey::EC.new("prime256v1")
     assert_equal false, ec.private?
+    assert_raise(OpenSSL::PKey::ECError) { ec.to_der }
     ec.generate_key!
     assert_equal true, ec.private?
+    assert_nothing_raised { ec.to_der }
   end if !openssl?(3, 0, 0)
 
   def test_marshal


### PR DESCRIPTION
i2d_PUBKEY_bio() against an EC_KEY without the public key component
trggers a null dereference.

This is a regression introduced by commit 56f0d34d63fb ("pkey:
refactor #export/#to_pem and #to_der", 2017-06-14).

Fixes https://github.com/ruby/openssl/pull/527#issuecomment-1220504524
Fixes https://github.com/ruby/openssl/issues/369#issuecomment-1221554057