### PR TITLE
add OpenSSL Provider support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,12 @@ jobs:
         run:  echo "RUBY_OPENSSL_EXTCFLAGS=-Werror" >> $GITHUB_ENV
         if: ${{ !matrix.skip-warnings }}
 
+      # Enable provider search path for OpenSSL 3.0 in MSYS2.
+      # Remove when Ruby 3.2 build is updated
+      - name: enable windows provider search path
+        run: echo "OPENSSL_MODULES=$($env:RI_DEVKIT)\$($env:MSYSTEM_PREFIX)\lib\ossl-modules" >> $env:GITHUB_ENV
+        if: runner.os == 'Windows' && matrix.ruby == '3.2'
+
       - name: compile
         run:  rake compile -- --enable-debug
 

--- a/ext/openssl/ossl.c
+++ b/ext/openssl/ossl.c
@@ -1255,6 +1255,7 @@ Init_openssl(void)
     Init_ossl_x509();
     Init_ossl_ocsp();
     Init_ossl_engine();
+    Init_ossl_provider();
     Init_ossl_asn1();
     Init_ossl_kdf();
 

--- a/ext/openssl/ossl.h
+++ b/ext/openssl/ossl.h
@@ -62,6 +62,10 @@
 # define OSSL_USE_ENGINE
 #endif
 
+#if OSSL_OPENSSL_PREREQ(3, 0, 0)
+# define OSSL_USE_PROVIDER
+#endif
+
 /*
  * Common Module
  */
@@ -188,6 +192,7 @@ extern VALUE dOSSL;
 #endif
 #include "ossl_x509.h"
 #include "ossl_engine.h"
+#include "ossl_provider.h"
 #include "ossl_kdf.h"
 
 void Init_openssl(void);

