### PR TITLE
Undefine `OpenSSL::SSL` for no socket platforms

### DIFF
--- a/ext/openssl/ossl_ssl.c
+++ b/ext/openssl/ossl_ssl.c
@@ -30,7 +30,6 @@
 } while (0)
 
 VALUE mSSL;
-static VALUE mSSLExtConfig;
 static VALUE eSSLError;
 VALUE cSSLContext;
 VALUE cSSLSocket;
@@ -2588,16 +2587,6 @@ Init_ossl_ssl(void)
      */
     mSSL = rb_define_module_under(mOSSL, "SSL");
 
-    /* Document-module: OpenSSL::ExtConfig
-     *
-     * This module contains configuration information about the SSL extension,
-     * for example if socket support is enabled, or the host name TLS extension
-     * is enabled.  Constants in this module will always be defined, but contain
-     * +true+ or +false+ values depending on the configuration of your OpenSSL
-     * installation.
-     */
-    mSSLExtConfig = rb_define_module_under(mOSSL, "ExtConfig");
-
     /* Document-class: OpenSSL::SSL::SSLError
      *
      * Generic error class raised by SSLSocket and SSLContext.
@@ -2759,8 +2748,6 @@ Init_ossl_ssl(void)
      * and it can randomly cause deadlock on Ruby thread switching.
      */
     rb_attr(cSSLContext, rb_intern_const("session_remove_cb"), 1, 1, Qfalse);
-
-    rb_define_const(mSSLExtConfig, "HAVE_TLSEXT_HOST_NAME", Qtrue);
 
     /*
      * A callback invoked whenever a new handshake is initiated on an
@@ -2953,10 +2940,8 @@ Init_ossl_ssl(void)
      */
     cSSLSocket = rb_define_class_under(mSSL, "SSLSocket", rb_cObject);
 #ifdef OPENSSL_NO_SOCK
-    rb_define_const(mSSLExtConfig, "OPENSSL_NO_SOCK", Qtrue);
     rb_define_method(cSSLSocket, "initialize", rb_f_notimplement, -1);
 #else
-    rb_define_const(mSSLExtConfig, "OPENSSL_NO_SOCK", Qfalse);
     rb_define_alloc_func(cSSLSocket, ossl_ssl_s_alloc);
     rb_define_method(cSSLSocket, "initialize", ossl_ssl_initialize, -1);
     rb_undef_method(cSSLSocket, "initialize_copy");

--- a/ext/openssl/ossl_ssl.c
+++ b/ext/openssl/ossl_ssl.c
@@ -11,6 +11,7 @@
  */
 #include "ossl.h"
 
+#ifndef OPENSSL_NO_SOCK
 #define numberof(ary) (int)(sizeof(ary)/sizeof((ary)[0]))
 
 #if !defined(TLS1_3_VERSION) && \
@@ -1537,7 +1538,6 @@ ossl_sslctx_flush_sessions(int argc, VALUE *argv, VALUE self)
 /*
  * SSLSocket class
  */
-#ifndef OPENSSL_NO_SOCK
 static inline int
 ssl_started(SSL *ssl)
 {
@@ -2565,6 +2565,7 @@ Init_ossl_ssl(void)
     rb_mWaitWritable = rb_define_module_under(rb_cIO, "WaitWritable");
 #endif
 
+#ifndef OPENSSL_NO_SOCK
     id_call = rb_intern_const("call");
     ID_callback_state = rb_intern_const("callback_state");
 
@@ -2939,9 +2940,6 @@ Init_ossl_ssl(void)
      * Document-class: OpenSSL::SSL::SSLSocket
      */
     cSSLSocket = rb_define_class_under(mSSL, "SSLSocket", rb_cObject);
-#ifdef OPENSSL_NO_SOCK
-    rb_define_method(cSSLSocket, "initialize", rb_f_notimplement, -1);
-#else
     rb_define_alloc_func(cSSLSocket, ossl_ssl_s_alloc);
     rb_define_method(cSSLSocket, "initialize", ossl_ssl_initialize, -1);
     rb_undef_method(cSSLSocket, "initialize_copy");
@@ -2976,7 +2974,6 @@ Init_ossl_ssl(void)
 # ifndef OPENSSL_NO_NEXTPROTONEG
     rb_define_method(cSSLSocket, "npn_protocol", ossl_ssl_npn_protocol, 0);
 # endif
-#endif
 
     rb_define_const(mSSL, "VERIFY_NONE", INT2NUM(SSL_VERIFY_NONE));
     rb_define_const(mSSL, "VERIFY_PEER", INT2NUM(SSL_VERIFY_PEER));
@@ -3138,4 +3135,5 @@ Init_ossl_ssl(void)
     DefIVarID(io);
     DefIVarID(context);
     DefIVarID(hostname);
+#endif /* !defined(OPENSSL_NO_SOCK) */
 }

