### PR TITLE
Add convenience constants 

### DIFF
--- a/lib/openssl/pkey.rb
+++ b/lib/openssl/pkey.rb
@@ -251,6 +251,18 @@ module OpenSSL::PKey
   class EC
     include OpenSSL::Marshal
 
+    CurveNameAlias = {
+      'nistp256' => 'prime256v1',
+      'nistp384' => 'secp384r1',
+      'nistp521' => 'secp521r1'
+    }.freeze
+
+    CurveNameAliasInv = {
+      'prime256v1' => 'nistp256',
+      'secp384r1' => 'nistp384',
+      'secp521r1' => 'nistp521'
+    }.freeze
+
     # :call-seq:
     #    key.dsa_sign_asn1(data) -> String
     #


### PR DESCRIPTION
Gem net-ssh [defines two convenience constants](https://github.com/net-ssh/net-ssh/blob/master/lib/net/ssh/transport/openssl.rb#L141-L151):

- OpenSSL::PKey::EC::CurveNameAlias
- OpenSSL::PKey::EC::CurveNameAliasInv

Because I have needed to duplicate these constants in other gems that depend on ruby/openssl, migrate them upstream to ruby/openssl for convenience.