### PR TITLE
Append flags from environment variables.

### DIFF
--- a/ext/openssl/extconf.rb
+++ b/ext/openssl/extconf.rb
@@ -18,6 +18,12 @@ dir_config("kerberos")
 
 Logging::message "=== OpenSSL for Ruby configurator ===\n"
 
+# Append flags from environment variables.
+extcflags = ENV["RUBY_OPENSSL_EXTCFLAGS"]
+append_cflags(extcflags.split) if extcflags
+extldflags = ENV["RUBY_OPENSSL_EXTLDFLAGS"]
+append_ldflags(extldflags.split) if extldflags
+
 ##
 # Adds -DOSSL_DEBUG for compilation and some more targets when GCC is used
 # To turn it on, use: --with-debug or --enable-debug


### PR DESCRIPTION
According to the `mkmf.rb#init_mkmf`, there are command line options below.

* `--with-cflags` to set the `cflags`
* `--with-ldflags` to set the `ldflags`

For example the following command compiles with the specified flags. Note that
`MAKEFLAGS` is to print the compiler command lines.

```
$ MAKEFLAGS="V=1" \
  bundle exec rake compile -- \
  --with-cflags="-Wundef -Werror" \
  --with-ldflags="-fstack-protector"
```

However, I couldn't find command line options to append the flags. And this
commit is to append the `cflags` and `ldflags` by the environment variables.

```
$ MAKEFLAGS="V=1" \
  RUBY_OPENSSL_EXTCFLAGS="-Wundef -Werror" \
  RUBY_OPENSSL_EXTLDFLAGS="-fstack-protector" \
  bundle exec rake compile
```

## Details

The implementation was inspired by Nokogiri project.
https://github.com/sparklemotion/nokogiri/blob/30e965809c4c55b191c5c9f3a2cc5a289fce4681/ext/nokogiri/extconf.rb#L648-L651

```
# adopt environment config
append_cflags(ENV["CFLAGS"].split) unless ENV["CFLAGS"].nil?
append_cppflags(ENV["CPPFLAGS"].split) unless ENV["CPPFLAGS"].nil?
append_ldflags(ENV["LDFLAGS"].split) unless ENV["LDFLAGS"].nil?
```

However, I wanted to avoid the `CFLAGS` was loaded unintentionally. Because I see `CFLAGS` and `LDFLAGS` are already set in the build environment in Fedora project. Those are used to set the flags, not to append. So, I used the prefix `RUBY_OPENSSL_`. I also wanted to clarify that the value is used not to set but to append to the existing cflags coming from the `rbconfig.rb`. If it seems the `template/Makefile.in` in ruby/ruby, the `EXTLDFLAGS` exists in the purpose of appendng the flags. So, I chose the `RUBY_OPENSSL_EXTCFLAGS` and `RUBY_OPENSSL_EXTLDFLAGS`.

You can also add your preferred debug flags like this.

```
$ MAKEFLAGS="V=1" \
  RUBY_OPENSSL_EXTCFLAGS="-O0 -g3 -ggdb3 -gdwarf-5" \
  bundle exec rake compile
```
