### PR TITLE
Gemfile: Add the test group not to install rdoc in CI.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,10 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
 
-      - name: depends
+      - name: bundle config
+        run:  bundle config set --local without development
+
+      - name: bundle install
         run:  bundle install
 
       # Enable the verbose option in mkmf.rb to print the compiling commands.
@@ -154,7 +157,10 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
 
-      - name: depends
+      - name: bundle config
+        run:  bundle config set --local without development
+
+      - name: bundle install
         run:  bundle install
 
       - name: enable mkmf verbose

--- a/Gemfile
+++ b/Gemfile
@@ -2,11 +2,14 @@ source "https://rubygems.org"
 
 gemspec
 
-group :development do
+group :test do
   gem "rake"
   gem "rake-compiler"
   gem "test-unit", "~> 3.0", ">= 3.4.6"
   gem "test-unit-ruby-core"
+end
+
+group :development do
   # In the case of Ruby whose rdoc is not a default gem.
   gem "rdoc"
 end


### PR DESCRIPTION
This PR is not to install rdoc in CI, mentioned at https://github.com/ruby/openssl/issues/699#issuecomment-1825781951 to avoid the issue https://github.com/ruby/openssl/issues/699.

You can check [this page](https://bundler.io/guides/groups.html) for Bundler group feature.

I wanted to do the following commands. However, the `set -ex` didn't work in Windows environment. So, I split the "depends" to "bundle config" and "bundle install".

```
- name: depends
  run:  |
    set -ex
    bundle config set --local without development
    bundle install
```




