### PR TITLE
pkey/ec: fix multiple ossl_raise() calls using cEC_POINT instead of eEC_POINT

### DIFF
--- a/ext/openssl/ossl_pkey_ec.c
+++ b/ext/openssl/ossl_pkey_ec.c
@@ -1445,7 +1445,7 @@ static VALUE ossl_ec_point_is_at_infinity(VALUE self)
     switch (EC_POINT_is_at_infinity(group, point)) {
     case 1: return Qtrue;
     case 0: return Qfalse;
-    default: ossl_raise(cEC_POINT, "EC_POINT_is_at_infinity");
+    default: ossl_raise(eEC_POINT, "EC_POINT_is_at_infinity");
     }
 
     UNREACHABLE;
@@ -1466,7 +1466,7 @@ static VALUE ossl_ec_point_is_on_curve(VALUE self)
     switch (EC_POINT_is_on_curve(group, point, ossl_bn_ctx)) {
     case 1: return Qtrue;
     case 0: return Qfalse;
-    default: ossl_raise(cEC_POINT, "EC_POINT_is_on_curve");
+    default: ossl_raise(eEC_POINT, "EC_POINT_is_on_curve");
     }
 
     UNREACHABLE;
@@ -1485,7 +1485,7 @@ static VALUE ossl_ec_point_make_affine(VALUE self)
     GetECPointGroup(self, group);
 
     if (EC_POINT_make_affine(group, point, ossl_bn_ctx) != 1)
-        ossl_raise(cEC_POINT, "EC_POINT_make_affine");
+        ossl_raise(eEC_POINT, "EC_POINT_make_affine");
 
     return self;
 }
@@ -1503,7 +1503,7 @@ static VALUE ossl_ec_point_invert(VALUE self)
     GetECPointGroup(self, group);
 
     if (EC_POINT_invert(group, point, ossl_bn_ctx) != 1)
-        ossl_raise(cEC_POINT, "EC_POINT_invert");
+        ossl_raise(eEC_POINT, "EC_POINT_invert");
 
     return self;
 }
@@ -1521,7 +1521,7 @@ static VALUE ossl_ec_point_set_to_infinity(VALUE self)
     GetECPointGroup(self, group);
 
     if (EC_POINT_set_to_infinity(group, point) != 1)
-        ossl_raise(cEC_POINT, "EC_POINT_set_to_infinity");
+        ossl_raise(eEC_POINT, "EC_POINT_set_to_infinity");
 
     return self;
 }


### PR DESCRIPTION
Initially caught by @rhenium as a copy-paste mistake while reviewing #564, there are multiple `ossl_raise` calls which specify the wrong type.

I have another version of this commit here https://github.com/bannable/openssl/commit/7085fc410d463bd16f669d4aff561966ddb0e199 targeting 3.0/master if needed, since this does not apply entirely cleanly. Please let me know if you would like a separate PR for that.