### PR TITLE
Windows Ruby 3.3: Workaround: Set OPENSSL_MODULES to find providers.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,10 +52,10 @@ jobs:
         if: ${{ !matrix.skip-warnings }}
 
       # Enable provider search path for OpenSSL 3.0 in MSYS2.
-      # Remove when Ruby 3.2 build is updated
+      # Remove when Ruby 3.2, and 3.3 builds are updated.
       - name: enable windows provider search path
         run: echo "OPENSSL_MODULES=$($env:RI_DEVKIT)\$($env:MSYSTEM_PREFIX)\lib\ossl-modules" >> $env:GITHUB_ENV
-        if: runner.os == 'Windows' && matrix.ruby == '3.2'
+        if: runner.os == 'Windows' && (matrix.ruby == '3.2' || matrix.ruby == '3.3')
 
       - name: compile
         run:  rake compile


### PR DESCRIPTION
This PR is a workaround to pass the following failing tests addressed on #711. So, this PR technically fixes #711. The issue is that OpenSSL couldn't find the `lib\ossl-modules\legacy.dll`. The https://github.com/openssl/openssl/issues/19368 was helpful to understand teh issue and find the solution.

---

This commit is a workaround to avoid the following test failures by loading legacy provider.

```
2) Error: test_openssl_legacy_provider(OpenSSL::TestProvider): OpenSSL::Provider::ProviderError: Failed to load legacy provider: (null) (name=legacy)
D:/a/ruby-openssl/ruby-openssl/test/openssl/test_provider.rb:62:in `load'
D:/a/ruby-openssl/ruby-openssl/test/openssl/test_provider.rb:62:in `<main>'
D:/a/ruby-openssl/ruby-openssl/test/openssl/test_provider.rb:61:in `with_openssl'
D:/a/ruby-openssl/ruby-openssl/test/openssl/test_provider.rb:36:in `test_openssl_legacy_provider'
     33:   end
     34:
     35:   def test_openssl_legacy_provider
  => 36:     with_openssl(<<-'end;')
     37:       OpenSSL::Provider.load("legacy")
     38:       algo = "RC4"
     39:       data = "a" * 1000
```

I hope this logic is included in an Ruby installer used in GitHub Actions Windows cases.

By the way, I found 

```
$ bin\openssl.exe list -provider legacy -providers
```

```
$HOME/.local/openssl-3.0.12-fips-debug-c3cc0f1386/bin/openssl list -provider legacy -providers
Providers:
  legacy
    name: OpenSSL Legacy Provider
    version: 3.0.12
    status: active
```





