### PR TITLE
Add support for IO#timeout.

### DIFF
--- a/ext/openssl/extconf.rb
+++ b/ext/openssl/extconf.rb
@@ -49,7 +49,7 @@ $defs.push("-D""OPENSSL_SUPPRESS_DEPRECATED")
 
 have_func("rb_io_descriptor")
 have_func("rb_io_maybe_wait(0, Qnil, Qnil, Qnil)", "ruby/io.h") # Ruby 3.1
-have_var("rb_eIOTimeoutError", "ruby/io.h")
+have_func("rb_io_timeout", "ruby/io.h")
 
 Logging::message "=== Checking for system dependent stuff... ===\n"
 have_library("nsl", "t_open")

--- a/ext/openssl/extconf.rb
+++ b/ext/openssl/extconf.rb
@@ -49,6 +49,7 @@ $defs.push("-D""OPENSSL_SUPPRESS_DEPRECATED")
 
 have_func("rb_io_descriptor")
 have_func("rb_io_maybe_wait(0, Qnil, Qnil, Qnil)", "ruby/io.h") # Ruby 3.1
+have_var("rb_eIOTimeoutError", "ruby/io.h")
 
 Logging::message "=== Checking for system dependent stuff... ===\n"
 have_library("nsl", "t_open")

--- a/ext/openssl/ossl_ssl.c
+++ b/ext/openssl/ossl_ssl.c
@@ -1725,7 +1725,7 @@ no_exception_p(VALUE opts)
 #define RUBY_IO_TIMEOUT_DEFAULT Qnil
 #endif
 
-#ifdef HAVE_RB_EIOTIMEOUTERROR
+#ifdef HAVE_RB_IO_TIMEOUT
 #define IO_TIMEOUT_ERROR rb_eIOTimeoutError
 #else
 #define IO_TIMEOUT_ERROR rb_eIOError

--- a/ext/openssl/ossl_ssl.c
+++ b/ext/openssl/ossl_ssl.c
@@ -1725,11 +1725,20 @@ no_exception_p(VALUE opts)
 #define RUBY_IO_TIMEOUT_DEFAULT Qnil
 #endif
 
+#ifdef HAVE_RB_EIOTIMEOUTERROR
+#define IO_TIMEOUT_ERROR rb_eIOTimeoutError
+#else
+#define IO_TIMEOUT_ERROR rb_eIOError
+#endif
+
+
 static void
 io_wait_writable(VALUE io)
 {
 #ifdef HAVE_RB_IO_MAYBE_WAIT
-    rb_io_maybe_wait_writable(errno, io, RUBY_IO_TIMEOUT_DEFAULT);
+    if (!rb_io_maybe_wait_writable(errno, io, RUBY_IO_TIMEOUT_DEFAULT)) {
+        rb_raise(IO_TIMEOUT_ERROR, "Timed out while waiting to become writable!");
+    }
 #else
     rb_io_t *fptr;
     GetOpenFile(io, fptr);
@@ -1741,7 +1750,9 @@ static void
 io_wait_readable(VALUE io)
 {
 #ifdef HAVE_RB_IO_MAYBE_WAIT
-    rb_io_maybe_wait_readable(errno, io, RUBY_IO_TIMEOUT_DEFAULT);
+    if (!rb_io_maybe_wait_readable(errno, io, RUBY_IO_TIMEOUT_DEFAULT)) {
+        rb_raise(IO_TIMEOUT_ERROR, "Timed out while waiting to become readable!");
+    }
 #else
     rb_io_t *fptr;
     GetOpenFile(io, fptr);

--- a/lib/openssl/ssl.rb
+++ b/lib/openssl/ssl.rb
@@ -299,6 +299,16 @@ ssbzSibBsu/6iGtCOGEoXJf//////////wIBAg==
       def wait_writable(*args)
         to_io.wait_writable(*args)
       end
+
+      if IO.method_defined?(:timeout)
+        def timeout
+          to_io.timeout
+        end
+
+        def timeout=(value)
+          to_io.timeout=(value)
+        end
+      end
     end
 
     def verify_certificate_identity(cert, hostname)

--- a/test/openssl/test_ssl.rb
+++ b/test/openssl/test_ssl.rb
@@ -193,6 +193,17 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
     }
   end
 
+  def test_read_with_timeout
+    omit "does not support timeout" unless IO.method_defined?(:timeout)
+
+    start_server do |port|
+      server_connect(port) do |ssl|
+        ssl.timeout = 0.001
+        assert_raise(IO::TimeoutError) {ssl.read(1)}
+      end
+    end
+  end
+
   def test_getbyte
     start_server { |port|
       server_connect(port) { |ssl|

--- a/test/openssl/test_ssl.rb
+++ b/test/openssl/test_ssl.rb
@@ -198,10 +198,15 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
 
     start_server do |port|
       server_connect(port) do |ssl|
-        ssl.timeout = 0.001
+        str = +("x" * 100 + "\n")
+        ssl.syswrite(str)
+        assert_equal(str, ssl.sysread(str.bytesize))
+
+        ssl.timeout = 0.01
         assert_raise(IO::TimeoutError) {ssl.read(1)}
-      ensure
-        ssl.close
+
+        ssl.syswrite(str)
+        assert_equal(str, ssl.sysread(str.bytesize))
       end
     end
   end

--- a/test/openssl/test_ssl.rb
+++ b/test/openssl/test_ssl.rb
@@ -202,7 +202,7 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
         ssl.syswrite(str)
         assert_equal(str, ssl.sysread(str.bytesize))
 
-        ssl.timeout = 0.01
+        ssl.timeout = 1
         assert_raise(IO::TimeoutError) {ssl.read(1)}
 
         ssl.syswrite(str)

--- a/test/openssl/test_ssl.rb
+++ b/test/openssl/test_ssl.rb
@@ -200,6 +200,8 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
       server_connect(port) do |ssl|
         ssl.timeout = 0.001
         assert_raise(IO::TimeoutError) {ssl.read(1)}
+      ensure
+        ssl.close
       end
     end
   end


### PR DESCRIPTION
(I expect this to fail on older Rubies until I add detection of `rb_eIOTimeoutError`).