### PR TITLE
ssl: use ffdhe2048 from RFC 7919 as the default DH group parameters

### DIFF
--- a/lib/openssl/ssl.rb
+++ b/lib/openssl/ssl.rb
@@ -34,21 +34,21 @@ module OpenSSL
       }
 
       if defined?(OpenSSL::PKey::DH)
-        DEFAULT_2048 = OpenSSL::PKey::DH.new <<-_end_of_pem_
+        DH_ffdhe2048 = OpenSSL::PKey::DH.new <<-_end_of_pem_
 -----BEGIN DH PARAMETERS-----
-MIIBCAKCAQEA7E6kBrYiyvmKAMzQ7i8WvwVk9Y/+f8S7sCTN712KkK3cqd1jhJDY
-JbrYeNV3kUIKhPxWHhObHKpD1R84UpL+s2b55+iMd6GmL7OYmNIT/FccKhTcveab
-VBmZT86BZKYyf45hUF9FOuUM9xPzuK3Vd8oJQvfYMCd7LPC0taAEljQLR4Edf8E6
-YoaOffgTf5qxiwkjnlVZQc3whgnEt9FpVMvQ9eknyeGB5KHfayAc3+hUAvI3/Cr3
-1bNveX5wInh5GDx1FGhKBZ+s1H+aedudCm7sCgRwv8lKWYGiHzObSma8A86KG+MD
-7Lo5JquQ3DlBodj3IDyPrxIv96lvRPFtAwIBAg==
+MIIBCAKCAQEA//////////+t+FRYortKmq/cViAnPTzx2LnFg84tNpWp4TZBFGQz
++8yTnc4kmz75fS/jY2MMddj2gbICrsRhetPfHtXV/WVhJDP1H18GbtCFY2VVPe0a
+87VXE15/V8k1mE8McODmi3fipona8+/och3xWKE2rec1MKzKT0g6eXq8CrGCsyT7
+YdEIqUuyyOP7uWrat2DX9GgdT0Kj3jlN9K5W7edjcrsZCwenyO4KbXCeAvzhzffi
+7MA0BM0oNC9hkXL+nOmFg/+OTxIy7vKBg8P+OxtMb61zO7X8vC7CIAXFjvGDfRaD
+ssbzSibBsu/6iGtCOGEoXJf//////////wIBAg==
 -----END DH PARAMETERS-----
         _end_of_pem_
-        private_constant :DEFAULT_2048
+        private_constant :DH_ffdhe2048
 
         DEFAULT_TMP_DH_CALLBACK = lambda { |ctx, is_export, keylen| # :nodoc:
           warn "using default DH parameters." if $VERBOSE
-          DEFAULT_2048
+          DH_ffdhe2048
         }
       end
 


### PR DESCRIPTION
In TLS 1.2 or before, if DH group parameters for DHE are not supplied with SSLContext#tmp_dh= or #tmp_dh_callback=, we currently use the self-generated parameters added in commit bb3399a61c03 ("support 2048 bit length DH-key", 2016-01-15) as the fallback.

While there is no known weakness in the current parameters, it would be a good idea to switch to pre-defined, more well audited parameters.

This also allows the fallback to work in the FIPS mode.

The PEM encoding was derived with:

	# RFC 7919 Appendix A.1. ffdhe2048
	print OpenSSL::PKey.read(OpenSSL::ASN1::Sequence([OpenSSL::ASN1::Integer((<<-END).split.join.to_i(16)), OpenSSL::ASN1::Integer(2)]).to_der).to_pem
	    FFFFFFFF FFFFFFFF ADF85458 A2BB4A9A AFDC5620 273D3CF1
	    D8B9C583 CE2D3695 A9E13641 146433FB CC939DCE 249B3EF9
	    7D2FE363 630C75D8 F681B202 AEC4617A D3DF1ED5 D5FD6561
	    2433F51F 5F066ED0 85636555 3DED1AF3 B557135E 7F57C935
	    984F0C70 E0E68B77 E2A689DA F3EFE872 1DF158A1 36ADE735
	    30ACCA4F 483A797A BC0AB182 B324FB61 D108A94B B2C8E3FB
	    B96ADAB7 60D7F468 1D4F42A3 DE394DF4 AE56EDE7 6372BB19
	    0B07A7C8 EE0A6D70 9E02FCE1 CDF7E2EC C03404CD 28342F61
	    9172FE9C E98583FF 8E4F1232 EEF28183 C3FE3B1B 4C6FAD73
	    3BB5FCBC 2EC22005 C58EF183 7D1683B2 C6F34A26 C1B2EFFA
	    886B4238 61285C97 FFFFFFFF FFFFFFFF
	END