### PR TITLE
Add rdoc as a development dependency.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,6 @@ group :development do
   gem "rake"
   gem "rake-compiler"
   gem "test-unit", "~> 3.0", ">= 3.4.6"
+  # In the case of Ruby whose rdoc is not a default gem.
+  gem "rdoc"
 end


### PR DESCRIPTION
There is a case of the Ruby where the rdoc is not a default gem. That is Ruby RPM packages on Fedora Linux and maybe the downstream Linux distributions. The intention is to reduce the size of the main Ruby RPM package.

I appreciate if the ruby/openssl considers this case.

---

Right now the `rdoc` is used in the `Rakefile`. And the `bundle exec rake compile` raises an error with the Ruby RPM package. This pull-request fixes the error.

```
$ cat /etc/fedora-release 
Fedora release 37 (Thirty Seven)

$ which ruby
/bin/ruby

$ ruby -v
ruby 3.1.3p185 (2022-11-24 revision 1a6b16756e) [x86_64-linux]

$ which gem
/bin/gem

$ which bundle
/bin/bundle

$ gem list rdoc

*** LOCAL GEMS ***

rdoc (6.4.0)

$ gem list | grep rdoc
rdoc (6.4.0) # <= It's not a default gem.
```


```
$ bundle install --standalone
Bundler 2.3.26 is running, but your lockfile was generated with 2.4.6. Installing Bundler 2.4.6 and restarting using that version.
Fetching gem metadata from https://rubygems.org/.
Following files may not be writable, so sudo is needed:
  /usr/bin
  /usr/share/gems
  /usr/share/gems/build_info
  /usr/share/gems/cache
  /usr/share/gems/doc
  /usr/share/gems/extensions
  /usr/share/gems/gems
  /usr/share/gems/plugins
  /usr/share/gems/specifications
Fetching bundler 2.4.6
Installing bundler 2.4.6
Fetching gem metadata from https://rubygems.org/.......
Fetching rake 13.0.6
Installing rake 13.0.6
Using openssl 3.1.0 from source at `.`
Fetching power_assert 2.0.3
Fetching rake-compiler 1.2.1
Using bundler 2.4.6
Installing power_assert 2.0.3
Installing rake-compiler 1.2.1
Fetching test-unit 3.5.7
Installing test-unit 3.5.7
Bundle complete! 4 Gemfile dependencies, 6 gems now installed.
Bundled gems are installed into `./bundle`

$ bundle exec rake compile
rake aborted!
LoadError: cannot load such file -- rdoc/task
/home/jaruga/var/git/ruby/openssl/Rakefile:2:in `require'
/home/jaruga/var/git/ruby/openssl/Rakefile:2:in `<top (required)>'
/home/jaruga/var/git/ruby/openssl/bundle/ruby/3.1.0/gems/rake-13.0.6/exe/rake:27:in `<top (required)>'
/usr/share/gems/gems/bundler-2.4.6/lib/bundler/cli/exec.rb:58:in `load'
/usr/share/gems/gems/bundler-2.4.6/lib/bundler/cli/exec.rb:58:in `kernel_load'
/usr/share/gems/gems/bundler-2.4.6/lib/bundler/cli/exec.rb:23:in `run'
/usr/share/gems/gems/bundler-2.4.6/lib/bundler/cli.rb:491:in `exec'
/usr/share/gems/gems/bundler-2.4.6/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/usr/share/gems/gems/bundler-2.4.6/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
/usr/share/gems/gems/bundler-2.4.6/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
/usr/share/gems/gems/bundler-2.4.6/lib/bundler/cli.rb:34:in `dispatch'
/usr/share/gems/gems/bundler-2.4.6/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
/usr/share/gems/gems/bundler-2.4.6/lib/bundler/cli.rb:28:in `start'
/usr/share/gems/gems/bundler-2.4.6/exe/bundle:45:in `block in <top (required)>'
/usr/share/gems/gems/bundler-2.4.6/lib/bundler/friendly_errors.rb:117:in `with_friendly_errors'
/usr/share/gems/gems/bundler-2.4.6/exe/bundle:33:in `<top (required)>'
/bin/bundle:25:in `load'
/bin/bundle:25:in `<main>'
(See full trace by running task with --trace)
```

