### PR TITLE
Prefer String#unpack1

### DIFF
--- a/lib/openssl/ssl.rb
+++ b/lib/openssl/ssl.rb
@@ -494,7 +494,7 @@ YoaOffgTf5qxiwkjnlVZQc3whgnEt9FpVMvQ9eknyeGB5KHfayAc3+hUAvI3/Cr3
         unless ctx.session_id_context
           # see #6137 - session id may not exceed 32 bytes
           prng = ::Random.new($0.hash)
-          session_id = prng.bytes(16).unpack('H*')[0]
+          session_id = prng.bytes(16).unpack1('H*')
           @ctx.session_id_context = session_id
         end
         @start_immediately = true

--- a/test/openssl/envutil.rb
+++ b/test/openssl/envutil.rb
@@ -205,7 +205,7 @@ eom
         assert(!abort, FailDesc[status, nil, stderr])
         #self._assertions += stdout[/^assertions=(\d+)/, 1].to_i
         begin
-          res = Marshal.load(stdout.unpack1("m"))
+          res = Marshal.load(stdout.unpack("m")[0])
         rescue => marshal_error
           ignore_stderr = nil
         end

--- a/test/openssl/envutil.rb
+++ b/test/openssl/envutil.rb
@@ -205,7 +205,7 @@ eom
         assert(!abort, FailDesc[status, nil, stderr])
         #self._assertions += stdout[/^assertions=(\d+)/, 1].to_i
         begin
-          res = Marshal.load(stdout.unpack("m")[0])
+          res = Marshal.load(stdout.unpack1("m"))
         rescue => marshal_error
           ignore_stderr = nil
         end

--- a/test/openssl/test_digest.rb
+++ b/test/openssl/test_digest.rb
@@ -67,7 +67,7 @@ class OpenSSL::TestDigest < OpenSSL::TestCase
   end
 
   def encode16(str)
-    str.unpack("H*").first
+    str.unpack1("H*")
   end
 
   def test_sha2

--- a/test/openssl/test_ns_spki.rb
+++ b/test/openssl/test_ns_spki.rb
@@ -38,13 +38,13 @@ class OpenSSL::TestNSSPI < OpenSSL::TestCase
   def test_decode_data
     spki = OpenSSL::Netscape::SPKI.new(@b64)
     assert_equal(@b64, spki.to_pem)
-    assert_equal(@b64.unpack("m").first, spki.to_der)
+    assert_equal(@b64.unpack1("m"), spki.to_der)
     assert_equal("MozillaIsMyFriend", spki.challenge)
     assert_equal(OpenSSL::PKey::RSA, spki.public_key.class)
 
-    spki = OpenSSL::Netscape::SPKI.new(@b64.unpack("m").first)
+    spki = OpenSSL::Netscape::SPKI.new(@b64.unpack1("m"))
     assert_equal(@b64, spki.to_pem)
-    assert_equal(@b64.unpack("m").first, spki.to_der)
+    assert_equal(@b64.unpack1("m"), spki.to_der)
     assert_equal("MozillaIsMyFriend", spki.challenge)
     assert_equal(OpenSSL::PKey::RSA, spki.public_key.class)
   end

--- a/test/openssl/test_pkcs12.rb
+++ b/test/openssl/test_pkcs12.rb
@@ -181,7 +181,7 @@ module OpenSSL
     def test_new_with_no_keys
       # generated with:
       #   openssl pkcs12 -certpbe PBE-SHA1-3DES -in <@mycert> -nokeys -export
-      str = <<~EOF.unpack("m").first
+      str = <<~EOF.unpack1("m")
 MIIGJAIBAzCCBeoGCSqGSIb3DQEHAaCCBdsEggXXMIIF0zCCBc8GCSqGSIb3
 DQEHBqCCBcAwggW8AgEAMIIFtQYJKoZIhvcNAQcBMBwGCiqGSIb3DQEMAQMw
 DgQIjv5c3OHvnBgCAggAgIIFiMJa8Z/w7errRvCQPXh9dGQz3eJaFq3S2gXD
