### PR TITLE
CI: Upgrade OpenSSL and LibreSSL versions.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,20 +64,24 @@ jobs:
         os: [ ubuntu-latest ]
         ruby: [ "3.0" ]
         openssl:
+          # https://www.openssl.org/source/
           - openssl-1.0.2u # EOL
           - openssl-1.1.0l # EOL
-          - openssl-1.1.1t
-          - openssl-3.0.8
+          - openssl-1.1.1u
+          - openssl-3.0.9
+          - openssl-3.1.1
+          # http://www.libressl.org/releases.html
           - libressl-3.1.5 # EOL
           - libressl-3.2.7 # EOL
           - libressl-3.3.6 # EOL
           - libressl-3.4.3 # EOL
-          - libressl-3.5.3
-          - libressl-3.6.1
-          - libressl-3.7.0 # Development release
+          - libressl-3.5.3 # EOL
+          - libressl-3.6.3
+          - libressl-3.7.3
+          - libressl-3.8.0 # Development release
         fips-enabled: [ false ]
         include:
-          - { os: ubuntu-latest, ruby: "3.0", openssl: openssl-3.0.8, fips-enabled: true, append-configure: 'enable-fips', name-extra: 'fips' }
+          - { os: ubuntu-latest, ruby: "3.0", openssl: openssl-3.0.9, fips-enabled: true, append-configure: 'enable-fips', name-extra: 'fips' }
     steps:
       - name: repo checkout
         uses: actions/checkout@v3

--- a/test/openssl/test_bn.rb
+++ b/test/openssl/test_bn.rb
@@ -175,7 +175,9 @@ class OpenSSL::TestBN < OpenSSL::TestCase
   end
 
   def test_mod_sqrt
-    assert_equal(3, 4.to_bn.mod_sqrt(5))
+    assert_equal(4, 4.to_bn.mod_sqrt(5).mod_sqr(5))
+    # One of 189484 or 326277 is returned as a square root of 2 (mod 515761).
+    assert_equal(2, 2.to_bn.mod_sqrt(515761).mod_sqr(515761))
     assert_equal(0, 5.to_bn.mod_sqrt(5))
     assert_raise(OpenSSL::BNError) { 3.to_bn.mod_sqrt(5) }
   end


### PR DESCRIPTION
This PR has 2 commits. The first commit is to upgrade OpenSSL and LibreSSL versions to the latest versions. And the second commit is the cherry-pick from <https://github.com/ruby/openssl/pull/614> (thanks!). I am not sure that now is a good to upgrade the versions in the CI.

For the first commit, I have a question. How did you know the LibreSSL versions that are End of Life (EOL)? The latest release of the LibreSSL is for LibreSSL 3.8, 3.7 and 3.6. So, I assumed that Libre 3.5 is EOL now. Is that correct?

http://www.libressl.org/releases.html
> LibreSSL 3.8.0, 3.7.3, 3.6.3 (May 27th, 2023)

I added the URLs to check the OpenSSL and LibreSSL to the comments in the CI YAML file to make this regular task to upgrade the versions easy.

https://www.openssl.org/source/
http://www.libressl.org/releases.html