--- a/ext/openssl/ossl_ssl_session.c
+++ b/ext/openssl/ossl_ssl_session.c
@@ -4,6 +4,7 @@
 
 #include "ossl.h"
 
+#ifndef OPENSSL_NO_SOCK
 VALUE cSSLSession;
 static VALUE eSSLSession;
 
@@ -299,6 +300,7 @@ static VALUE ossl_ssl_session_to_text(VALUE self)
 	return ossl_membio2str(out);
 }
 
+#endif /* !defined(OPENSSL_NO_SOCK) */
 
 void Init_ossl_ssl_session(void)
 {
@@ -307,6 +309,7 @@ void Init_ossl_ssl_session(void)
     mSSL = rb_define_module_under(mOSSL, "SSL");
     eOSSLError = rb_define_class_under(mOSSL, "OpenSSLError", rb_eStandardError);
 #endif
+#ifndef OPENSSL_NO_SOCK
 	cSSLSession = rb_define_class_under(mSSL, "Session", rb_cObject);
 	eSSLSession = rb_define_class_under(cSSLSession, "SessionError", eOSSLError);
 
@@ -324,4 +327,5 @@ void Init_ossl_ssl_session(void)
 	rb_define_method(cSSLSession, "to_der", ossl_ssl_session_to_der, 0);
 	rb_define_method(cSSLSession, "to_pem", ossl_ssl_session_to_pem, 0);
 	rb_define_method(cSSLSession, "to_text", ossl_ssl_session_to_text, 0);
+#endif /* !defined(OPENSSL_NO_SOCK) */
 }

--- a/lib/openssl/ssl.rb
+++ b/lib/openssl/ssl.rb
@@ -11,6 +11,9 @@
 =end
 
 require "openssl/buffering"
+
+if defined?(OpenSSL::SSL)
+
 require "io/nonblock"
 require "ipaddr"
 require "socket"
@@ -539,4 +542,6 @@ YoaOffgTf5qxiwkjnlVZQc3whgnEt9FpVMvQ9eknyeGB5KHfayAc3+hUAvI3/Cr3
       end
     end
   end
+end
+
 end

--- a/test/openssl/test_pair.rb
+++ b/test/openssl/test_pair.rb
@@ -2,7 +2,7 @@
 require_relative 'utils'
 require_relative 'ut_eof'
 
-if defined?(OpenSSL)
+if defined?(OpenSSL::SSL)
 
 module OpenSSL::SSLPairM
   def setup

--- a/test/openssl/test_ssl.rb
+++ b/test/openssl/test_ssl.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require_relative "utils"
 
-if defined?(OpenSSL)
+if defined?(OpenSSL::SSL)
 
 class OpenSSL::TestSSL < OpenSSL::SSLTestCase
   def test_bad_socket

--- a/test/openssl/test_ssl_session.rb
+++ b/test/openssl/test_ssl_session.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require_relative "utils"
 
-if defined?(OpenSSL)
+if defined?(OpenSSL::SSL)
 
 class OpenSSL::TestSSLSession < OpenSSL::SSLTestCase
   def test_session


### PR DESCRIPTION
This fixes a linkage error about `ossl_ssl_type` on platforms that do not have socket, like WASI.

Even before this patch, `OpenSSL::SSL::Socket.new` throws `NotImplementedError` under `OPENSSL_NO_SOCK` since https://github.com/ruby/ruby/commit/ee22fad45d394818690c4a7586d7bb576ba67c56 However, due to some new use of OpenSSL::SSL::Socket over the past few years, the build under `OPENSSL_NO_SOCK` had been broken.

This patch guards those new use of `OpenSSL::SSL::Socket` by `OPENSSL_NO_SOCK`.
* `SSLContext#servername_cb=`, which sets a callback taking a socket.
* `OpenSSL::Session`, which can accept a socket to create a new session.