### PR TITLE
Add the 4th argument to the OSSL_OPENSSL_PREREQ macro.

### DIFF
--- a/ext/openssl/ossl.c
+++ b/ext/openssl/ossl.c
@@ -407,7 +407,7 @@ static VALUE
 ossl_fips_mode_get(VALUE self)
 {
 
-#if OSSL_OPENSSL_PREREQ(3, 0, 0)
+#if OSSL_OPENSSL_PREREQ(3, 0, 0, 0)
     VALUE enabled;
     enabled = EVP_default_properties_is_fips_enabled(NULL) ? Qtrue : Qfalse;
     return enabled;
@@ -435,7 +435,7 @@ ossl_fips_mode_get(VALUE self)
 static VALUE
 ossl_fips_mode_set(VALUE self, VALUE enabled)
 {
-#if OSSL_OPENSSL_PREREQ(3, 0, 0)
+#if OSSL_OPENSSL_PREREQ(3, 0, 0, 0)
     if (RTEST(enabled)) {
         if (!EVP_default_properties_enable_fips(NULL, 1)) {
             ossl_raise(eOSSLError, "Turning on FIPS mode failed");
@@ -1178,7 +1178,7 @@ Init_openssl(void)
      */
     rb_define_const(mOSSL, "OPENSSL_FIPS",
 /* OpenSSL 3 is FIPS-capable even when it is installed without fips option */
-#if OSSL_OPENSSL_PREREQ(3, 0, 0)
+#if OSSL_OPENSSL_PREREQ(3, 0, 0, 0)
                     Qtrue
 #elif defined(OPENSSL_FIPS)
 		    Qtrue

--- a/ext/openssl/ossl.h
+++ b/ext/openssl/ossl.h
@@ -42,27 +42,28 @@
 
 #ifndef LIBRESSL_VERSION_NUMBER
 # define OSSL_IS_LIBRESSL 0
-# define OSSL_OPENSSL_PREREQ(maj, min, pat) \
-      (OPENSSL_VERSION_NUMBER >= ((maj << 28) | (min << 20) | (pat << 12)))
-# define OSSL_LIBRESSL_PREREQ(maj, min, pat) 0
+# define OSSL_OPENSSL_PREREQ(maj, min, fix, pat) \
+      (OPENSSL_VERSION_NUMBER >= ((maj << 28) | (min << 20) | (fix << 12) | \
+      (pat << 4)))
+# define OSSL_LIBRESSL_PREREQ(maj, min, fix) 0
 #else
 # define OSSL_IS_LIBRESSL 1
-# define OSSL_OPENSSL_PREREQ(maj, min, pat) 0
-# define OSSL_LIBRESSL_PREREQ(maj, min, pat) \
-      (LIBRESSL_VERSION_NUMBER >= ((maj << 28) | (min << 20) | (pat << 12)))
+# define OSSL_OPENSSL_PREREQ(maj, min, fix, pat) 0
+# define OSSL_LIBRESSL_PREREQ(maj, min, fix) \
+      (LIBRESSL_VERSION_NUMBER >= ((maj << 28) | (min << 20) | (fix << 12)))
 #endif
 
-#if OSSL_OPENSSL_PREREQ(3, 0, 0)
+#if OSSL_OPENSSL_PREREQ(3, 0, 0, 0)
 # define OSSL_3_const const
 #else
 # define OSSL_3_const /* const */
 #endif
 
-#if !defined(OPENSSL_NO_ENGINE) && !OSSL_OPENSSL_PREREQ(3, 0, 0)
+#if !defined(OPENSSL_NO_ENGINE) && !OSSL_OPENSSL_PREREQ(3, 0, 0, 0)
 # define OSSL_USE_ENGINE
 #endif
 
-#if OSSL_OPENSSL_PREREQ(3, 0, 0)
+#if OSSL_OPENSSL_PREREQ(3, 0, 0, 0)
 # define OSSL_USE_PROVIDER
 #endif
 

--- a/ext/openssl/ossl_kdf.c
+++ b/ext/openssl/ossl_kdf.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2007, 2017 Ruby/OpenSSL Project Authors
  */
 #include "ossl.h"
-#if OSSL_OPENSSL_PREREQ(1, 1, 0) || OSSL_LIBRESSL_PREREQ(3, 6, 0)
+#if OSSL_OPENSSL_PREREQ(1, 1, 0, 0) || OSSL_LIBRESSL_PREREQ(3, 6, 0)
 # include <openssl/kdf.h>
 #endif
 
@@ -141,7 +141,7 @@ kdf_scrypt(int argc, VALUE *argv, VALUE self)
 }
 #endif
 
-#if OSSL_OPENSSL_PREREQ(1, 1, 0) || OSSL_LIBRESSL_PREREQ(3, 6, 0)
+#if OSSL_OPENSSL_PREREQ(1, 1, 0, 0) || OSSL_LIBRESSL_PREREQ(3, 6, 0)
 /*
  * call-seq:
  *    KDF.hkdf(ikm, salt:, info:, length:, hash:) -> String
@@ -305,7 +305,7 @@ Init_ossl_kdf(void)
 #if defined(HAVE_EVP_PBE_SCRYPT)
     rb_define_module_function(mKDF, "scrypt", kdf_scrypt, -1);
 #endif
-#if OSSL_OPENSSL_PREREQ(1, 1, 0) || OSSL_LIBRESSL_PREREQ(3, 6, 0)
+#if OSSL_OPENSSL_PREREQ(1, 1, 0, 0) || OSSL_LIBRESSL_PREREQ(3, 6, 0)
     rb_define_module_function(mKDF, "hkdf", kdf_hkdf, -1);
 #endif
 }

--- a/ext/openssl/ossl_pkey.c
+++ b/ext/openssl/ossl_pkey.c
@@ -79,7 +79,7 @@ ossl_pkey_new(EVP_PKEY *pkey)
     return obj;
 }
 
-#if OSSL_OPENSSL_PREREQ(3, 0, 0)
+#if OSSL_OPENSSL_PREREQ(3, 0, 0, 0)
 # include <openssl/decoder.h>
 
 EVP_PKEY *
@@ -372,7 +372,7 @@ pkey_generate(int argc, VALUE *argv, VALUE self, int genparam)
             ossl_raise(ePKeyError, "EVP_PKEY_CTX_new");
     }
     else {
-#if OSSL_OPENSSL_PREREQ(3, 0, 0)
+#if OSSL_OPENSSL_PREREQ(3, 0, 0, 0)
         ctx = EVP_PKEY_CTX_new_from_name(NULL, StringValueCStr(alg), NULL);
         if (!ctx)
             ossl_raise(ePKeyError, "EVP_PKEY_CTX_new_from_name");
@@ -500,7 +500,7 @@ ossl_pkey_s_generate_key(int argc, VALUE *argv, VALUE self)
 void
 ossl_pkey_check_public_key(const EVP_PKEY *pkey)
 {
-#if OSSL_OPENSSL_PREREQ(3, 0, 0)
+#if OSSL_OPENSSL_PREREQ(3, 0, 0, 0)
     if (EVP_PKEY_missing_parameters(pkey))
         ossl_raise(ePKeyError, "parameters missing");
 #else
@@ -792,7 +792,7 @@ ossl_pkey_export_traditional(int argc, VALUE *argv, VALUE self, int to_der)
 	}
     }
     else {
-#if OSSL_OPENSSL_PREREQ(1, 1, 0) || OSSL_LIBRESSL_PREREQ(3, 5, 0)
+#if OSSL_OPENSSL_PREREQ(1, 1, 0, 0) || OSSL_LIBRESSL_PREREQ(3, 5, 0)
 	if (!PEM_write_bio_PrivateKey_traditional(bio, pkey, enc, NULL, 0,
 						  ossl_pem_passwd_cb,
 						  (void *)pass)) {
@@ -1109,7 +1109,7 @@ ossl_pkey_sign(int argc, VALUE *argv, VALUE self)
             rb_jump_tag(state);
         }
     }
-#if OSSL_OPENSSL_PREREQ(1, 1, 1) || OSSL_LIBRESSL_PREREQ(3, 4, 0)
+#if OSSL_OPENSSL_PREREQ(1, 1, 1, 0) || OSSL_LIBRESSL_PREREQ(3, 4, 0)
     if (EVP_DigestSign(ctx, NULL, &siglen, (unsigned char *)RSTRING_PTR(data),
                        RSTRING_LEN(data)) < 1) {
         EVP_MD_CTX_free(ctx);
@@ -1214,7 +1214,7 @@ ossl_pkey_verify(int argc, VALUE *argv, VALUE self)
             rb_jump_tag(state);
         }
     }
-#if OSSL_OPENSSL_PREREQ(1, 1, 1) || OSSL_LIBRESSL_PREREQ(3, 4, 0)
+#if OSSL_OPENSSL_PREREQ(1, 1, 1, 0) || OSSL_LIBRESSL_PREREQ(3, 4, 0)
     ret = EVP_DigestVerify(ctx, (unsigned char *)RSTRING_PTR(sig),
                            RSTRING_LEN(sig), (unsigned char *)RSTRING_PTR(data),
                            RSTRING_LEN(data));

--- a/ext/openssl/ossl_pkey.h
+++ b/ext/openssl/ossl_pkey.h
@@ -116,7 +116,7 @@ static VALUE ossl_##_keytype##_get_##_name(VALUE self)			\
 	OSSL_PKEY_BN_DEF_GETTER0(_keytype, _type, a2,			\
 		_type##_get0_##_group(obj, NULL, &bn))
 
-#if !OSSL_OPENSSL_PREREQ(3, 0, 0)
+#if !OSSL_OPENSSL_PREREQ(3, 0, 0, 0)
 #define OSSL_PKEY_BN_DEF_SETTER3(_keytype, _type, _group, a1, a2, a3)	\
 /*									\
  *  call-seq:								\

--- a/ext/openssl/ossl_pkey_ec.c
+++ b/ext/openssl/ossl_pkey_ec.c
@@ -248,7 +248,7 @@ ossl_ec_key_get_group(VALUE self)
 static VALUE
 ossl_ec_key_set_group(VALUE self, VALUE group_v)
 {
-#if OSSL_OPENSSL_PREREQ(3, 0, 0)
+#if OSSL_OPENSSL_PREREQ(3, 0, 0, 0)
     rb_raise(ePKeyError, "pkeys are immutable on OpenSSL 3.0");
 #else
     EC_KEY *ec;
@@ -290,7 +290,7 @@ static VALUE ossl_ec_key_get_private_key(VALUE self)
  */
 static VALUE ossl_ec_key_set_private_key(VALUE self, VALUE private_key)
 {
-#if OSSL_OPENSSL_PREREQ(3, 0, 0)
+#if OSSL_OPENSSL_PREREQ(3, 0, 0, 0)
     rb_raise(ePKeyError, "pkeys are immutable on OpenSSL 3.0");
 #else
     EC_KEY *ec;
@@ -341,7 +341,7 @@ static VALUE ossl_ec_key_get_public_key(VALUE self)
  */
 static VALUE ossl_ec_key_set_public_key(VALUE self, VALUE public_key)
 {
-#if OSSL_OPENSSL_PREREQ(3, 0, 0)
+#if OSSL_OPENSSL_PREREQ(3, 0, 0, 0)
     rb_raise(ePKeyError, "pkeys are immutable on OpenSSL 3.0");
 #else
     EC_KEY *ec;
@@ -513,7 +513,7 @@ ossl_ec_key_to_der(VALUE self)
  */
 static VALUE ossl_ec_key_generate_key(VALUE self)
 {
-#if OSSL_OPENSSL_PREREQ(3, 0, 0)
+#if OSSL_OPENSSL_PREREQ(3, 0, 0, 0)
     rb_raise(ePKeyError, "pkeys are immutable on OpenSSL 3.0");
 #else
     EC_KEY *ec;
@@ -1367,7 +1367,7 @@ static VALUE ossl_ec_point_make_affine(VALUE self)
     GetECPointGroup(self, group);
 
     rb_warn("OpenSSL::PKey::EC::Point#make_affine! is deprecated");
-#if !OSSL_OPENSSL_PREREQ(3, 0, 0)
+#if !OSSL_OPENSSL_PREREQ(3, 0, 0, 0)
     if (EC_POINT_make_affine(group, point, ossl_bn_ctx) != 1)
         ossl_raise(eEC_POINT, "EC_POINT_make_affine");
 #endif


### PR DESCRIPTION
This PR is to add the 4th argument patch to the `OSSL_OPENSSL_PREREQ`.

Because I want to run for example "OpenSSL version >= 3.1.0, and < 3.1.3" in the C files. And we can write it as `OSSL_OPENSSL_PREREQ(3, 1, 0, 0) && !OSSL_OPENSSL_PREREQ(3, 1, 0, 3)`.

---

To compare with the OpenSSL 3.Y.Z version.

* Change from the `OSSL_OPENSSL_PREREQ(maj, min, pat)` to the `OSSL_OPENSSL_PREREQ(maj, min, fix, pat)`. The third argument is not "patch" but "fix". Add the firth argument "patch". Note below are the `OPENSSL_VERSION_NUMBER` formats.
  * OpenSSL 3: 0xMNN00PP0 (major minor 00 patch 0)
  * OpenSSL before 3: 0xMNNFFPPS (major minor fix patch status)
  * LibreSSL: 0x20000000 (fixed value)
* Change from the `OSSL_OPENSSL_PREREQ(maj, min, pat)` to the `OSSL_OPENSSL_PREREQ(maj, min, fix)`. The third argument is not "patch" but "fix". Note the `LIBRESSL_VERSION_NUMBER` format is 0xMNNFF00f (major minor fix patch status).