### PR TITLE
Revert "Skip OpenSSL::TestHMAC#test_dup when running with RHEL9"

### DIFF
--- a/test/openssl/test_hmac.rb
+++ b/test/openssl/test_hmac.rb
@@ -21,9 +21,6 @@ class OpenSSL::TestHMAC < OpenSSL::TestCase
   end
 
   def test_dup
-    require "etc"
-    pend "[Bug #19386] OpenSSL 3.0.1 of RHEL9 is not working this test" if Etc.uname[:release] =~ /el9/
-
     h1 = OpenSSL::HMAC.new("KEY", "MD5")
     h1.update("DATA")
     h = h1.dup


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/19386#note-11