### PR TITLE
CI: A temporary workaround to pass the macos-latest trufferuby-head case.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,12 @@ jobs:
         run:  echo "RUBY_OPENSSL_EXTCFLAGS=-Werror" >> $GITHUB_ENV
         if: ${{ !matrix.skip-warnings }}
 
+      # A temporary workaround to pass the CI case.
+      # https://github.com/ruby/openssl/issues/650
+      - name: remove openssl 3 include directory
+        run:  rm -rfv "$(brew --prefix openssl@3)/include"
+        if: matrix.os == 'macos-latest' && matrix.ruby == 'truffleruby-head'
+
       # Enable provider search path for OpenSSL 3.0 in MSYS2.
       # Remove when Ruby 3.2 build is updated
       - name: enable windows provider search path


### PR DESCRIPTION
This PR is a workaround for the https://github.com/ruby/openssl/issues/650. It seems that the setting of the `openssl@3`'s include directory is unintentionally added to the compiler argument `-I<include dir>`. And that causes the compiler error in the process of the Ruby OpenSSL binding.

---

Remove openssl@3 brew package's include directory as a temporary workaround to avoid an error by the -Wmacro-redefined compiler warning in the process of compiling the Ruby OpenSSL binding in the macos-latest trufferuby-head CI case.