### PR TITLE
Skip failing test with truffleruby and ubuntu-22.04

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,7 @@ jobs:
           - { os: windows-latest, ruby: truffleruby }
           - { os: windows-latest, ruby: truffleruby-head }
           - { os: macos-latest,   ruby: truffleruby }
+          - { os: ubuntu-20.04,   ruby: truffleruby }
         include:
           - { os: windows-latest, ruby: ucrt }
           - { os: windows-latest, ruby: mswin }


### PR DESCRIPTION
https://github.com/ruby/openssl/actions/runs/4190107682/jobs/7263178067