### PR TITLE
CI: Added the rubyinstaller2 issue link that legacy provider is not loaded.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,8 +51,11 @@ jobs:
         run:  echo "RUBY_OPENSSL_EXTCFLAGS=-Werror" >> $GITHUB_ENV
         if: ${{ !matrix.skip-warnings }}
 
-      # Enable provider search path for OpenSSL 3.0 in MSYS2.
-      # Remove when Ruby 3.2, and 3.3 builds are updated.
+      # Workaround: Enable provider search path to load the legacy provider
+      # (legacy.dll) in OpenSSL 3 in Windows MSYS2.
+      # Remove the workaround when the issue is fixed in Ruby 3.2 and 3.3
+      # builds.
+      # https://github.com/oneclick/rubyinstaller2/issues/365
       - name: enable windows provider search path
         run: echo "OPENSSL_MODULES=$($env:RI_DEVKIT)\$($env:MSYSTEM_PREFIX)\lib\ossl-modules" >> $env:GITHUB_ENV
         if: runner.os == 'Windows' && (matrix.ruby == '3.2' || matrix.ruby == '3.3')


### PR DESCRIPTION
* Added the upstream rubyinstaller2 issue link as a comment. The issue is that the legacy provider (legacy.dll) not loaded in Windows MSYS2 OpenSSL 3 environment.
* Polished the text on the comment.