### PR TITLE
Fix warnings about the OPENSSL_FIPS macro in OpenSSL 1.1.

### DIFF
--- a/ext/openssl/ossl.c
+++ b/ext/openssl/ossl.c
@@ -422,7 +422,7 @@ ossl_fips_mode_get(VALUE self)
     VALUE enabled;
     enabled = EVP_default_properties_is_fips_enabled(NULL) ? Qtrue : Qfalse;
     return enabled;
-#elif OPENSSL_FIPS
+#elif defined(OPENSSL_FIPS)
     VALUE enabled;
     enabled = FIPS_mode() ? Qtrue : Qfalse;
     return enabled;
@@ -457,7 +457,7 @@ ossl_fips_mode_set(VALUE self, VALUE enabled)
         }
     }
     return enabled;
-#elif OPENSSL_FIPS
+#elif defined(OPENSSL_FIPS)
     if (RTEST(enabled)) {
 	int mode = FIPS_mode();
 	if(!mode && !FIPS_mode_set(1)) /* turning on twice leads to an error */
@@ -1215,7 +1215,7 @@ Init_openssl(void)
 /* OpenSSL 3 is FIPS-capable even when it is installed without fips option */
 #if OSSL_OPENSSL_PREREQ(3, 0, 0)
                     Qtrue
-#elif OPENSSL_FIPS
+#elif defined(OPENSSL_FIPS)
 		    Qtrue
 #else
 		    Qfalse


### PR DESCRIPTION
This PR fixes #620. I wanted to add the cases on the CI. However I couldn't reproduce it on the CI. So, I checked the PR suppress the warnings on my local environment. Later I consider adding the CI cases to test the compiler warnings.

@botovq, thanks for the report. Could you check this PR on your environment, just in case? Thanks.

---

The commit c5b2bc1268bcb946ff2eb52904a85278a1dac12c made the warnings below in the case of OpenSSL 1.1 where the `OPENSSL_FIPS` macro is not defined.

```
$ ruby -v
ruby 3.2.1 (2023-02-08 revision 31819e82c8) [x86_64-linux]

$ bundle install --standalone

$ bundle exec rake compile -- \
  --with-openssl-dir=$HOME/.local/openssl-1.1.1t-debug \
  --with-cflags="-Wundef"
mkdir -p tmp/x86_64-linux/openssl/3.2.1
cd tmp/x86_64-linux/openssl/3.2.1
/usr/local/ruby-3.2.1/bin/ruby -I. -r.rake-compiler-siteconf.rb ../../../../ext/openssl/extconf.rb -- --with-openssl-dir=/home/jaruga/.local/openssl-1.1.1t-debug --with-cflags=-Wundef
...
gcc -I. -I/usr/local/ruby-3.2.1/include/ruby-3.2.0/x86_64-linux -I/usr/local/ruby-3.2.1/include/ruby-3.2.0/ruby/backward -I/usr/local/ruby-3.2.1/include/ruby-3.2.0 -I../../../../ext/openssl -DRUBY_EXTCONF_H=\"extconf.h\" -I/home/jaruga/.local/openssl-1.1.1t-debug/include    -fPIC -Wundef  -o ossl.o -c ../../../../ext/openssl/ossl.c
../../../../ext/openssl/ossl.c: In function ‘ossl_fips_mode_get’:
../../../../ext/openssl/ossl.c:425:7: warning: "OPENSSL_FIPS" is not defined, evaluates to 0 [-Wundef]
  425 | #elif OPENSSL_FIPS
      |       ^~~~~~~~~~~~
../../../../ext/openssl/ossl.c: In function ‘ossl_fips_mode_set’:
../../../../ext/openssl/ossl.c:460:7: warning: "OPENSSL_FIPS" is not defined, evaluates to 0 [-Wundef]
  460 | #elif OPENSSL_FIPS
      |       ^~~~~~~~~~~~
../../../../ext/openssl/ossl.c: In function ‘Init_openssl’:
../../../../ext/openssl/ossl.c:1218:7: warning: "OPENSSL_FIPS" is not defined, evaluates to 0 [-Wundef]
 1218 | #elif OPENSSL_FIPS
      |       ^~~~~~~~~~~~
...
cp tmp/x86_64-linux/openssl/3.2.1/openssl.so tmp/x86_64-linux/stage/lib/openssl.so
```