### PR TITLE
test/openssl/test_pkey_ec.rb: refactor tests for EC.builtin_curves

### DIFF
--- a/test/openssl/test_pkey_ec.rb
+++ b/test/openssl/test_pkey_ec.rb
@@ -5,20 +5,6 @@ if defined?(OpenSSL)
 
 class OpenSSL::TestEC < OpenSSL::PKeyTestCase
   def test_ec_key
-    builtin_curves = OpenSSL::PKey::EC.builtin_curves
-    assert_not_empty builtin_curves
-
-    builtin_curves.each do |curve_name, comment|
-      # Oakley curves and X25519 are not suitable for signing and causes
-      # FIPS-selftest failure on some environment, so skip for now.
-      next if ["Oakley", "X25519"].any? { |n| curve_name.start_with?(n) }
-
-      key = OpenSSL::PKey::EC.generate(curve_name)
-      assert_predicate key, :private?
-      assert_predicate key, :public?
-      assert_nothing_raised { key.check_key }
-    end
-
     key1 = OpenSSL::PKey::EC.generate("prime256v1")
 
     # PKey is immutable in OpenSSL >= 3.0; constructing an empty EC object is
@@ -47,6 +33,17 @@ class OpenSSL::TestEC < OpenSSL::PKeyTestCase
       key5.public_key = key_tmp.public_key
       assert_not_equal key1.to_der, key5.to_der
     end
+  end
+
+  def test_builtin_curves
+    builtin_curves = OpenSSL::PKey::EC.builtin_curves
+    assert_not_empty builtin_curves
+    assert_equal 2, builtin_curves[0].size
+    assert_kind_of String, builtin_curves[0][0]
+    assert_kind_of String, builtin_curves[0][1]
+
+    builtin_curve_names = builtin_curves.map { |name, comment| name }
+    assert_include builtin_curve_names, "prime256v1"
   end
 
   def test_generate


### PR DESCRIPTION
Check that OpenSSL::PKey::EC.builtin_curves returns an array in the expected format.

Similarly to OpenSSL::Cipher.ciphers, OpenSSL::PKey::EC.builtin_curves returns a list of known named curves rather than actually usable ones.

https://github.com/ruby/openssl/issues/671 found that the list may include unapproved (and thus unusable) curves when the FIPS module is loaded.