### PR TITLE
CI: Enable the verbose mode in the mkmf.rb.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,11 @@ jobs:
       - name: depends
         run:  bundle install
 
+      # Enable the verbose option in mkmf.rb to print the compiling commands.
+      - name: enable mkmf verbose
+        run:  tool/enable-mkmf-verbose
+        if: runner.os == 'Linux' || runner.os == 'macOS'
+
       - name: compile
         run:  rake compile -- --enable-debug
 
@@ -128,6 +133,10 @@ jobs:
 
       - name: depends
         run:  bundle install
+
+      - name: enable mkmf verbose
+        run:  tool/enable-mkmf-verbose
+        if: runner.os == 'Linux' || runner.os == 'macOS'
 
       - name: compile
         run:  rake compile -- --enable-debug --with-openssl-dir=$HOME/.openssl/${{ matrix.openssl }}

--- a/tool/enable-mkmf-verbose
+++ b/tool/enable-mkmf-verbose
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+set -eux
+
+gem_home="$(gem environment home)"
+mkmf_rb_path="$(find "${gem_home}"/../.. -name mkmf.rb)"
+
+# Backup the original file.
+cp -p "${mkmf_rb_path}" "${mkmf_rb_path}.orig"
+
+# Replace the target line to set the verbose option.
+sed -i -e 's/^V = .*/V = 1/' "${mkmf_rb_path}"
+
+# Print the difference between the original and modified file. This is useful
+# to debug when the `mkmf.rb` may change in the future. And check if the
+#`mkmf.rb` was modified. Because the `sed` command returns the exit status 0 no
+# matter it replaces successfully or not.
+if diff "${mkmf_rb_path}.orig" "${mkmf_rb_path}"; then
+  echo "error: ${mkmf_rb_path} was not modified." 1>&2
+  exit 1
+elif [ "${?}" != 1 ]; then
+  echo "error: diff was failed." 1>&2
+  exit 1
+fi


### PR DESCRIPTION
This PR is to print the compiling commands in the process of the `rake compile`, and enables us to detect the compiler warnings like the issue <https://github.com/ruby/openssl/issues/620> in a PR process. This is a workaround until a formal way to enable the verbose mode in runtime of Ruby will be implemented. You can see https://github.com/ruby/setup-ruby/issues/505#issuecomment-1555880562 for the proposal.

Here is the result on my forked repository.

Ubuntu Ruby 3.2
https://github.com/junaruga/openssl/actions/runs/5049251346/jobs/9058658930#step:6:81
> gcc -I. -I/opt/hostedtoolcache/Ruby/3.2.2/x64/include/ruby-3.2.0/x86_64-linux -I/opt/hostedtoolcache/Ruby/3.2.2/x64/include/ruby-3.2.0/ruby/backward -I/opt/hostedtoolcache/Ruby/3.2.2/x64/include/ruby-3.2.0 -I../../../../ext/openssl  -DRUBY_EXTCONF_H=\"extconf.h\" -I/opt/hostedtoolcache/Ruby/3.2.2/x64/include -DENABLE_PATH_CHECK=0   -fPIC -O3 -fno-fast-math -ggdb3 -Wall -Wextra -Wdeprecated-declarations -Wdiv-by-zero -Wduplicated-cond -Wimplicit-function-declaration -Wimplicit-int -Wmisleading-indentation -Wpointer-arith -Wwrite-strings -Wold-style-definition -Wimplicit-fallthrough=0 -Wmissing-noreturn -Wno-cast-function-type -Wno-constant-logical-operand -Wno-long-long -Wno-missing-field-initializers -Wno-overlength-strings -Wno-packed-bitfield-compat -Wno-parentheses-equality -Wno-self-assign -Wno-tautological-compare -Wno-unused-parameter -Wno-unused-value -Wsuggest-attribute=format -Wsuggest-attribute=noreturn -Wunused-variable -Wundef  -fPIC   -o openssl_missing.o -c ../../../../ext/openssl/openssl_missing.c

macOS Ruby 3.2
https://github.com/junaruga/openssl/actions/runs/5049251346/jobs/9058660439#step:6:85
> clang -I. -I/Users/runner/hostedtoolcache/Ruby/3.2.2/x64/include/ruby-3.2.0/x86_64-darwin20 -I/Users/runner/hostedtoolcache/Ruby/3.2.2/x64/include/ruby-3.2.0/ruby/backward -I/Users/runner/hostedtoolcache/Ruby/3.2.2/x64/include/ruby-3.2.0 -I../../../../ext/openssl -DRUBY_EXTCONF_H=\"extconf.h\" -I/Users/runner/hostedtoolcache/Ruby/3.2.2/x64/openssl/include -I/Users/runner/hostedtoolcache/Ruby/3.2.2/x64/include -DENABLE_PATH_CHECK=0 -I/usr/local/opt/gmp/include -D_XOPEN_SOURCE -D_DARWIN_C_SOURCE -D_DARWIN_UNLIMITED_SELECT -D_REENTRANT   -fno-common -fdeclspec -O3 -fno-fast-math -ggdb3 -Wall -Wextra -Wextra-tokens -Wdeprecated-declarations -Wdivision-by-zero -Wdiv-by-zero -Wimplicit-function-declaration -Wimplicit-int -Wmisleading-indentation -Wpointer-arith -Wshorten-64-to-32 -Wwrite-strings -Wold-style-definition -Wmissing-noreturn -Wno-constant-logical-operand -Wno-long-long -Wno-missing-field-initializers -Wno-overlength-strings -Wno-parentheses-equality -Wno-self-assign -Wno-tautological-compare -Wno-unused-parameter -Wno-unused-value -Wunused-variable -Wundef  -fno-common -pipe  -o openssl_missing.o -c ../../../../ext/openssl/openssl_missing.c

---

Enable the verbose option in mkmf.rb to print the compiling commands in the process of the `rake compile`. Because it's helpful to see what compiler warnings are checked.

The script only runs in Linux and macOS. Not Windows. Because the sh script doesn't work in Windows. For the syntax, see the reference.[1]

Right now there is a way to configure Ruby with `--enable-mkmf-verbose` in this purpose. But there is no formal way to enable the verbose mode in runtime of Ruby. My intention is that this commit is a workaround for this purpose.

[1] https://docs.github.com/en/actions/learn-github-actions/variables
  * Default environment variables - RUNNER_OS
  * Detecting the operating system