### PR TITLE
Remove OSSL_DEBUG compile-time option

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,10 +58,10 @@ jobs:
         if: runner.os == 'Windows' && matrix.ruby == '3.2'
 
       - name: compile
-        run:  rake compile -- --enable-debug
+        run:  rake compile
 
       - name: test
-        run:  rake test TESTOPTS="-v --no-show-detail-immediately" OSSL_MDEBUG=1
+        run:  rake test TESTOPTS="-v --no-show-detail-immediately"
         timeout-minutes: 5
 
   test-openssls:
@@ -169,10 +169,10 @@ jobs:
         if: ${{ !matrix.skip-warnings }}
 
       - name: compile
-        run:  rake compile -- --enable-debug --with-openssl-dir=$HOME/.openssl/${{ matrix.openssl }}
+        run:  rake compile -- --with-openssl-dir=$HOME/.openssl/${{ matrix.openssl }}
 
       - name: test
-        run:  rake test TESTOPTS="-v --no-show-detail-immediately" OSSL_MDEBUG=1
+        run:  rake test TESTOPTS="-v --no-show-detail-immediately"
         timeout-minutes: 5
         if: ${{ !matrix.fips-enabled }}
 

--- a/ext/openssl/extconf.rb
+++ b/ext/openssl/extconf.rb
@@ -45,13 +45,6 @@ dir_config("kerberos")
 
 Logging::message "=== OpenSSL for Ruby configurator ===\n"
 
-##
-# Adds -DOSSL_DEBUG for compilation and some more targets when GCC is used
-# To turn it on, use: --with-debug or --enable-debug
-#
-if with_config("debug") or enable_config("debug")
-  $defs.push("-DOSSL_DEBUG")
-end
 $defs.push("-D""OPENSSL_SUPPRESS_DEPRECATED")
 
 have_func("rb_io_descriptor")

--- a/test/openssl/test_engine.rb
+++ b/test/openssl/test_engine.rb
@@ -82,7 +82,7 @@ class OpenSSL::TestEngine < OpenSSL::TestCase
 
   # this is required because OpenSSL::Engine methods change global state
   def with_openssl(code, **opts)
-    assert_separately([{ "OSSL_MDEBUG" => nil }, "-ropenssl"], <<~"end;", **opts)
+    assert_separately(["-ropenssl"], <<~"end;", **opts)
       #{code}
     end;
   end

--- a/test/openssl/test_fips.rb
+++ b/test/openssl/test_fips.rb
@@ -9,7 +9,7 @@ class OpenSSL::TestFIPS < OpenSSL::TestCase
       omit "Only for FIPS mode environment"
     end
 
-    assert_separately([{ "OSSL_MDEBUG" => nil }, "-ropenssl"], <<~"end;")
+    assert_separately(["-ropenssl"], <<~"end;")
       assert OpenSSL.fips_mode == true, ".fips_mode should return true on FIPS mode enabled"
     end;
   end
@@ -19,7 +19,7 @@ class OpenSSL::TestFIPS < OpenSSL::TestCase
       omit "Only for non-FIPS mode environment"
     end
 
-    assert_separately([{ "OSSL_MDEBUG" => nil }, "-ropenssl"], <<~"end;")
+    assert_separately(["-ropenssl"], <<~"end;")
       message = ".fips_mode should return false on FIPS mode disabled. " \
                 "If you run the test on FIPS mode, please set " \
                 "TEST_RUBY_OPENSSL_FIPS_ENABLED=true"
@@ -35,7 +35,7 @@ class OpenSSL::TestFIPS < OpenSSL::TestCase
   def test_fips_mode_get_with_fips_mode_set
     omit('OpenSSL is not FIPS-capable') unless OpenSSL::OPENSSL_FIPS
 
-    assert_separately([{ "OSSL_MDEBUG" => nil }, "-ropenssl"], <<~"end;")
+    assert_separately(["-ropenssl"], <<~"end;")
       begin
         OpenSSL.fips_mode = true
         assert OpenSSL.fips_mode == true, ".fips_mode should return true when .fips_mode=true"

--- a/test/openssl/test_provider.rb
+++ b/test/openssl/test_provider.rb
@@ -58,7 +58,7 @@ class OpenSSL::TestProvider < OpenSSL::TestCase
 
   # this is required because OpenSSL::Provider methods change global state
   def with_openssl(code, **opts)
-    assert_separately([{ "OSSL_MDEBUG" => nil }, "-ropenssl"], <<~"end;", **opts)
+    assert_separately(["-ropenssl"], <<~"end;", **opts)
       #{code}
     end;
   end

--- a/test/openssl/utils.rb
+++ b/test/openssl/utils.rb
@@ -4,26 +4,6 @@ begin
 rescue LoadError
 end
 
-# Compile OpenSSL with crypto-mdebug and run this test suite with OSSL_MDEBUG=1
-# environment variable to enable memory leak check.
-if ENV["OSSL_MDEBUG"] == "1"
-  if OpenSSL.respond_to?(:print_mem_leaks)
-    OpenSSL.mem_check_start
-
-    END {
-      GC.start
-      case OpenSSL.print_mem_leaks
-      when nil
-        warn "mdebug: check what is printed"
-      when true
-        raise "mdebug: memory leaks detected"
-      end
-    }
-  else
-    warn "OSSL_MDEBUG=1 is specified but OpenSSL is not built with crypto-mdebug"
-  end
-end
-
 require "test/unit"
 require "core_assertions"
 require "tempfile"


### PR DESCRIPTION
Remove the OSSL_DEBUG flag and OpenSSL.mem_check_start which is only compiled when the flag is given. They are meant purely for development of Ruby/OpenSSL.

OpenSSL.mem_check_start helped us find memory leak bugs in past, but it is no longer working with the recent OpenSSL versions. Let's just remove it now.