### PR TITLE
CI: Add OpenSSL 3.1 FIPS case.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,6 +92,7 @@ jobs:
         fips-enabled: [ false ]
         include:
           - { os: ubuntu-latest, ruby: "3.0", openssl: openssl-3.0.9, fips-enabled: true, append-configure: 'enable-fips', name-extra: 'fips' }
+          - { os: ubuntu-latest, ruby: "3.0", openssl: openssl-3.1.1, fips-enabled: true, append-configure: 'enable-fips', name-extra: 'fips' }
     steps:
       - name: repo checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
I would like to add OpenSSL 3.1 FIPS case to the CI. In some cases, a behavior between OpenSSL 3.1 FIPS and 3.0 FIPS is different.

For example the crypto ed25519 is not allowed by the `FIPS_UNAPPROVED_PROPERTIES` in OpenSSL 3.1 FIPS according to the head of the `openssl-3.1` branch.

```
$ grep PROV_NAMES_ED25519 providers/fips/fipsprov.c
    { PROV_NAMES_ED25519, FIPS_UNAPPROVED_PROPERTIES,
    { PROV_NAMES_ED25519, FIPS_UNAPPROVED_PROPERTIES, ossl_ed25519_keymgmt_functions,
```

But the crypto ed25519 is allowed by the `FIPS_DEFAULT_PROPERTIES` in the OpenSSL 3.0 FIPS according to the head of the `openssl-3.0` branch.

```
$ grep PROV_NAMES_ED25519 providers/fips/fipsprov.c
    { PROV_NAMES_ED25519, FIPS_DEFAULT_PROPERTIES, ossl_ed25519_signature_functions },
    { PROV_NAMES_ED25519, FIPS_DEFAULT_PROPERTIES, ossl_ed25519_keymgmt_functions,
```
