### PR TITLE
Expose `IO#timeout` and `IO#timeout=` if available

### DIFF
--- a/lib/openssl/ssl.rb
+++ b/lib/openssl/ssl.rb
@@ -421,6 +421,18 @@ ssbzSibBsu/6iGtCOGEoXJf//////////wIBAg==
         nil
       end
 
+      if IO.method_defined?(:timeout)
+        def timeout
+          @io.timeout
+        end
+      end
+
+      if IO.method_defined?(:timeout=)
+        def timeout=(timeout)
+          @io.timeout = timeout
+        end
+      end
+
       private
 
       def using_anon_cipher?

--- a/test/openssl/test_ssl.rb
+++ b/test/openssl/test_ssl.rb
@@ -81,6 +81,23 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
     }
   end
 
+  def test_socket_timeout
+    start_server { |port|
+      begin
+        ssl = OpenSSL::SSL::SSLSocket.open("127.0.0.1", port)
+        ssl.sync_close = true
+        assert_nil ssl.timeout
+        ssl.timeout = 1
+        assert_equal 1, ssl.timeout
+        ssl.connect
+
+        ssl.puts "abc"; assert_equal "abc\n", ssl.gets
+      ensure
+        ssl&.close
+      end
+    }
+  end
+
   def test_socket_open_with_context
     start_server { |port|
       begin


### PR DESCRIPTION
Ref: https://bugs.ruby-lang.org/issues/18630

FYI: @ioquatix 