### PR TITLE
Allow empty string to OpenSSL::Cipher#update

### DIFF
--- a/ext/openssl/ossl_cipher.c
+++ b/ext/openssl/ossl_cipher.c
@@ -384,8 +384,7 @@ ossl_cipher_update(int argc, VALUE *argv, VALUE self)
 
     StringValue(data);
     in = (unsigned char *)RSTRING_PTR(data);
-    if ((in_len = RSTRING_LEN(data)) == 0)
-        ossl_raise(rb_eArgError, "data must not be empty");
+    in_len = RSTRING_LEN(data);
     GetCipher(self, ctx);
     out_len = in_len+EVP_CIPHER_CTX_block_size(ctx);
     if (out_len <= 0) {

--- a/test/openssl/test_cipher.rb
+++ b/test/openssl/test_cipher.rb
@@ -108,12 +108,6 @@ class OpenSSL::TestCipher < OpenSSL::TestCase
     assert_not_equal s1, s2
   end
 
-  def test_empty_data
-    cipher = OpenSSL::Cipher.new("DES-EDE3-CBC").encrypt
-    cipher.random_key
-    assert_raise(ArgumentError) { cipher.update("") }
-  end
-
   def test_initialize
     cipher = OpenSSL::Cipher.new("DES-EDE3-CBC")
     assert_raise(RuntimeError) { cipher.__send__(:initialize, "DES-EDE3-CBC") }


### PR DESCRIPTION
For some reasons, plaintext may be empty string.

ref https://www.rfc-editor.org/rfc/rfc9001.html#section-5.8