### PR TITLE
Returns keysize in bits

### DIFF
--- a/ext/openssl/ossl_pkey.c
+++ b/ext/openssl/ossl_pkey.c
@@ -1666,6 +1666,23 @@ ossl_pkey_decrypt(int argc, VALUE *argv, VALUE self)
     return str;
 }
 
+
+/*
+ * Returns bit length of the PKEy
+ */ 
+static VALUE
+ossl_pkey_length_in_bits(VALUE self)
+{
+  EVP_PKEY * pkey;
+  int bits;
+
+  GetPKey(self, pkey);
+
+  bits = EVP_PKEY_get_bits(pkey);
+  return INT2NUM(bits);
+  
+}
+
 /*
  * INIT
  */
@@ -1784,6 +1801,9 @@ Init_ossl_pkey(void)
     rb_define_method(cPKey, "derive", ossl_pkey_derive, -1);
     rb_define_method(cPKey, "encrypt", ossl_pkey_encrypt, -1);
     rb_define_method(cPKey, "decrypt", ossl_pkey_decrypt, -1);
+
+
+    rb_define_method(cPKey, "keysize_in_bits", ossl_pkey_length_in_bits, 0);
 
     id_private_q = rb_intern("private?");
 

--- a/test/openssl/test_pkey.rb
+++ b/test/openssl/test_pkey.rb
@@ -24,6 +24,7 @@ class OpenSSL::TestPKey < OpenSSL::PKeyTestCase
     assert_instance_of OpenSSL::PKey::PKey, x25519
     assert_equal "X25519", x25519.oid
     assert_match %r{oid=X25519}, x25519.inspect
+    assert_equal 253, x25519.keysize_in_bits
   end
 
   def test_s_generate_parameters

--- a/test/openssl/test_pkey_dh.rb
+++ b/test/openssl/test_pkey_dh.rb
@@ -36,6 +36,9 @@ class OpenSSL::TestPKeyDH < OpenSSL::PKeyTestCase
     assert_equal z, dh1.derive(dh2_pub)
     assert_equal z, dh2.derive(dh1_pub)
 
+    assert_equal(1024, dh1.keysize_in_bits)
+    assert_equal(1024, dh2.keysize_in_bits)
+
     assert_raise(OpenSSL::PKey::PKeyError) { params.derive(dh1_pub) }
     assert_raise(OpenSSL::PKey::PKeyError) { dh1_pub.derive(params) }
 

--- a/test/openssl/test_pkey_ec.rb
+++ b/test/openssl/test_pkey_ec.rb
@@ -76,16 +76,19 @@ class OpenSSL::TestEC < OpenSSL::PKeyTestCase
     assert_equal(true, key0.check_key)
     assert_equal(true, key0.private?)
     assert_equal(true, key0.public?)
+    assert_equal(256, key0.keysize_in_bits)
 
     key1 = OpenSSL::PKey.read(key0.public_to_der)
     assert_equal(true, key1.check_key)
     assert_equal(false, key1.private?)
     assert_equal(true, key1.public?)
+    assert_equal(256, key1.keysize_in_bits)
 
     key2 = OpenSSL::PKey.read(key0.private_to_der)
     assert_equal(true, key2.private?)
     assert_equal(true, key2.public?)
     assert_equal(true, key2.check_key)
+    assert_equal(256, key2.keysize_in_bits)
 
     # Behavior of EVP_PKEY_public_check changes between OpenSSL 1.1.1 and 3.0
     key4 = Fixtures.pkey("p256_too_large")


### PR DESCRIPTION
There are some situation the actual key size in bits are required, for example for display or analysis. 

For EC/RSA etc, the key size is fixed which is not really useful. However recently I've been working on X25519 key and the key size is at odd 253, not at byte boundary. Projected there will more situation like this in coming use cases where key size in bit is more desirable especially when PQ key get involved.

The method keysize_in_bits() attached to OpenSSL::PKey class shall be available to all PKey type and it is just returning the key size in bits.