--- a/ext/openssl/ossl_provider.c
+++ b/ext/openssl/ossl_provider.c
@@ -1,0 +1,211 @@
+/*
+ * This program is licensed under the same licence as Ruby.
+ * (See the file 'LICENCE'.)
+ */
+#include "ossl.h"
+
+#ifdef OSSL_USE_PROVIDER
+# include <openssl/provider.h>
+
+#define NewProvider(klass) \
+    TypedData_Wrap_Struct((klass), &ossl_provider_type, 0)
+#define SetProvider(obj, provider) do { \
+    if (!(provider)) { \
+        ossl_raise(rb_eRuntimeError, "Provider wasn't initialized."); \
+    } \
+    RTYPEDDATA_DATA(obj) = (provider); \
+} while(0)
+#define GetProvider(obj, provider) do { \
+    TypedData_Get_Struct((obj), OSSL_PROVIDER, &ossl_provider_type, (provider)); \
+    if (!(provider)) { \
+        ossl_raise(rb_eRuntimeError, "PROVIDER wasn't initialized."); \
+    } \
+} while (0)
+
+static const rb_data_type_t ossl_provider_type = {
+    "OpenSSL/Provider",
+    {
+        0,
+    },
+    0, 0, RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED,
+};
+
+/*
+ * Classes
+ */
+/* Document-class: OpenSSL::Provider
+ *
+ * This class is the access to openssl's Provider
+ * See also, https://www.openssl.org/docs/manmaster/man7/provider.html
+ */
+static VALUE cProvider;
+/* Document-class: OpenSSL::Provider::ProviderError
+ *
+ * This is the generic exception for OpenSSL::Provider related errors
+ */
+static VALUE eProviderError;
+
+/*
+ * call-seq:
+ *    OpenSSL::Provider.load(name) -> provider
+ *
+ * This method loads and initializes a provider
+ */
+static VALUE
+ossl_provider_s_load(VALUE klass, VALUE name)
+{
+    OSSL_PROVIDER *provider = NULL;
+    VALUE obj;
+
+    const char *provider_name_ptr = StringValueCStr(name);
+
+    provider = OSSL_PROVIDER_load(NULL, provider_name_ptr);
+    if (provider == NULL) {
+        ossl_raise(eProviderError, "Failed to load %s provider", provider_name_ptr);
+    }
+    obj = NewProvider(klass);
+    SetProvider(obj, provider);
+
+    return obj;
+}
+
+struct ary_with_state { VALUE ary; int state; };
+struct rb_push_provider_name_args { OSSL_PROVIDER *prov; VALUE ary; };
+
+static VALUE
+rb_push_provider_name(VALUE rb_push_provider_name_args)
+{
+    struct rb_push_provider_name_args *args = (struct rb_push_provider_name_args *)rb_push_provider_name_args;
+
+    VALUE name = rb_str_new2(OSSL_PROVIDER_get0_name(args->prov));
+    return rb_ary_push(args->ary, name);
+}
+
+static int
+push_provider(OSSL_PROVIDER *prov, void *cbdata)
+{
+    struct ary_with_state *ary_with_state = (struct ary_with_state *)cbdata;
+    struct rb_push_provider_name_args args = { prov, ary_with_state->ary };
+
+    rb_protect(rb_push_provider_name, (VALUE)&args, &ary_with_state->state);
+    if (ary_with_state->state) {
+        return 0;
+    } else {
+        return 1;
+    }
+}
+
+/*
+ * call-seq:
+ *    OpenSSL::Provider.provider_names -> [provider_name, ...]
+ *
+ * Returns an array of currently loaded provider names.
+ */
+static VALUE
+ossl_provider_s_provider_names(VALUE klass)
+{
+    VALUE ary = rb_ary_new();
+    struct ary_with_state cbdata = { ary, 0 };
+
+    int result = OSSL_PROVIDER_do_all(NULL, &push_provider, (void*)&cbdata);
+    if (result != 1 ) {
+        if (cbdata.state) {
+            rb_jump_tag(cbdata.state);
+        } else {
+            ossl_raise(eProviderError, "Failed to load provider names");
+        }
+    }
+
+    return ary;
+}
+
+/*
+ * call-seq:
+ *    provider.unload -> true
+ *
+ * This method unloads this provider.
+ *
+ * if provider unload fails or already unloaded, it raises OpenSSL::Provider::ProviderError
+ */
+static VALUE
+ossl_provider_unload(VALUE self)
+{
+    OSSL_PROVIDER *prov;
+    if (RTYPEDDATA_DATA(self) == NULL) {
+        ossl_raise(eProviderError, "Provider already unloaded.");
+    }
+    GetProvider(self, prov);
+
+    int result = OSSL_PROVIDER_unload(prov);
+
+    if (result != 1) {
+        ossl_raise(eProviderError, "Failed to unload provider");
+    }
+    RTYPEDDATA_DATA(self) = NULL;
+    return Qtrue;
+}
+
+/*
+ * call-seq:
+ *    provider.name -> string
+ *
+ * Get the name of this provider.
+ *
+ * if this provider is already unloaded, it raises OpenSSL::Provider::ProviderError
+ */
+static VALUE
+ossl_provider_get_name(VALUE self)
+{
+    OSSL_PROVIDER *prov;
+    if (RTYPEDDATA_DATA(self) == NULL) {
+        ossl_raise(eProviderError, "Provider already unloaded.");
+    }
+    GetProvider(self, prov);
+
+    return rb_str_new2(OSSL_PROVIDER_get0_name(prov));
+}
+
+/*
+ * call-seq:
+ *    provider.inspect -> string
+ *
+ * Pretty prints this provider.
+ */
+static VALUE
+ossl_provider_inspect(VALUE self)
+{
+    OSSL_PROVIDER *prov;
+    if (RTYPEDDATA_DATA(self) == NULL ) {
+        return rb_sprintf("#<%"PRIsVALUE" unloaded provider>", rb_obj_class(self));
+    }
+    GetProvider(self, prov);
+
+    return rb_sprintf("#<%"PRIsVALUE" name=\"%s\">",
+                      rb_obj_class(self), OSSL_PROVIDER_get0_name(prov));
+}
+
+void
+Init_ossl_provider(void)
+{
+#if 0
+    mOSSL = rb_define_module("OpenSSL");
+    eOSSLError = rb_define_class_under(mOSSL, "OpenSSLError", rb_eStandardError);
+#endif
+
+    cProvider = rb_define_class_under(mOSSL, "Provider", rb_cObject);
+    eProviderError = rb_define_class_under(cProvider, "ProviderError", eOSSLError);
+
+    rb_undef_alloc_func(cProvider);
+    rb_define_singleton_method(cProvider, "load", ossl_provider_s_load, 1);
+    rb_define_singleton_method(cProvider, "provider_names", ossl_provider_s_provider_names, 0);
+
+    rb_define_method(cProvider, "unload", ossl_provider_unload, 0);
+    rb_define_method(cProvider, "name", ossl_provider_get_name, 0);
+    rb_define_method(cProvider, "inspect", ossl_provider_inspect, 0);
+}
+#else
+void
+Init_ossl_provider(void)
+{
+}
+#endif

--- a/ext/openssl/ossl_provider.h
+++ b/ext/openssl/ossl_provider.h
@@ -1,0 +1,5 @@
+#if !defined(OSSL_PROVIDER_H)
+#define OSSL_PROVIDER_H
+
+void Init_ossl_provider(void);
+#endif

