### PR TITLE
Use X509_ALGOR_get0() accessor for X509_ALGOR

### DIFF
--- a/ext/openssl/ossl_ts.c
+++ b/ext/openssl/ossl_ts.c
@@ -152,7 +152,7 @@ obj_to_asn1obj_i(VALUE obj)
 }
 
 static VALUE
-get_asn1obj(ASN1_OBJECT *obj)
+get_asn1obj(const ASN1_OBJECT *obj)
 {
     BIO *out;
     VALUE ret;
@@ -236,11 +236,13 @@ ossl_ts_req_get_algorithm(VALUE self)
     TS_REQ *req;
     TS_MSG_IMPRINT *mi;
     X509_ALGOR *algor;
+    const ASN1_OBJECT *obj;
 
     GetTSRequest(self, req);
     mi = TS_REQ_get_msg_imprint(req);
     algor = TS_MSG_IMPRINT_get_algo(mi);
-    return get_asn1obj(algor->algorithm);
+    X509_ALGOR_get0(&obj, NULL, NULL, algor);
+    return get_asn1obj(obj);
 }
 
 /*
@@ -490,13 +492,15 @@ ossl_ts_req_to_der(VALUE self)
     TS_REQ *req;
     TS_MSG_IMPRINT *mi;
     X509_ALGOR *algo;
+    const ASN1_OBJECT *obj;
     ASN1_OCTET_STRING *hashed_msg;
 
     GetTSRequest(self, req);
     mi = TS_REQ_get_msg_imprint(req);
 
     algo = TS_MSG_IMPRINT_get_algo(mi);
-    if (OBJ_obj2nid(algo->algorithm) == NID_undef)
+    X509_ALGOR_get0(&obj, NULL, NULL, algo);
+    if (OBJ_obj2nid(obj) == NID_undef)
         ossl_raise(eTimestampError, "Message imprint missing algorithm");
 
     hashed_msg = TS_MSG_IMPRINT_get_msg(mi);
@@ -969,11 +973,13 @@ ossl_ts_token_info_get_algorithm(VALUE self)
     TS_TST_INFO *info;
     TS_MSG_IMPRINT *mi;
     X509_ALGOR *algo;
+    const ASN1_OBJECT *obj;
 
     GetTSTokenInfo(self, info);
     mi = TS_TST_INFO_get_msg_imprint(info);
     algo = TS_MSG_IMPRINT_get_algo(mi);
-    return get_asn1obj(algo->algorithm);
+    X509_ALGOR_get0(&obj, NULL, NULL, algo);
+    return get_asn1obj(obj);
 }
 
 /*

--- a/ext/openssl/ossl_x509cert.c
+++ b/ext/openssl/ossl_x509cert.c
@@ -328,13 +328,15 @@ ossl_x509_get_signature_algorithm(VALUE self)
 {
     X509 *x509;
     BIO *out;
+    const ASN1_OBJECT *obj;
     VALUE str;
 
     GetX509(self, x509);
     out = BIO_new(BIO_s_mem());
     if (!out) ossl_raise(eX509CertError, NULL);
 
-    if (!i2a_ASN1_OBJECT(out, X509_get0_tbs_sigalg(x509)->algorithm)) {
+    X509_ALGOR_get0(&obj, NULL, NULL, X509_get0_tbs_sigalg(x509));
+    if (!i2a_ASN1_OBJECT(out, obj)) {
 	BIO_free(out);
 	ossl_raise(eX509CertError, NULL);
     }

--- a/ext/openssl/ossl_x509crl.c
+++ b/ext/openssl/ossl_x509crl.c
@@ -169,6 +169,7 @@ ossl_x509crl_get_signature_algorithm(VALUE self)
 {
     X509_CRL *crl;
     const X509_ALGOR *alg;
+    const ASN1_OBJECT *obj;
     BIO *out;
 
     GetX509CRL(self, crl);
@@ -176,7 +177,8 @@ ossl_x509crl_get_signature_algorithm(VALUE self)
 	ossl_raise(eX509CRLError, NULL);
     }
     X509_CRL_get0_signature(crl, NULL, &alg);
-    if (!i2a_ASN1_OBJECT(out, alg->algorithm)) {
+    X509_ALGOR_get0(&obj, NULL, NULL, alg);
+    if (!i2a_ASN1_OBJECT(out, obj)) {
 	BIO_free(out);
 	ossl_raise(eX509CRLError, NULL);
     }

--- a/ext/openssl/ossl_x509req.c
+++ b/ext/openssl/ossl_x509req.c
@@ -259,6 +259,7 @@ ossl_x509req_get_signature_algorithm(VALUE self)
 {
     X509_REQ *req;
     const X509_ALGOR *alg;
+    const ASN1_OBJECT *obj;
     BIO *out;
 
     GetX509Req(self, req);
@@ -267,7 +268,8 @@ ossl_x509req_get_signature_algorithm(VALUE self)
 	ossl_raise(eX509ReqError, NULL);
     }
     X509_REQ_get0_signature(req, NULL, &alg);
-    if (!i2a_ASN1_OBJECT(out, alg->algorithm)) {
+    X509_ALGOR_get0(&obj, NULL, NULL, alg);
+    if (!i2a_ASN1_OBJECT(out, obj)) {
 	BIO_free(out);
 	ossl_raise(eX509ReqError, NULL);
     }


### PR DESCRIPTION
While the struct is currently still public in OpenSSL, there has been an accessor since OpenSSL 0.9.8h. It would be nice if this accessor could be used so that the struct can be made opaque at some point in the future.