### PR TITLE
Use openssl? instead of OpenSSL::OPENSSL_VERSION_NUMBER.

### DIFF
--- a/test/openssl/test_cipher.rb
+++ b/test/openssl/test_cipher.rb
@@ -205,7 +205,7 @@ class OpenSSL::TestCipher < OpenSSL::TestCase
     assert_raise(OpenSSL::Cipher::CipherError) { cipher.update(ct2) }
   end if has_cipher?("aes-128-ccm") &&
          OpenSSL::Cipher.new("aes-128-ccm").authenticated? &&
-         OpenSSL::OPENSSL_VERSION_NUMBER >= 0x1010103f # version >= 1.1.1c
+         openssl?(1, 1, 1, 0x03, 0xf) # version >= 1.1.1c
 
   def test_aes_gcm
     # GCM spec Appendix B Test Case 4

--- a/test/openssl/test_pkey.rb
+++ b/test/openssl/test_pkey.rb
@@ -188,7 +188,7 @@ class OpenSSL::TestPKey < OpenSSL::PKeyTestCase
   end
 
   def raw_initialize
-    pend "Ed25519 is not implemented" unless OpenSSL::OPENSSL_VERSION_NUMBER >= 0x10101000 && # >= v1.1.1
+    pend "Ed25519 is not implemented" unless openssl?(1, 1, 1) # >= v1.1.1
 
     assert_raise(OpenSSL::PKey::PKeyError) { OpenSSL::PKey.new_raw_private_key("foo123", "xxx") }
     assert_raise(OpenSSL::PKey::PKeyError) { OpenSSL::PKey.new_raw_private_key("ED25519", "xxx") }

--- a/test/openssl/utils.rb
+++ b/test/openssl/utils.rb
@@ -131,11 +131,12 @@ module OpenSSL::TestUtils
     end
   end
 
-  def openssl?(major = nil, minor = nil, fix = nil, patch = 0)
+  def openssl?(major = nil, minor = nil, fix = nil, patch = 0, status = 0)
     return false if OpenSSL::OPENSSL_VERSION.include?("LibreSSL")
     return true unless major
     OpenSSL::OPENSSL_VERSION_NUMBER >=
-      major * 0x10000000 + minor * 0x100000 + fix * 0x1000 + patch * 0x10
+      major * 0x10000000 + minor * 0x100000 + fix * 0x1000 + patch * 0x10 +
+      status * 0x1
   end
 
   def libressl?(major = nil, minor = nil, fix = nil)


### PR DESCRIPTION
This PR is just for refactoring to use the common method `test/openssl/utils.rb#openssl?` instead of using the `OpenSSL::OPENSSL_VERSION_NUMBER` directly.