### PR TITLE
Implement FIPS functions, adding OpenSSL FIPS mode case on CI.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
 
   test-openssls:
     name: >-
-      ${{ matrix.openssl }}
+      ${{ matrix.openssl }} ${{ matrix.name_extra || '' }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -70,6 +70,9 @@ jobs:
           - libressl-3.5.3
           - libressl-3.6.1
           - libressl-3.7.0 # Development release
+        fips_enabled: [ false ]
+        include:
+          - { os: ubuntu-latest, ruby: "3.0", openssl: openssl-3.0.8, fips_enabled: true, append_configure: 'enable-fips', name_extra: 'fips' }
     steps:
       - name: repo checkout
         uses: actions/checkout@v3
@@ -83,7 +86,7 @@ jobs:
             tar xf ${{ matrix.openssl }}.tar.gz && cd ${{ matrix.openssl }}
             # shared is required for 1.0.x.
             ./Configure --prefix=$HOME/.openssl/${{ matrix.openssl }} --libdir=lib \
-                shared linux-x86_64
+                shared linux-x86_64 ${{ matrix.append_configure }}
             make depend
             ;;
           libressl-*)
@@ -97,6 +100,26 @@ jobs:
           esac
           make -j4
           make install_sw
+
+      - name: prepare openssl fips
+        run: make install_fips
+        working-directory: tmp/build-openssl/${{ matrix.openssl }}
+        if: matrix.fips_enabled
+
+      - name: set the open installed directory
+        run: >
+          sed -e "s|OPENSSL_DIR|$HOME/.openssl/${{ matrix.openssl }}|"
+          test/openssl/fixtures/ssl/openssl_fips.cnf.tmpl >
+          test/openssl/fixtures/ssl/openssl_fips.cnf
+        if: matrix.fips_enabled
+
+      - name: set openssl config file path for fips.
+        run: echo "OPENSSL_CONF=$(pwd)/test/openssl/fixtures/ssl/openssl_fips.cnf" >> $GITHUB_ENV
+        if: matrix.fips_enabled
+
+      - name: set fips enviornment variable for testing.
+        run: echo "TEST_RUBY_OPENSSL_FIPS_ENABLED=true" >> $GITHUB_ENV
+        if: matrix.fips_enabled
 
       - name: load ruby
         uses: ruby/setup-ruby@v1
@@ -112,3 +135,10 @@ jobs:
       - name: test
         run:  rake test TESTOPTS="-v --no-show-detail-immediately" OSSL_MDEBUG=1
         timeout-minutes: 5
+        if: ${{ !matrix.fips_enabled }}
+
+      # Run only the passing tests on the FIPS mode as a temporary workaround.
+      # TODO Fix other tests, and run all the tests on FIPS mode.
+      - name: test on fips mode
+        run:  ruby -Ilib test/openssl/test_fips.rb
+        if: matrix.fips_enabled

--- a/test/openssl/fixtures/ssl/openssl_fips.cnf.tmpl
+++ b/test/openssl/fixtures/ssl/openssl_fips.cnf.tmpl
@@ -1,0 +1,19 @@
+config_diagnostics = 1
+openssl_conf = openssl_init
+
+# It seems that the .include needs an absolute path.
+.include OPENSSL_DIR/ssl/fipsmodule.cnf
+
+[openssl_init]
+providers = provider_sect
+alg_section = algorithm_sect
+
+[provider_sect]
+fips = fips_sect
+base = base_sect
+
+[base_sect]
+activate = 1
+
+[algorithm_sect]
+default_properties = fips=yes

--- a/test/openssl/test_fips.rb
+++ b/test/openssl/test_fips.rb
@@ -4,20 +4,44 @@ require_relative 'utils'
 if defined?(OpenSSL)
 
 class OpenSSL::TestFIPS < OpenSSL::TestCase
+  def test_fips_mode_get_is_true_on_fips_mode_enabled
+    unless ENV["TEST_RUBY_OPENSSL_FIPS_ENABLED"]
+      omit "Only for FIPS mode environment"
+    end
+
+    assert_separately([{ "OSSL_MDEBUG" => nil }, "-ropenssl"], <<~"end;")
+      assert OpenSSL.fips_mode == true, ".fips_mode should return true on FIPS mode enabled"
+    end;
+  end
+
+  def test_fips_mode_get_is_false_on_fips_mode_disabled
+    if ENV["TEST_RUBY_OPENSSL_FIPS_ENABLED"]
+      omit "Only for non-FIPS mode environment"
+    end
+
+    assert_separately([{ "OSSL_MDEBUG" => nil }, "-ropenssl"], <<~"end;")
+      message = ".fips_mode should return false on FIPS mode disabled. " \
+                "If you run the test on FIPS mode, please set " \
+                "TEST_RUBY_OPENSSL_FIPS_ENABLED=true"
+      assert OpenSSL.fips_mode == false, message
+    end;
+  end
+
   def test_fips_mode_is_reentrant
     OpenSSL.fips_mode = false
     OpenSSL.fips_mode = false
   end
 
