### PR TITLE
History.md: Escape Markdown syntax Italic "*". [ci skip]

### DIFF
--- a/History.md
+++ b/History.md
@@ -457,7 +457,7 @@ Security fixes
 Bug fixes
 ---------
 
-* Fixed OpenSSL::PKey::*.{new,generate} immediately aborting if the thread is
+* Fixed OpenSSL::PKey::\*.{new,generate} immediately aborting if the thread is
   interrupted.
   [[Bug #14882]](https://bugs.ruby-lang.org/issues/14882)
   [[GitHub #205]](https://github.com/ruby/openssl/pull/205)


### PR DESCRIPTION
When opening the `History.md` on VIM. A part of the text is unintentionally shown as italic below. We need to escape the markdown syntax `*` for italic.

![ruby-openssl-History md-italic](https://github.com/ruby/openssl/assets/121989/27a5fcac-d98b-452f-a29e-b6c36ba5c794)

You can see the `*` is escaped in the modified [`History.md`](https://github.com/junaruga/ruby-openssl/blob/wip/doc-escape-markdown-syntax/History.md#bug-fixes-6) on my forked repository.
