### PR TITLE
Revert openssl dir workaround on TruffleRuby

### DIFF
--- a/ext/openssl/extconf.rb
+++ b/ext/openssl/extconf.rb
@@ -13,14 +13,7 @@
 
 require "mkmf"
 
-ssl_dirs = nil
-if defined?(::TruffleRuby)
-  # Always respect the openssl prefix chosen by truffle/openssl-prefix
-  require 'truffle/openssl-prefix'
-  ssl_dirs = dir_config("openssl", ENV["OPENSSL_PREFIX"])
-else
-  ssl_dirs = dir_config("openssl")
-end
+ssl_dirs = dir_config("openssl")
 dir_config_given = ssl_dirs.any?
 
 _, ssl_ldir = ssl_dirs


### PR DESCRIPTION
* This reverts commit ca738e7e13570e88eaa9892cbb3dffb330320706 / https://github.com/ruby/openssl/pull/653.
* No longer needed since https://github.com/oracle/truffleruby/issues/3170 was fixed.

The fix is only in truffleruby-head, not yet in a release.
However, it seems truffleruby release is only used on ubuntu-22.04 in CI, where it works fine because anyway OpenSSL is picked: https://github.com/eregon/openssl/actions/runs/7060198654/job/19219283155#step:9:34
So it seems fine to merge this now and no need to wait for the 24.0 release.