### PR TITLE
Add more methods to `SocketForwarder`.

### DIFF
--- a/lib/openssl/buffering.rb
+++ b/lib/openssl/buffering.rb
@@ -229,7 +229,7 @@ module OpenSSL::Buffering
   #
   # Unlike IO#gets the separator must be provided if a limit is provided.
 
-  def gets(eol=$/, limit=nil)
+  def gets(eol=$/, limit=nil, chomp: false)
     idx = @rbuffer.index(eol)
     until @eof
       break if idx
@@ -244,7 +244,11 @@ module OpenSSL::Buffering
     if size && limit && limit >= 0
       size = [size, limit].min
     end
-    consume_rbuff(size)
+    line = consume_rbuff(size)
+    if chomp && line
+      line.chomp!(eol)
+    end
+    line
   end
 
   ##

--- a/lib/openssl/ssl.rb
+++ b/lib/openssl/ssl.rb
@@ -252,6 +252,14 @@ ssbzSibBsu/6iGtCOGEoXJf//////////wIBAg==
         to_io.peeraddr
       end
 
+      def local_address
+        to_io.local_address
+      end
+
+      def remote_address
+        to_io.remote_address
+      end
+
       def setsockopt(level, optname, optval)
         to_io.setsockopt(level, optname, optval)
       end
@@ -270,6 +278,26 @@ ssbzSibBsu/6iGtCOGEoXJf//////////wIBAg==
 
       def do_not_reverse_lookup=(flag)
         to_io.do_not_reverse_lookup = flag
+      end
+
+      def close_on_exec=(value)
+        to_io.close_on_exec = value
+      end
+
+      def close_on_exec?
+        to_io.close_on_exec?
+      end
+
+      def wait(*args)
+        to_io.wait(*args)
+      end
+
+      def wait_readable(*args)
+        to_io.wait_readable(*args)
+      end
+
+      def wait_writable(*args)
+        to_io.wait_writable(*args)
       end
     end
 

--- a/test/openssl/test_pair.rb
+++ b/test/openssl/test_pair.rb
@@ -115,6 +115,17 @@ module OpenSSL::TestPairM
     }
   end
 
+  def test_gets_chomp
+    ssl_pair {|s1, s2|
+      s1 << "line1\r\nline2\r\nline3\r\n"
+      s1.close
+
+      assert_equal("line1", s2.gets("\r\n", chomp: true))
+      assert_equal("line2\r\n", s2.gets("\r\n", chomp: false))
+      assert_equal("line3", s2.gets(chomp: true))
+    }
+  end
+
   def test_gets_eof_limit
     ssl_pair {|s1, s2|
       s1.write("hello")


### PR DESCRIPTION
Generic code that assumes the `Socket` interface will fail if it tries to use `wait` or `wait_readable` or `close_on_exec` family of methods. Can we add these?