### PR TITLE
maint-2.2 Actions - update workflow to use OpenSSL 1.1.1, actions/checkout@v3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,11 +10,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest ]
+        # ubuntu-latest is 22.04, uses OpenSSL 3
+        os: [ ubuntu-20.04, macos-latest ]
         ruby: [ head, "3.0", "2.7", "2.6", "2.5", "2.4", "2.3" ]
     steps:
       - name: repo checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: load ruby
         uses: ruby/setup-ruby@v1
@@ -38,12 +39,11 @@ jobs:
       fail-fast: false
       matrix:
         os: [ windows-latest ]
-        ruby: [ mswin, mingw, "3.0", "2.7", "2.6", "2.5", "2.4", "2.3" ]
-        exclude:
-          - { os: "windows-latest", ruby: "mswin" } # OpenSSL 3.0
+        # current mswin build uses OpenSSL 3
+        ruby: [ mingw, "3.0", "2.7", "2.6", "2.5", "2.4", "2.3" ]
     steps:
       - name: repo checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: load ruby, install/update gcc, install openssl
         uses: MSP-Greg/setup-ruby-pkgs@v1
@@ -82,7 +82,7 @@ jobs:
           - libressl-3.3.4
     steps:
       - name: repo checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: prepare openssl
         run: |


### PR DESCRIPTION
See [Ubuntu-latest workflows will use Ubuntu-22.04](https://github.com/actions/runner-images/issues/6399).

This branch should test against OpenSSL 1.1.1, but 'ubuntu-latest' will soon be Ubuntu-22.04, which uses OpenSSL 3.0.

Update Actions to use ubuntu-20.04, and update 'actions/checkout' from 'v2' to 'v3'