-  def test_fips_mode_get
-    return unless OpenSSL::OPENSSL_FIPS
+  def test_fips_mode_get_with_fips_mode_set
+    omit('OpenSSL is not FIPS-capable') unless OpenSSL::OPENSSL_FIPS
+
     assert_separately([{ "OSSL_MDEBUG" => nil }, "-ropenssl"], <<~"end;")
       begin
         OpenSSL.fips_mode = true
-        assert OpenSSL.fips_mode == true, ".fips_mode returns true when .fips_mode=true"
+        assert OpenSSL.fips_mode == true, ".fips_mode should return true when .fips_mode=true"
 
         OpenSSL.fips_mode = false
-        assert OpenSSL.fips_mode == false, ".fips_mode returns false when .fips_mode=false"
+        assert OpenSSL.fips_mode == false, ".fips_mode should return false when .fips_mode=false"
       rescue OpenSSL::OpenSSLError
         pend "Could not set FIPS mode (OpenSSL::OpenSSLError: \#$!); skipping"
       end


### PR DESCRIPTION
This PR includes the 2 commits below.

* CI: Add OpenSSL FIPS mode case.
* Fix the fips_mode_get on OpenSSL 3.

The 1st commit is to add the latest stable OpenSSL version 3.0.8 FIPS mode to the CI. I was able to create the FIPS mode environment. That means you can create the environment in your local environment too!

The 2nd commit fixes the issue https://github.com/ruby/openssl/issues/605 related to the `OpenSSL.fips_mode` (`fips_mode_get`). The commit can be also a minimal fix to test the FIPS mode created by the 1st commit.

## CI: Add OpenSSL FIPS mode case.

I referred to the following documents.

* https://github.com/openssl/openssl/blob/master/README-FIPS.md
* https://www.openssl.org/docs/manmaster/man7/fips_module.html

I prepared the OpenSSL config file to enable the FIPS mode: `test/openssl/fixtures/ssl/openssl_fips.cnf.tmpl` that was introduced in the document above.

As a reference, if you want to change the default OpenSSL config file (`OPENSSL_INSTALL_DIR/ssl/openssl.cnf`) to enable the FIPS mode, the difference is below for the OpenSSL 3.0.8 config file.

```
$ diff -u openssl.cnf openssl_fips2.cnf 
--- openssl.cnf	2023-03-16 17:04:39.238327719 +0100
+++ openssl_fips2.cnf	2023-03-16 17:13:29.319381845 +0100
@@ -49,16 +49,18 @@
 # referenced from the [provider_sect] below.
 # Refer to the OpenSSL security policy for more information.
 # .include fipsmodule.cnf
+.include /home/jaruga/.local/openssl-3.0.8-fips/ssl/fipsmodule.cnf
 
 [openssl_init]
 providers = provider_sect
+alg_section = algorithm_sect
 
 # List of providers to load
 [provider_sect]
 default = default_sect
 # The fips section name should match the section name inside the
 # included fipsmodule.cnf.
-# fips = fips_sect
+fips = fips_sect
 
 # If no providers are activated explicitly, the default one is activated implicitly.
 # See man 7 OSSL_PROVIDER-default for more details.
@@ -69,8 +71,10 @@
 # OpenSSL may not work correctly which could lead to significant system
 # problems including inability to remotely access the system.
 [default_sect]
-# activate = 1
+activate = 1
 
+[algorithm_sect]
+default_properties = fips=yes
 
 ####################################################################
 [ ca ]
```

## Fix the fips_mode_get on OpenSSL 3.

The commit only fixes `OpenSSL.fips_mode` (`fips_mode_get`). I think this can be a good start to fixing other issues for OpenSSL 3 FIPS mode in other PRs. The use of the `TEST_RUBY_OPENSSL_FIPS_ENABLED` is not the best way. However, I don't know a better way than that right now.

The test `test_fips_mode_get` previously passed unintentionally because the `OpenSSL::OPENSSL_FIPS` returns `false` in the FIPS mode-enabled environment. So, I added the pending message.


What do you think? Review, please. Thanks.



