### PR TITLE
extconf.rb: apply RUBY_OPENSSL_EXT{C,LD}FLAGS after checking features

### DIFF
--- a/ext/openssl/extconf.rb
+++ b/ext/openssl/extconf.rb
@@ -18,12 +18,6 @@ dir_config("kerberos")
 
 Logging::message "=== OpenSSL for Ruby configurator ===\n"
 
-# Append flags from environment variables.
-extcflags = ENV["RUBY_OPENSSL_EXTCFLAGS"]
-append_cflags(extcflags.split) if extcflags
-extldflags = ENV["RUBY_OPENSSL_EXTLDFLAGS"]
-append_ldflags(extldflags.split) if extldflags
-
 ##
 # Adds -DOSSL_DEBUG for compilation and some more targets when GCC is used
 # To turn it on, use: --with-debug or --enable-debug
@@ -197,6 +191,12 @@ have_func("EVP_PKEY_eq(NULL, NULL)", evp_h)
 have_func("EVP_PKEY_dup(NULL)", evp_h)
 
 Logging::message "=== Checking done. ===\n"
+
+# Append flags from environment variables.
+extcflags = ENV["RUBY_OPENSSL_EXTCFLAGS"]
+append_cflags(extcflags.split) if extcflags
+extldflags = ENV["RUBY_OPENSSL_EXTLDFLAGS"]
+append_ldflags(extldflags.split) if extldflags
 
 create_header
 create_makefile("openssl")


### PR DESCRIPTION
RUBY_OPENSSL_EXTCFLAGS and RUBY_OPENSSL_EXTLDFLAGS have been added for the primary purpose of custom warning flags for development and CI.

Since checking programs generated by mkmf may not be completely warning-free, we don't want to apply -Werror that may be supplied from these environment variables.