### PR TITLE
Drop support for Ruby 2.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     uses: ruby/actions/.github/workflows/ruby_versions.yml@master
     with:
       engine: cruby-truffleruby
-      min_version: 2.6
+      min_version: 2.7
   test:
     needs: ruby-versions
     name: >-

--- a/ext/openssl/ossl.c
+++ b/ext/openssl/ossl.c
@@ -369,22 +369,6 @@ ossl_get_errors(VALUE _)
  */
 VALUE dOSSL;
 
-#if !defined(HAVE_VA_ARGS_MACRO)
-void
-ossl_debug(const char *fmt, ...)
-{
-    va_list args;
-
-    if (dOSSL == Qtrue) {
-	fprintf(stderr, "OSSL_DEBUG: ");
-	va_start(args, fmt);
-	vfprintf(stderr, fmt, args);
-	va_end(args);
-	fprintf(stderr, " [CONTEXT N/A]\n");
-    }
-}
-#endif
-
 /*
  * call-seq:
  *   OpenSSL.debug -> true | false

--- a/ext/openssl/ossl.h
+++ b/ext/openssl/ossl.h
@@ -157,7 +157,6 @@ VALUE ossl_to_der_if_possible(VALUE);
  */
 extern VALUE dOSSL;
 
-#if defined(HAVE_VA_ARGS_MACRO)
 #define OSSL_Debug(...) do { \
   if (dOSSL == Qtrue) { \
     fprintf(stderr, "OSSL_DEBUG: "); \
@@ -165,11 +164,6 @@ extern VALUE dOSSL;
     fprintf(stderr, " [%s:%d]\n", __FILE__, __LINE__); \
   } \
 } while (0)
-
-#else
-void ossl_debug(const char *, ...);
-#define OSSL_Debug ossl_debug
-#endif
 
 /*
  * Include all parts

--- a/openssl.gemspec
+++ b/openssl.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.extra_rdoc_files = Dir["*.md"]
   spec.rdoc_options = ["--main", "README.md"]
 
-  spec.required_ruby_version = ">= 2.6.0"
+  spec.required_ruby_version = ">= 2.7.0"
 
   spec.metadata["msys2_mingw_dependencies"] = "openssl"
 end


### PR DESCRIPTION
Ruby 2.6 has reached EOL on 2022-03. Requiring Ruby 2.7 allows us to use C99 syntax.

ref: https://github.com/ruby/openssl/pull/631