### PR TITLE
Print the Ruby and compiler info or the command itself before compiling.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,6 +5,8 @@ require 'bundler/gem_tasks'
 begin
   require 'rake/extensiontask'
   Rake::ExtensionTask.new('openssl')
+  # Run the debug_compiler task before the compile task.
+  Rake::Task['compile'].prerequisites.unshift :debug_compiler
 rescue LoadError
   warn "rake-compiler not installed. Run 'bundle install' to " \
     "install testing dependency gems."
@@ -22,6 +24,19 @@ RDoc::Task.new do |rdoc|
 end
 
 task :test => [:compile, :debug]
+
+# Print Ruby and compiler info for debugging purpose.
+task :debug_compiler do
+  ruby '-v'
+  compiler = RbConfig::CONFIG['CC']
+  case compiler
+  when 'gcc', 'clang'
+    sh "#{compiler} --version"
+  else
+    puts "Compiler: #{RbConfig::CONFIG['CC']}"
+  end
+end
+
 task :debug do
   ruby "-I./lib -ropenssl -ve'puts OpenSSL::OPENSSL_VERSION, OpenSSL::OPENSSL_LIBRARY_VERSION'"
 end


### PR DESCRIPTION
This PR is for a preparation of the <https://github.com/ruby/openssl/issues/626>.

---

Print the Ruby and compiler info or the command itself before compiling.

The new task "debug_compiler" to print the Ruby and compiler version or,
compiler command itself for the debugging purpose. The task name is aligning
with the "debug" task that is to print the info in the Ruby OpenSSL binding for
the debugging purpose.

The compiler version info is useful when we hit the issues coming from the
newly updated compilers on the CI, and we find the cause.
