### PR TITLE
Fix regression in do_write(s) causing significant performance issues when using large (>10meg) writes

### DIFF
--- a/lib/openssl/buffering.rb
+++ b/lib/openssl/buffering.rb
@@ -348,13 +348,18 @@ module OpenSSL::Buffering
     @wbuffer << s
     @wbuffer.force_encoding(Encoding::BINARY)
     @sync ||= false
-    if @sync or @wbuffer.size > BLOCK_SIZE
-      until @wbuffer.empty?
-        begin
-          nwrote = syswrite(@wbuffer)
-        rescue Errno::EAGAIN
-          retry
+    buffer_size = @wbuffer.size
+    if @sync or buffer_size > BLOCK_SIZE
+      nwrote = 0
+      begin
+        while nwrote < buffer_size do
+          begin
+            nwrote += syswrite(@wbuffer[nwrote, buffer_size - nwrote])
+          rescue Errno::EAGAIN
+            retry
+          end
         end
+      ensure
         @wbuffer[0, nwrote] = ""
       end
     end


### PR DESCRIPTION
Adjust the buffer write function to clear the buffer once, rather than piece by piece.  This avoids a case where a large write (in our case, around 70mbytes) will consume 100% of CPU.  This takes a webrick GET request via SSL from around 200kbyts/sec and consuming 100% of a core, to line speed on gigabit ethernet and 6% cpu utlization.

(The reason was that removing the head of the buffer was a full copy every single write block, which turned out to be 16k for us, hence every 16k copying the 77meg of data that went in the front of it).

Passes tests, and has been tested on our systems with chef-zero