--- a/test/openssl/test_provider.rb
+++ b/test/openssl/test_provider.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+require_relative 'utils'
+if defined?(OpenSSL) && defined?(OpenSSL::Provider) && !OpenSSL.fips_mode
+
+class OpenSSL::TestProvider < OpenSSL::TestCase
+  def test_openssl_provider_name_inspect
+    with_openssl <<-'end;'
+      provider = OpenSSL::Provider.load("default")
+      assert_equal("default", provider.name)
+      assert_not_nil(provider.inspect)
+    end;
+  end
+
+  def test_openssl_provider_names
+    with_openssl <<-'end;'
+      legacy_provider = OpenSSL::Provider.load("legacy")
+      assert_equal(2, OpenSSL::Provider.provider_names.size)
+      assert_includes(OpenSSL::Provider.provider_names, "legacy")
+
+      assert_equal(true, legacy_provider.unload)
+      assert_equal(1, OpenSSL::Provider.provider_names.size)
+      assert_not_includes(OpenSSL::Provider.provider_names, "legacy")
+    end;
+  end
+
+  def test_unloaded_openssl_provider
+    with_openssl <<-'end;'
+      default_provider = OpenSSL::Provider.load("default")
+      assert_equal(true, default_provider.unload)
+      assert_raise(OpenSSL::Provider::ProviderError) { default_provider.name }
+      assert_raise(OpenSSL::Provider::ProviderError) { default_provider.unload }
+    end;
+  end
+
+  def test_openssl_legacy_provider
+    with_openssl(<<-'end;')
+      OpenSSL::Provider.load("legacy")
+      algo = "RC4"
+      data = "a" * 1000
+      key = OpenSSL::Random.random_bytes(16)
+
+      # default provider does not support RC4
+      cipher = OpenSSL::Cipher.new(algo)
+      cipher.encrypt
+      cipher.key = key
+      encrypted = cipher.update(data) + cipher.final
+
+      other_cipher = OpenSSL::Cipher.new(algo)
+      other_cipher.decrypt
+      other_cipher.key = key
+      decrypted = other_cipher.update(encrypted) + other_cipher.final
+
+      assert_equal(data, decrypted)
+    end;
+  end
+
+  private
+
+  # this is required because OpenSSL::Provider methods change global state
+  def with_openssl(code, **opts)
+    assert_separately([{ "OSSL_MDEBUG" => nil }, "-ropenssl"], <<~"end;", **opts)
+      #{code}
+    end;
+  end
+end
+
+end


### PR DESCRIPTION
Hi! Thank you for great gem.

This PR fix #567 

Currently Ruby does not seem to have an API to load providers
To add a provider, you need to set the following file in OPENSSL_CONF

```ruby 
➜  ~ ruby -v
ruby 3.2.2 (2023-03-30 revision e51014f9c0) [arm64-darwin22]
➜  ~ irb
irb(main):001:0> require 'openssl'
=> true
irb(main):002:0> OpenSSL::VERSION
=> "3.1.0"
irb(main):003:0> OpenSSL::OPENSSL_VERSION
=> "OpenSSL 3.1.0 14 Mar 2023"
irb(main):004:0> OpenSSL::OPENSSL_LIBRARY_VERSION
=> "OpenSSL 3.1.0 14 Mar 2023"
irb(main):005:0> OpenSSL::Cipher.new("RC4")
(irb):5:in `initialize': unsupported (OpenSSL::Cipher::CipherError)
	from (irb):5:in `new'
	from (irb):5:in `<main>'
~~~
➜  ~ cat .add_provider_conf
openssl_conf = openssl_init

[openssl_init]
providers = provider_sect

[provider_sect]
default = default_sect
legacy = legacy_sect

[default_sect]
activate = 1

[legacy_sect]
activate = 1

➜  ~ irb
irb(main):001:0> ENV['OPENSSL_CONF'] = ".add_provider_conf"
=> ".add_provider_conf"
irb(main):002:0> require 'openssl'
=> true
# default provider does not support RC4 
irb(main):003:0> OpenSSL::Cipher.new("RC4")
=> #<OpenSSL::Cipher:0x0000000110e015d0>
```

This change provides an API to add a provider using `OSSL_PROVIDER_load`

```ruby
OpenSSL::Provider.load("legacy")
=> #<OpenSSL::Provider name="legacy">
cipher = OpenSSL::Cipher.new("RC4")
=> #<OpenSSL::Cipher:0x0000000108eb3648>
```

I am just a beginner to Ruby C extensions. I would love to get a review!

ref:
https://www.openssl.org/docs/manmaster/man3/OSSL_PROVIDER_load.html

