### PR TITLE
CI: Check compiler warnings.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,10 @@ jobs:
         run:  echo "MAKEFLAGS=V=1" >> $GITHUB_ENV
         if: runner.os == 'Linux' || runner.os == 'macOS'
 
+      - name: set flags to check compiler warnings.
+        run:  echo "RUBY_OPENSSL_EXTCFLAGS=-Werror" >> $GITHUB_ENV
+        if: ${{ !matrix.skip-warnings }}
+
       - name: compile
         run:  rake compile -- --enable-debug
 
@@ -141,6 +145,10 @@ jobs:
       - name: enable mkmf verbose
         run:  echo "MAKEFLAGS=V=1" >> $GITHUB_ENV
         if: runner.os == 'Linux' || runner.os == 'macOS'
+
+      - name: set flags to check compiler warnings.
+        run:  echo "RUBY_OPENSSL_EXTCFLAGS=-Werror" >> $GITHUB_ENV
+        if: ${{ !matrix.skip-warnings }}
 
       - name: compile
         run:  rake compile -- --enable-debug --with-openssl-dir=$HOME/.openssl/${{ matrix.openssl }}


### PR DESCRIPTION
This PR fixes <https://github.com/ruby/openssl/issues/626>.

Add checks to make CI fail by compiler warnings in the `rake compile`.

If the `skip-warnings` (default: `false`, as an undefined variable is evaluated as `false` in the `if` syntax) is `true` in specific matrix cases, the cases skip the checks. If you want to skip new compiler warnings coming from external changes such as upgraded compiler or OpenSSL versions in the specific matrix cases, you can set the `skip-warnings: true` for the cases.

Note that this issue https://github.com/ruby/openssl/issues/628 was detected in the process of this work.
