### PR TITLE
CI: Add OpenSSL 3.2.0.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,6 +80,7 @@ jobs:
           - openssl-1.1.1w # EOL
           - openssl-3.0.12
           - openssl-3.1.4
+          - openssl-3.2.0
           # http://www.libressl.org/releases.html
           - libressl-3.1.5 # EOL
           - libressl-3.2.7 # EOL
@@ -93,6 +94,7 @@ jobs:
         include:
           - { os: ubuntu-latest, ruby: "3.0", openssl: openssl-3.0.12, fips-enabled: true, append-configure: 'enable-fips', name-extra: 'fips' }
           - { os: ubuntu-latest, ruby: "3.0", openssl: openssl-3.1.4, fips-enabled: true, append-configure: 'enable-fips', name-extra: 'fips' }
+          - { os: ubuntu-latest, ruby: "3.0", openssl: openssl-3.2.0, fips-enabled: true, append-configure: 'enable-fips', name-extra: 'fips' }
           - { os: ubuntu-latest, ruby: "3.0", openssl: openssl-head, git: 'git://git.openssl.org/openssl.git', branch: 'master' }
           - { os: ubuntu-latest, ruby: "3.0", openssl: openssl-head, git: 'git://git.openssl.org/openssl.git', branch: 'master', fips-enabled: true, append-configure: 'enable-fips', name-extra: 'fips' }
     steps:


### PR DESCRIPTION
OpenSSL 3.2.0 is available now.
https://www.openssl.org/blog/blog/2023/11/23/OpenSSL32/