### PR TITLE
Change RSA padding default to OAEP

### DIFF
--- a/lib/openssl/pkey.rb
+++ b/lib/openssl/pkey.rb
@@ -363,13 +363,13 @@ module OpenSSL::PKey
     #    rsa.private_encrypt(string, padding) -> String
     #
     # Encrypt +string+ with the private key.  +padding+ defaults to
-    # PKCS1_PADDING. The encrypted string output can be decrypted using
+    # PKCS1_OAEP_PADDING. The encrypted string output can be decrypted using
     # #public_decrypt.
     #
     # <b>Deprecated in version 3.0</b>.
     # Consider using PKey::PKey#sign_raw and PKey::PKey#verify_raw, and
     # PKey::PKey#verify_recover instead.
-    def private_encrypt(string, padding = PKCS1_PADDING)
+    def private_encrypt(string, padding = PKCS1_OAEP_PADDING)
       n or raise OpenSSL::PKey::RSAError, "incomplete RSA"
       private? or raise OpenSSL::PKey::RSAError, "private key needed."
       begin
@@ -386,12 +386,12 @@ module OpenSSL::PKey
     #    rsa.public_decrypt(string, padding) -> String
     #
     # Decrypt +string+, which has been encrypted with the private key, with the
-    # public key.  +padding+ defaults to PKCS1_PADDING.
+    # public key.  +padding+ defaults to PKCS1_OAEP_PADDING.
     #
     # <b>Deprecated in version 3.0</b>.
     # Consider using PKey::PKey#sign_raw and PKey::PKey#verify_raw, and
     # PKey::PKey#verify_recover instead.
-    def public_decrypt(string, padding = PKCS1_PADDING)
+    def public_decrypt(string, padding = PKCS1_OAEP_PADDING)
       n or raise OpenSSL::PKey::RSAError, "incomplete RSA"
       begin
         verify_recover(nil, string, {
@@ -407,12 +407,12 @@ module OpenSSL::PKey
     #    rsa.public_encrypt(string, padding) -> String
     #
     # Encrypt +string+ with the public key.  +padding+ defaults to
-    # PKCS1_PADDING. The encrypted string output can be decrypted using
+    # PKCS1_OAEP_PADDING. The encrypted string output can be decrypted using
     # #private_decrypt.
     #
     # <b>Deprecated in version 3.0</b>.
     # Consider using PKey::PKey#encrypt and PKey::PKey#decrypt instead.
-    def public_encrypt(data, padding = PKCS1_PADDING)
+    def public_encrypt(data, padding = PKCS1_OAEP_PADDING)
       n or raise OpenSSL::PKey::RSAError, "incomplete RSA"
       begin
         encrypt(data, {
@@ -428,11 +428,11 @@ module OpenSSL::PKey
     #    rsa.private_decrypt(string, padding) -> String
     #
     # Decrypt +string+, which has been encrypted with the public key, with the
-    # private key. +padding+ defaults to PKCS1_PADDING.
+    # private key. +padding+ defaults to PKCS1_OAEP_PADDING.
     #
     # <b>Deprecated in version 3.0</b>.
     # Consider using PKey::PKey#encrypt and PKey::PKey#decrypt instead.
-    def private_decrypt(data, padding = PKCS1_PADDING)
+    def private_decrypt(data, padding = PKCS1_OAEP_PADDING)
       n or raise OpenSSL::PKey::RSAError, "incomplete RSA"
       private? or raise OpenSSL::PKey::RSAError, "private key needed."
       begin

--- a/test/openssl/test_pkey_rsa.rb
+++ b/test/openssl/test_pkey_rsa.rb
@@ -155,8 +155,8 @@ class OpenSSL::TestPKeyRSA < OpenSSL::PKeyTestCase
     plain1 = key.public_decrypt(cipher1, OpenSSL::PKey::RSA::PKCS1_PADDING)
     assert_equal(plain0, plain1)
 
-    cipherdef = key.private_encrypt(plain0) # PKCS1_PADDING is default
-    plain1 = key.public_decrypt(cipherdef)
+    cipherdef = key.private_encrypt(plain0, OpenSSL::PKey::RSA::PKCS1_PADDING)
+    plain1 = key.public_decrypt(cipherdef, OpenSSL::PKey::RSA::PKCS1_PADDING)
     assert_equal(plain0, plain1)
     assert_equal(cipher1, cipherdef)
 
@@ -226,19 +226,18 @@ class OpenSSL::TestPKeyRSA < OpenSSL::PKeyTestCase
     rsapriv = Fixtures.pkey("rsa-1")
     rsapub = OpenSSL::PKey.read(rsapriv.public_to_der)
 
-    # Defaults to PKCS #1 v1.5
     raw = "data"
-    enc_legacy = rsapub.public_encrypt(raw)
+    enc_legacy = rsapub.public_encrypt(raw, OpenSSL::PKey::RSA::PKCS1_PADDING)
     assert_equal raw, rsapriv.decrypt(enc_legacy)
     enc_new = rsapub.encrypt(raw)
-    assert_equal raw, rsapriv.private_decrypt(enc_new)
+    assert_equal raw, rsapriv.private_decrypt(enc_new, OpenSSL::PKey::RSA::PKCS1_PADDING)
 
-    # OAEP with default parameters
+    # Defaults to OAEP with default parameters
     raw = "data"
-    enc_legacy = rsapub.public_encrypt(raw, OpenSSL::PKey::RSA::PKCS1_OAEP_PADDING)
+    enc_legacy = rsapub.public_encrypt(raw)
     assert_equal raw, rsapriv.decrypt(enc_legacy, { "rsa_padding_mode" => "oaep" })
     enc_new = rsapub.encrypt(raw, { "rsa_padding_mode" => "oaep" })
-    assert_equal raw, rsapriv.private_decrypt(enc_legacy, OpenSSL::PKey::RSA::PKCS1_OAEP_PADDING)
+    assert_equal raw, rsapriv.private_decrypt(enc_legacy)
   end
 
   def test_export


### PR DESCRIPTION
PKCS#1 v1.5 has been unsafe since [1998's Bleichenbacher attack](https://en.wikipedia.org/wiki/Adaptive_chosen-ciphertext_attack). Even if these PKey::RSA methods are deprecated in favor of the new [`PKey::PKey#{encrypt,decrypt}`](https://ruby-doc.org/stdlib-3.1.0/libdoc/openssl/rdoc/OpenSSL/PKey/PKey.html#method-i-decrypt) interface, they can and are still used as https://shopify.engineering/building-flex-comp shows - in which case this library is recommending unsafe defaults to people who are not intimitely familiar with cryptography.