### PR TITLE
Fix OpenSSL::PKey.read that cannot parse PKey in the FIPS mode.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -149,5 +149,7 @@ jobs:
       # Run only the passing tests on the FIPS mode as a temporary workaround.
       # TODO Fix other tests, and run all the tests on FIPS mode.
       - name: test on fips mode
-        run:  ruby -Ilib test/openssl/test_fips.rb
+        run:  |
+          ruby -I./lib -ropenssl \
+            -e 'Dir.glob "./test/openssl/{test_fips.rb,test_pkey.rb}", &method(:require)'
         if: matrix.fips_enabled

--- a/test/openssl/test_pkey.rb
+++ b/test/openssl/test_pkey.rb
@@ -82,6 +82,9 @@ class OpenSSL::TestPKey < OpenSSL::PKeyTestCase
   end
 
   def test_ed25519
+    # https://github.com/openssl/openssl/issues/20758
+    pend('Not supported on FIPS mode enabled') if OpenSSL.fips_mode
+
     # Test vector from RFC 8032 Section 7.1 TEST 2
     priv_pem = <<~EOF
     -----BEGIN PRIVATE KEY-----
@@ -127,6 +130,8 @@ class OpenSSL::TestPKey < OpenSSL::PKeyTestCase
   end
 
   def test_x25519
+    pend('Not supported on FIPS mode enabled') if OpenSSL.fips_mode
+
     # Test vector from RFC 7748 Section 6.1
     alice_pem = <<~EOF
     -----BEGIN PRIVATE KEY-----
@@ -153,6 +158,8 @@ class OpenSSL::TestPKey < OpenSSL::PKeyTestCase
   end
 
   def test_compare?
+    pend('Not supported on FIPS mode enabled') if OpenSSL.fips_mode
+
     key1 = Fixtures.pkey("rsa1024")
     key2 = Fixtures.pkey("rsa1024")
     key3 = Fixtures.pkey("rsa2048")

--- a/test/openssl/utils.rb
+++ b/test/openssl/utils.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 begin
   require "openssl"
-
-  # Disable FIPS mode for tests for installations
-  # where FIPS mode would be enabled by default.
-  # Has no effect on all other installations.
-  OpenSSL.fips_mode=false
 rescue LoadError
 end
 


### PR DESCRIPTION
This PR is to fix the following issue that is managed as one of the issues at <https://github.com/ruby/openssl/issues/603> on the FIPS mode. This PR is based on the PR <https://github.com/ruby/openssl/pull/608>. So, please consider reviewing and merging the #608 first. Then I can rebase this PR on the latest master branch.

```
$ openssl genrsa -out key.pem 4096

$ ruby -e "require 'openssl'; OpenSSL::PKey.read(File.read('key.pem'))"
-e:1:in `read': Could not parse PKey (OpenSSL::PKey::PKeyError)
  from -e:1:in `<main>'
```

There are some commits on this PR. The first 3 commits are basically from the PR #603. Then the 4th commit is the main commit to fix this issue. The patch is the same with what I mentioned at <https://github.com/ruby/openssl/issues/603#issuecomment-1507152493>. The 4th and 5th commits are to run the unit test `test/openssl/test_pkey.rb`.

https://github.com/junaruga/openssl/actions/runs/4681990779/jobs/8295272065#step:11:732

Before the main 4rd commit, the `test_generic_oid_inspect` and `test_to_text` was failing in the `test/openssl/test_pkey.rb`. So, running `test/openssl/test_pkey.rb` can test that this issue was fixed.

Note that the 3 tests `test_ed25519`, `test_x25519` and `test_compare?` in the `test/openssl/test_pkey.rb` are still failing due to other issues. And I am working on it at the <https://github.com/ruby/openssl/issues/603#issuecomment-1511534153>.

I confirmed that CI passed on my forked repository.
https://github.com/junaruga/openssl/actions/runs/4724029713/jobs/8380737782#step:12:64


