### PR TITLE
Actions - Use Ubuntu 20.04 for 1.1.1 CI, misc fixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,12 +10,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        # ubuntu-22.04 uses OpenSSL 3.0, ubuntu-20.04 uses OpenSSL 1.1.1
+        os: [ ubuntu-22.04, ubuntu-20.04, macos-latest, windows-latest ]
         ruby: [ head, "3.1", "3.0", "2.7", "2.6" ]
+        exclude:
+          # uses non-standard MSYS2 OpenSSL 3 package
+          - { os: windows-latest, ruby: head }
         include:
+          - { os: windows-latest, ruby: ucrt }
           - { os: windows-latest, ruby: mswin }
-          - { os: ubuntu-22.04, ruby: head }
-          - { os: ubuntu-22.04, ruby: "3.1" }
+          
     steps:
       - name: repo checkout
         uses: actions/checkout@v3
@@ -47,8 +51,8 @@ jobs:
         openssl:
           - openssl-1.0.2u # EOL
           - openssl-1.1.0l # EOL
-          - openssl-1.1.1q
-          - openssl-3.0.5
+          - openssl-1.1.1s
+          - openssl-3.0.7
           - libressl-3.1.5 # EOL
           - libressl-3.2.7
           - libressl-3.3.5
@@ -56,7 +60,7 @@ jobs:
           - libressl-3.5.0
     steps:
       - name: repo checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: prepare openssl
         run: |


### PR DESCRIPTION
See [Ubuntu-latest workflows will use Ubuntu-22.04](https://github.com/actions/runner-images/issues/6399).

'master' should test against both OpenSSL 1.1.1 and OpenSSL 3.0.  Due to the above (changing 'ubuntu-latest' from 20.04 to 
22.04), the mix of CI done with each OpenSSL version changes.

For the standard CI done in the 'test' jobs, this now runs the same job matrix for OpenSSL 1.1.1 and OpenSSL 3.0.  Not sure if that's needed, especially with Ruby master?