### PR TITLE
Relax error message for OpenSSL 3.1

### DIFF
--- a/test/openssl/test_ssl.rb
+++ b/test/openssl/test_ssl.rb
@@ -1046,9 +1046,7 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
     start_server(ignore_listener_error: true) { |port|
       ctx = OpenSSL::SSL::SSLContext.new
       ctx.set_params
-      # OpenSSL <= 1.1.0: "self signed certificate in certificate chain"
-      # OpenSSL >= 3.0.0: "self-signed certificate in certificate chain"
-      assert_raise_with_message(OpenSSL::SSL::SSLError, /self.signed/) {
+      assert_raise_with_message(OpenSSL::SSL::SSLError, /certificate/) {
         server_connect(port, ctx)
       }
     }


### PR DESCRIPTION
A tentative measures for https://github.com/ruby/openssl/issues/606