### PR TITLE
test/openssl/test_pkey.rb: Fix pending tests in FIPS case.

### DIFF
--- a/test/openssl/test_pkey.rb
+++ b/test/openssl/test_pkey.rb
@@ -82,8 +82,7 @@ class OpenSSL::TestPKey < OpenSSL::PKeyTestCase
   end
 
   def test_ed25519
-    # https://github.com/openssl/openssl/issues/20758
-    pend('Not supported on FIPS mode enabled') if OpenSSL.fips_mode
+    pend_on_openssl_issue_21493
 
     # Test vector from RFC 8032 Section 7.1 TEST 2
     priv_pem = <<~EOF
@@ -101,7 +100,13 @@ class OpenSSL::TestPKey < OpenSSL::PKeyTestCase
       pub = OpenSSL::PKey.read(pub_pem)
     rescue OpenSSL::PKey::PKeyError
       # OpenSSL < 1.1.1
-      pend "Ed25519 is not implemented"
+      if !openssl?(1, 1, 1)
+        pend "Ed25519 is not implemented"
+      elsif OpenSSL.fips_mode && openssl?(3, 1, 0, 0)
+        # See OpenSSL providers/fips/fipsprov.c PROV_NAMES_ED25519 entries
+        # with FIPS_UNAPPROVED_PROPERTIES in OpenSSL 3.1+.
+        pend "Ed25519 is not approved in OpenSSL 3.1+ FIPS code"
+      end
     end
     assert_instance_of OpenSSL::PKey::PKey, priv
     assert_instance_of OpenSSL::PKey::PKey, pub
@@ -143,7 +148,7 @@ class OpenSSL::TestPKey < OpenSSL::PKeyTestCase
   end
 
   def test_x25519
-    pend('Not supported on FIPS mode enabled') if OpenSSL.fips_mode
+    pend_on_openssl_issue_21493
 
     # Test vector from RFC 7748 Section 6.1
     alice_pem = <<~EOF
@@ -197,7 +202,7 @@ class OpenSSL::TestPKey < OpenSSL::PKeyTestCase
   end
 
   def test_compare?
-    pend('Not supported on FIPS mode enabled') if OpenSSL.fips_mode
+    pend_on_openssl_issue_21493
 
     key1 = Fixtures.pkey("rsa1024")
     key2 = Fixtures.pkey("rsa1024")

--- a/test/openssl/utils.rb
+++ b/test/openssl/utils.rb
@@ -143,6 +143,22 @@ module OpenSSL::TestUtils
     return false unless version
     !major || (version.map(&:to_i) <=> [major, minor, fix]) >= 0
   end
+
+  # OpenSSL 3: x25519 a decode from and then encode to a pem file corrupts the
+  # key if fips+base provider is used
+  # This issue happens in OpenSSL between 3.0,0 and 3.0.10 or between 3.1.0 and
+  # 3.1.2.
+  # https://github.com/openssl/openssl/issues/21493
+  # https://github.com/openssl/openssl/pull/21519
+  def pend_on_openssl_issue_21493
+    if OpenSSL.fips_mode &&
+      (
+        (openssl?(3, 0, 0, 0) && !openssl?(3, 0, 0, 11)) ||
+        (openssl?(3, 1, 0, 0) && !openssl?(3, 1, 0, 3))
+      )
+      pend('See <https://github.com/openssl/openssl/issues/21493>')
+    end
+  end
 end
 
 class OpenSSL::TestCase < Test::Unit::TestCase


### PR DESCRIPTION
This PR is to run the previously pended tests by the issues (https://github.com/openssl/openssl/issues/21493 and https://github.com/openssl/openssl/issues/20758) conditionally on OpenSSL versions including the fixes in FIPS case. The fixes were merged to the OpenSSL (openssl/openssl) master, openssl-3.1, and openssl-3.0 branches. See [this](https://github.com/openssl/openssl/pull/21519#issuecomment-1665686153). So, the coming stable versions should pass the tests.

