### PR TITLE
Rakefile: Print the message with `Rake.rake_output_message`.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -33,7 +33,7 @@ task :debug_compiler do
   when 'gcc', 'clang'
     sh "#{compiler} --version"
   else
-    puts "Compiler: #{RbConfig::CONFIG['CC']}"
+    Rake.rake_output_message "Compiler: #{RbConfig::CONFIG['CC']}"
   end
 end
 


### PR DESCRIPTION
The `puts` method outputs the message to the `$stdout`, while the `sh` method outputs the message of the executed command to the `$stderr` by the `Rake.rake_output_message`.
https://github.com/ruby/rake/blob/v13.0.6/lib/rake/file_utils.rb#L51

This caused the message `Compiler: ...` not printed before the actual compiling task like the CI result below.
<https://github.com/ruby/openssl/actions/runs/5142797693/jobs/9256988158#step:6:141>.