### PR TITLE
Fix LIBRESSL_VERSION_NUMBER document mistake.

### DIFF
--- a/ext/openssl/ossl.c
+++ b/ext/openssl/ossl.c
@@ -1165,10 +1165,10 @@ Init_openssl(void)
 #if defined(LIBRESSL_VERSION_NUMBER)
     /*
      * Version number of LibreSSL the ruby OpenSSL extension was built with
-     * (base 16). The format is <tt>0xMNNFFPPS (major minor fix patch
+     * (base 16). The format is <tt>0xMNNFF00f (major minor fix 00
      * status)</tt>. This constant is only defined in LibreSSL cases.
      *
-     * See also the man page OPENSSL_VERSION_NUMBER(3).
+     * See also the man page LIBRESSL_VERSION_NUMBER(3).
      */
     rb_define_const(mOSSL, "LIBRESSL_VERSION_NUMBER", INT2NUM(LIBRESSL_VERSION_NUMBER));
 #endif


### PR DESCRIPTION
This PR improves and fixes typo created by the PR https://github.com/ruby/openssl/pull/662. Sorry! I checked the generated rdoc on local.

Note that here is the actual man content.

```
$ man -M /home/jaruga/.local/libressl-6650dce/share/man/ 3 LIBRESSL_VERSION_NUMBER
...
DESCRIPTION
     OPENSSL_VERSION_NUMBER and LIBRESSL_VERSION_NUMBER are numeric release version
     identifiers.  The first two digits contain the major release number, the third and
     fourth digits the minor release number, and the fifth and sixth digits the fix re‐
     lease number.  For OpenSSL, the seventh and eight digits contain the patch release
     number and the final digit is 0 for development, 1 to e for betas 1 to 14, or f
     for release.  For LibreSSL, OPENSSL_VERSION_NUMBER is always 0x020000000, and
     LIBRESSL_VERSION_NUMBER always ends with 00f.
...
     LIBRESSL_VERSION_NUMBER first appeared in LibreSSL 2.0.0 and OpenBSD 5.6 and got
     its final format in LibreSSL 2.3.2 and OpenBSD 5.9.  LIBRESSL_VERSION_TEXT first
     appeared in LibreSSL 2.2.2 and OpenBSD 5.8.
```

---

* Fix the wrong man reference.
* According to the LIBRESSL_VERSION_NUMBER(3), the value always ends with 00f.
