### PR TITLE
Fix TimeoutError on TruffleRuby

### DIFF
--- a/test/openssl/envutil.rb
+++ b/test/openssl/envutil.rb
@@ -194,9 +194,7 @@ module Test
   }
   def pend(msg = nil) $stdout.syswrite [Marshal.dump(msg.to_s)].pack("m"); exit! 0 end
 #{src}
-  class Test::Unit::Runner
-    @@stop_auto_run = true
-  end
+  Test::Unit::AutoRunner.need_auto_run = false
 eom
         args = args.dup
         args.insert((Hash === args.first ? 1 : 0), "--disable=gems", *$:.map {|l| "-I#{l}"})


### PR DESCRIPTION
The issue was reported here https://github.com/oracle/truffleruby/issues/2800.

It happens that all the test cases in `tests/openssl/test_engine.rb` fail with error `Timeout::Error: execution of assert_separately expired` on TruffleRuby head.

Timeout is caused by recursive requiring and auto-running the `tests/openssl/test_engine.rb` file. 
https://github.com/ruby/openssl/blob/4f1267d0f0f0907b829063f1ab7f3265259351fc/test/openssl/test_engine.rb#L75-L81 
Looks like the purpose of this `require` is making available in the forked process some helpers defined in the test file.

The fix repairs a mechanism to disable auto-running tests in a forked process. `Test::Unit::Runner` isn't available and looks like is a part of CRuby's own test infrastructure (it's defined [here](https://github.com/ruby/ruby/blob/v3_2_0/tool/lib/test/unit.rb#L1388)).