### PR TITLE
Include "additional data" message in OpenSSL errors

### DIFF
--- a/test/openssl/test_config.rb
+++ b/test/openssl/test_config.rb
@@ -91,22 +91,19 @@ __EOC__
     assert_equal('123baz456bar798', c['dollar']['qux'])
     assert_equal('123baz456bar798.123baz456bar798', c['dollar']['quxx'])
 
-    excn = assert_raise(OpenSSL::ConfigError) do
+    assert_raise_with_message(OpenSSL::ConfigError, /error in line 1: variable has no value/) do
       OpenSSL::Config.parse("foo = $bar")
     end
-    assert_equal("error in line 1: variable has no value", excn.message)
 
-    excn = assert_raise(OpenSSL::ConfigError) do
+    assert_raise_with_message(OpenSSL::ConfigError, /error in line 1: no close brace/) do
       OpenSSL::Config.parse("foo = $(bar")
     end
-    assert_equal("error in line 1: no close brace", excn.message)
 
-    excn = assert_raise(OpenSSL::ConfigError) do
+    assert_raise_with_message(OpenSSL::ConfigError, /error in line 1: missing equal sign/) do
       OpenSSL::Config.parse("f o =b  ar      # no space in key")
     end
-    assert_equal("error in line 1: missing equal sign", excn.message)
 
-    excn = assert_raise(OpenSSL::ConfigError) do
+    assert_raise_with_message(OpenSSL::ConfigError, /error in line 7: missing close square bracket/) do
       OpenSSL::Config.parse(<<__EOC__)
 # comment 1               # comments
 
@@ -117,7 +114,6 @@ __EOC__
 [third                    # section not terminated
 __EOC__
     end
-    assert_equal("error in line 7: missing close square bracket", excn.message)
   end
 
   def test_s_parse_include

--- a/test/openssl/test_ossl.rb
+++ b/test/openssl/test_ossl.rb
@@ -60,6 +60,18 @@ class OpenSSL::OSSL < OpenSSL::SSLTestCase
     assert_operator(a_b_time, :<, a_c_time * 10, "fixed_length_secure_compare timing test failed")
     assert_operator(a_c_time, :<, a_b_time * 10, "fixed_length_secure_compare timing test failed")
   end
+
+  def test_error_data
+    # X509V3_EXT_nconf_nid() called from OpenSSL::X509::ExtensionFactory#create_ext is a function
+    # that uses ERR_raise_data() to append additional information about the error.
+    #
+    # The generated message should look like:
+    #     "subjectAltName = IP:not.a.valid.ip.address: bad ip address (value=not.a.valid.ip.address)"
+    ef = OpenSSL::X509::ExtensionFactory.new
+    assert_raise_with_message(OpenSSL::X509::ExtensionError, /\(value=not.a.valid.ip.address\)/) {
+      ef.create_ext("subjectAltName", "IP:not.a.valid.ip.address")
+    }
+  end
 end
 
 end


### PR DESCRIPTION
Error entries in the OpenSSL error queue may contain additional contextual information associated with the error, which can be helpful when debugging.

This "additional data" is currently only printed to stderr when OpenSSL.debug is enabled. Let's include this in the exception messages raised with ossl_raise(), too.

	$ ruby -Ilib -ropenssl -e'OpenSSL.debug=true; OpenSSL::SSL::SSLContext.new.ecdh_curves="P-256:not-a-curve"'
	-e:1: warning: error on stack: error:0A080106:SSL routines:gid_cb:passed invalid argument (group 'not-a-curve' cannot be set)
	-e:1:in `ecdh_curves=': passed invalid argument (group 'not-a-curve' cannot be set) (OpenSSL::SSL::SSLError)
		from -e:1:in `<main>'
