### PR TITLE
CI: Upgrade OpenSSL versions.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,9 +77,9 @@ jobs:
           # https://www.openssl.org/source/
           - openssl-1.0.2u # EOL
           - openssl-1.1.0l # EOL
-          - openssl-1.1.1u
-          - openssl-3.0.9
-          - openssl-3.1.1
+          - openssl-1.1.1v
+          - openssl-3.0.10
+          - openssl-3.1.2
           # http://www.libressl.org/releases.html
           - libressl-3.1.5 # EOL
           - libressl-3.2.7 # EOL
@@ -91,8 +91,8 @@ jobs:
           - libressl-3.8.0 # Development release
         fips-enabled: [ false ]
         include:
-          - { os: ubuntu-latest, ruby: "3.0", openssl: openssl-3.0.9, fips-enabled: true, append-configure: 'enable-fips', name-extra: 'fips' }
-          - { os: ubuntu-latest, ruby: "3.0", openssl: openssl-3.1.1, fips-enabled: true, append-configure: 'enable-fips', name-extra: 'fips' }
+          - { os: ubuntu-latest, ruby: "3.0", openssl: openssl-3.0.10, fips-enabled: true, append-configure: 'enable-fips', name-extra: 'fips' }
+          - { os: ubuntu-latest, ruby: "3.0", openssl: openssl-3.1.2, fips-enabled: true, append-configure: 'enable-fips', name-extra: 'fips' }
     steps:
       - name: repo checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
OpenSSL new versions were released for OpenSSL 3.1, 3.0 and 1.1.1.
https://www.openssl.org/source/

