### PR TITLE
Rakefile: Print FIPS information in the `rake debug`.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -180,6 +180,7 @@ jobs:
       # TODO Fix other tests, and run all the tests on FIPS mode.
       - name: test on fips mode
         run:  |
-          ruby -I./lib -ropenssl \
+          bundle exec rake debug &&
+            ruby -I./lib -ropenssl \
             -e 'Dir.glob "./test/openssl/{test_fips.rb,test_pkey.rb}", &method(:require)'
         if: matrix.fips-enabled

--- a/Rakefile
+++ b/Rakefile
@@ -42,11 +42,15 @@ task :debug do
     openssl_version_number_str = OpenSSL::OPENSSL_VERSION_NUMBER.to_s(16)
     libressl_version_number_str = (defined? OpenSSL::LIBRESSL_VERSION_NUMBER) ?
       OpenSSL::LIBRESSL_VERSION_NUMBER.to_s(16) : "undefined"
+    providers_str = (defined? OpenSSL::Provider) ?
+      OpenSSL::Provider.provider_names.join(", ") : "undefined"
     puts <<~MESSAGE
       OpenSSL::OPENSSL_VERSION: #{OpenSSL::OPENSSL_VERSION}
       OpenSSL::OPENSSL_LIBRARY_VERSION: #{OpenSSL::OPENSSL_LIBRARY_VERSION}
       OpenSSL::OPENSSL_VERSION_NUMBER: #{openssl_version_number_str}
       OpenSSL::LIBRESSL_VERSION_NUMBER: #{libressl_version_number_str}
+      FIPS enabled: #{OpenSSL.fips_mode}
+      Providers: #{providers_str}
     MESSAGE
   EOF
   ruby %Q(-I./lib -ropenssl -ve'#{ruby_code}')


### PR DESCRIPTION
I would like to add FIPS information to the `rake debug`. It is convenient to check if Ruby OpenSSL binding is running with the OpenSSL with a proper FIPS configuration properly. I need to install many OpenSSL versions or specific commit versions with the FIPS configuration file to debug or fix a FIPS related issue.

---

Add FIPS information (FIPS enabled, and providers) to the `rake debug` task, and run the `rake debug` in FIPS case to check if OpenSSL is running in FIPS.