@@ -230,7 +230,7 @@ AA==
     def test_new_with_no_certs
       # generated with:
       #   openssl pkcs12 -inkey fixtures/openssl/pkey/rsa-1.pem -nocerts -export
-      str = <<~EOF.unpack("m").first
+      str = <<~EOF.unpack1("m")
 MIIJ7wIBAzCCCbUGCSqGSIb3DQEHAaCCCaYEggmiMIIJnjCCCZoGCSqGSIb3
 DQEHAaCCCYsEggmHMIIJgzCCCX8GCyqGSIb3DQEMCgECoIIJbjCCCWowHAYK
 KoZIhvcNAQwBAzAOBAjX5nN8jyRKwQICCAAEgglIBIRLHfiY1mNHpl3FdX6+

--- a/test/openssl/test_pkey_dsa.rb
+++ b/test/openssl/test_pkey_dsa.rb
@@ -58,7 +58,7 @@ class OpenSSL::TestPKeyDSA < OpenSSL::PKeyTestCase
     signature = dsa512.sign("SHA256", data)
     assert_equal true, dsa512.verify("SHA256", signature, data)
 
-    signature0 = (<<~'end;').unpack("m")[0]
+    signature0 = (<<~'end;').unpack1("m")
       MCwCFH5h40plgU5Fh0Z4wvEEpz0eE9SnAhRPbkRB8ggsN/vsSEYMXvJwjGg/
       6g==
     end;

--- a/test/openssl/test_pkey_ec.rb
+++ b/test/openssl/test_pkey_ec.rb
@@ -110,7 +110,7 @@ class OpenSSL::TestEC < OpenSSL::PKeyTestCase
     signature = p256.sign("SHA256", data)
     assert_equal true, p256.verify("SHA256", signature, data)
 
-    signature0 = (<<~'end;').unpack("m")[0]
+    signature0 = (<<~'end;').unpack1("m")
       MEQCIEOTY/hD7eI8a0qlzxkIt8LLZ8uwiaSfVbjX2dPAvN11AiAQdCYx56Fq
       QdBp1B4sxJoA8jvODMMklMyBKVmudboA6A==
     end;

--- a/test/openssl/test_pkey_rsa.rb
+++ b/test/openssl/test_pkey_rsa.rb
@@ -83,7 +83,7 @@ class OpenSSL::TestPKeyRSA < OpenSSL::PKeyTestCase
     signature = rsa1024.sign("SHA256", data)
     assert_equal true, rsa1024.verify("SHA256", signature, data)
 
-    signature0 = (<<~'end;').unpack("m")[0]
+    signature0 = (<<~'end;').unpack1("m")
       oLCgbprPvfhM4pjFQiDTFeWI9Sk+Og7Nh9TmIZ/xSxf2CGXQrptlwo7NQ28+
       WA6YQo8jPH4hSuyWIM4Gz4qRYiYRkl5TDMUYob94zm8Si1HxEiS9354tzvqS
       zS8MLW2BtNPuTubMxTItHGTnOzo9sUg0LAHVFt8kHG2NfKAw/gQ=

--- a/test/openssl/test_ssl_session.rb
+++ b/test/openssl/test_ssl_session.rb
@@ -22,7 +22,7 @@ class OpenSSL::TestSSLSession < OpenSSL::SSLTestCase
         assert_match(/\A-----BEGIN SSL SESSION PARAMETERS-----/, pem)
         assert_match(/-----END SSL SESSION PARAMETERS-----\Z/, pem)
         pem.gsub!(/-----(BEGIN|END) SSL SESSION PARAMETERS-----/, '').gsub!(/[\r\n]+/m, '')
-        assert_equal(session.to_der, pem.unpack('m*')[0])
+        assert_equal(session.to_der, pem.unpack1('m'))
         assert_not_nil(session.to_text)
       }
     end


### PR DESCRIPTION
String#unpack1 avoids the intermediate array created by String#unpack for single elements, while also making a call to Array#first/[0] unnecessary.