### PR TITLE
CI: Fix a typo in the comment. [ci skip]

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -130,7 +130,7 @@ jobs:
         run: echo "OPENSSL_CONF=$(pwd)/test/openssl/fixtures/ssl/openssl_fips.cnf" >> $GITHUB_ENV
         if: matrix.fips-enabled
 
-      - name: set fips enviornment variable for testing.
+      - name: set fips environment variable for testing.
         run: echo "TEST_RUBY_OPENSSL_FIPS_ENABLED=true" >> $GITHUB_ENV
         if: matrix.fips-enabled
 


### PR DESCRIPTION
This typo was found in the https://github.com/ruby/openssl/pull/635#issuecomment-1586548069 .