### PR TITLE
CI: Add OpenSSL master branch head non-FIPS and FIPS cases.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,17 +93,28 @@ jobs:
         include:
           - { os: ubuntu-latest, ruby: "3.0", openssl: openssl-3.0.10, fips-enabled: true, append-configure: 'enable-fips', name-extra: 'fips' }
           - { os: ubuntu-latest, ruby: "3.0", openssl: openssl-3.1.2, fips-enabled: true, append-configure: 'enable-fips', name-extra: 'fips' }
+          - { os: ubuntu-latest, ruby: "3.0", openssl: openssl-head, git: 'git://git.openssl.org/openssl.git', branch: 'master' }
+          - { os: ubuntu-latest, ruby: "3.0", openssl: openssl-head, git: 'git://git.openssl.org/openssl.git', branch: 'master', fips-enabled: true, append-configure: 'enable-fips', name-extra: 'fips' }
     steps:
       - name: repo checkout
         uses: actions/checkout@v3
 
       - name: prepare openssl
         run: |
+          # Enable Bash debugging option temporarily for debugging use.
+          set -x
           mkdir -p tmp/build-openssl && cd tmp/build-openssl
           case ${{ matrix.openssl }} in
           openssl-*)
-            curl -OL https://ftp.openssl.org/source/${{ matrix.openssl }}.tar.gz
-            tar xf ${{ matrix.openssl }}.tar.gz && cd ${{ matrix.openssl }}
+            if [ -z "${{ matrix.git }}" ]; then
+              curl -OL https://ftp.openssl.org/source/${{ matrix.openssl }}.tar.gz
+              tar xf ${{ matrix.openssl }}.tar.gz && cd ${{ matrix.openssl }}
+            else
+              git clone -b ${{ matrix.branch }} --depth 1 ${{ matrix.git }} ${{ matrix.openssl }}
+              cd ${{ matrix.openssl }}
+              # Log the commit hash.
+              echo "Git commit: $(git rev-parse HEAD)"
+            fi
             # shared is required for 1.0.x.
             ./Configure --prefix=$HOME/.openssl/${{ matrix.openssl }} --libdir=lib \
                 shared linux-x86_64 ${{ matrix.append-configure }}


### PR DESCRIPTION
This PR is to add the cases to test Ruby OpenSSL binding (ruby/openssl) on OpenSSL master branch non-FIPS and FIPS cases.

## Motivation

My motivation for this PR is that we can immediately test Ruby OpenSSL binding with the OpenSSL where a PR to fix the issues related to our unit test was merged. There is a time lag until the next OpenSSL stable version including the fixes.

I reported one issue https://github.com/openssl/openssl/issues/21493 that caused some test failures in our unit test in FIPS case to the OpenSSL project (openssl/openssl), and the PR https://github.com/openssl/openssl/pull/21519#issuecomment-1665686153 fixing the issue was merged to the `master` branch (openssl-3.2.0-dev), (and `openssl-3.1` and `openssl-3.0` branches too) recently. Adding these CI cases by this PR, I can check the Ruby OpenSSL binding's unit tests on the fixed versions of the OpenSSL.

## Description

I added an option to download OpenSSL from their Git repository. I added the `set -x` to enable Bash debugging option and `set +x` to disable Bash debugging option. Because it was convenient to debug the bash script error, and it is convenient to check which commands are actually executed in the CI log.


