### PR TITLE
Enhance printing OpenSSL versions.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -38,7 +38,18 @@ task :debug_compiler do
 end
 
 task :debug do
-  ruby "-I./lib -ropenssl -ve'puts OpenSSL::OPENSSL_VERSION, OpenSSL::OPENSSL_LIBRARY_VERSION'"
+  ruby_code = <<~'EOF'
+    openssl_version_number_str = OpenSSL::OPENSSL_VERSION_NUMBER.to_s(16)
+    libressl_version_number_str = (defined? OpenSSL::LIBRESSL_VERSION_NUMBER) ?
+      OpenSSL::LIBRESSL_VERSION_NUMBER.to_s(16) : "undefined"
+    puts <<~MESSAGE
+      OpenSSL::OPENSSL_VERSION: #{OpenSSL::OPENSSL_VERSION}
+      OpenSSL::OPENSSL_LIBRARY_VERSION: #{OpenSSL::OPENSSL_LIBRARY_VERSION}
+      OpenSSL::OPENSSL_VERSION_NUMBER: #{openssl_version_number_str}
+      OpenSSL::LIBRESSL_VERSION_NUMBER: #{libressl_version_number_str}
+    MESSAGE
+  EOF
+  ruby %Q(-I./lib -ropenssl -ve'#{ruby_code}')
 end
 
 task :default => :test

--- a/ext/openssl/ossl.c
+++ b/ext/openssl/ossl.c
@@ -1149,9 +1149,26 @@ Init_openssl(void)
 
     /*
      * Version number of OpenSSL the ruby OpenSSL extension was built with
-     * (base 16)
+     * (base 16). The formats are below.
+     *
+     * [OpenSSL 3] <tt>0xMNN00PP0 (major minor 00 patch 0)</tt>
+     * [OpenSSL before 3] <tt>0xMNNFFPPS (major minor fix patch status)</tt>
+     * [LibreSSL] <tt>0x20000000 (fixed value)</tt>
+     *
+     * See also the man page OPENSSL_VERSION_NUMBER(3).
      */
     rb_define_const(mOSSL, "OPENSSL_VERSION_NUMBER", INT2NUM(OPENSSL_VERSION_NUMBER));
+
+#if defined(LIBRESSL_VERSION_NUMBER)
+    /*
+     * Version number of LibreSSL the ruby OpenSSL extension was built with
+     * (base 16). The format is <tt>0xMNNFFPPS (major minor fix patch
+     * status)</tt>. This constant is only defined in LibreSSL cases.
+     *
+     * See also the man page OPENSSL_VERSION_NUMBER(3).
+     */
+    rb_define_const(mOSSL, "LIBRESSL_VERSION_NUMBER", INT2NUM(LIBRESSL_VERSION_NUMBER));
+#endif
 
     /*
      * Boolean indicating whether OpenSSL is FIPS-capable or not


### PR DESCRIPTION
This PR is to enhance the feature of printing OpenSSL versions. This is useful when running tests conditionally depending on OpenSSL and LibreSSL versions. In my case, it was useful to fix pending tests in FIPS case. See my working branch [wip/fip-test-debug commits](
https://github.com/junaruga/openssl/commits/wip/fip-test-debug) to fix pending tests. The last 4 commits are mine. And the 3rd newest commit is the same with this PR's commit.

For the `OPENSSL_VERSION_NUMBER` format, the [OPENSSL_VERSION_NUMBER(3)](https://www.openssl.org/docs/manmaster/man3/OPENSSL_VERSION_NUMBER.html) documents were helpful for me. You can check each OpenSSL version's format by clicking the master, 3.1, 3.0, 1.1.1, 1.0.2 links. For adding the `OpenSSL::LIBRESSL_VERSION_NUMBER`, perhaps it is controversial. Because the `test/openssl/utils.rb#libressl?` doesn't depending on the `LIBRESSL_VERSION_NUMBER`. But I thought it was useful to debug C files.

---

* Updated the `OpenSSL::OPENSSL_VERSION_NUMBER` comment explaining the format.
* Added the `OpenSSL::LIBRESSL_VERSION_NUMBER`. It's useful to debug the C language code. Note `test/openssl/utils.rb#libressl?` is not using this value.
* Update `rake debug` to print `OpenSSL::OPENSSL_VERSION_NUMBER` and `OpenSSL::LIBRESSL_VERSION_NUMBER.`