### PR TITLE
Stub gemspec for JRuby

### DIFF
--- a/openssl.gemspec
+++ b/openssl.gemspec
@@ -8,9 +8,15 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/ruby/openssl"
   spec.license       = "Ruby"
 
-  spec.files         = Dir["lib/**/*.rb", "ext/**/*.{c,h,rb}", "*.md", "BSDL", "LICENSE.txt"]
-  spec.require_paths = ["lib"]
-  spec.extensions    = ["ext/openssl/extconf.rb"]
+  if Gem::Platform === spec.platform and spec.platform =~ 'java' or RUBY_ENGINE == 'jruby'
+    spec.platform    = "java"
+    spec.files       = []
+    spec.add_runtime_dependency('jruby-openssl', '~> 0.14')
+  else
+    spec.files         = Dir["lib/**/*.rb", "ext/**/*.{c,h,rb}", "*.md", "BSDL", "LICENSE.txt"]
+    spec.require_paths = ["lib"]
+    spec.extensions    = ["ext/openssl/extconf.rb"]
+  end
 
   spec.extra_rdoc_files = Dir["*.md"]
   spec.rdoc_options = ["--main", "README.md"]


### PR DESCRIPTION
JRuby has its own implementation of the `openssl` library in jruby-openssl. The simplest way for us to allow users to set openssl as a gem dependency is to ship a stub gem that just depends on jruby-openssl. This patch adds that to the gemspec. Additional work may be required to fit this stub gem into the test and release process.

See #20 for more details.