### PR TITLE
omit tests related legacy provider

### DIFF
--- a/test/openssl/test_provider.rb
+++ b/test/openssl/test_provider.rb
@@ -11,7 +11,9 @@ class OpenSSL::TestProvider < OpenSSL::TestCase
     end;
   end
 
-  def test_openssl_provider_names
+  def test_openssl_provider_name
+    omit if /freebsd/ =~ RUBY_PLATFORM
+
     with_openssl <<-'end;'
       legacy_provider = OpenSSL::Provider.load("legacy")
       assert_equal(2, OpenSSL::Provider.provider_names.size)
@@ -33,6 +35,8 @@ class OpenSSL::TestProvider < OpenSSL::TestCase
   end
 
   def test_openssl_legacy_provider
+    omit if /freebsd/ =~ RUBY_PLATFORM
+
     with_openssl(<<-'end;')
       OpenSSL::Provider.load("legacy")
       algo = "RC4"

--- a/test/openssl/test_provider.rb
+++ b/test/openssl/test_provider.rb
@@ -11,7 +11,7 @@ class OpenSSL::TestProvider < OpenSSL::TestCase
     end;
   end
 
-  def test_openssl_provider_name
+  def test_openssl_provider_names
     omit if /freebsd/ =~ RUBY_PLATFORM
 
     with_openssl <<-'end;'


### PR DESCRIPTION
Tests of legacy provider failed with recent update of FreeBSD

https://rubyci.s3.amazonaws.com/freebsd13/ruby-master/log/20240207T023002Z.fail.html.gz

I make to skip them at `ruby/ruby` repo. please let me know if you have any idea about that.

Thanks ❤️ 