### PR TITLE
.github/workflows/test.yml: Update OpenSSL versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,8 +61,8 @@ jobs:
         openssl:
           - openssl-1.0.2u # EOL
           - openssl-1.1.0l # EOL
-          - openssl-1.1.1s
-          - openssl-3.0.7
+          - openssl-1.1.1t
+          - openssl-3.0.8
           - libressl-3.1.5 # EOL
           - libressl-3.2.7 # EOL
           - libressl-3.3.6 # EOL


### PR DESCRIPTION
This PR is just to upgrade the tested OpenSSL version the latest ones.
https://www.openssl.org/source/

As Fedora 37+ already has the openssl 3.0.8, it's convenient if this repository has tests on the openssl version 3.0.8.
https://src.fedoraproject.org/rpms/openssl
