### PR TITLE
CI: Upgrade OpenSSL and LibreSSL versions.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,9 +81,9 @@ jobs:
           - openssl-1.0.2u # EOL
           - openssl-1.1.0l # EOL
           - openssl-1.1.1w # EOL
-          - openssl-3.0.12
-          - openssl-3.1.4
-          - openssl-3.2.0
+          - openssl-3.0.13
+          - openssl-3.1.5
+          - openssl-3.2.1
           # http://www.libressl.org/releases.html
           - libressl-3.1.5 # EOL
           - libressl-3.2.7 # EOL
@@ -92,12 +92,12 @@ jobs:
           - libressl-3.5.3 # EOL
           - libressl-3.6.3
           - libressl-3.7.3
-          - libressl-3.8.1 # Development release
+          - libressl-3.8.2
         fips-enabled: [ false ]
         include:
-          - { os: ubuntu-latest, ruby: "3.0", openssl: openssl-3.0.12, fips-enabled: true, append-configure: 'enable-fips', name-extra: 'fips' }
-          - { os: ubuntu-latest, ruby: "3.0", openssl: openssl-3.1.4, fips-enabled: true, append-configure: 'enable-fips', name-extra: 'fips' }
-          - { os: ubuntu-latest, ruby: "3.0", openssl: openssl-3.2.0, fips-enabled: true, append-configure: 'enable-fips', name-extra: 'fips' }
+          - { os: ubuntu-latest, ruby: "3.0", openssl: openssl-3.0.13, fips-enabled: true, append-configure: 'enable-fips', name-extra: 'fips' }
+          - { os: ubuntu-latest, ruby: "3.0", openssl: openssl-3.1.5, fips-enabled: true, append-configure: 'enable-fips', name-extra: 'fips' }
+          - { os: ubuntu-latest, ruby: "3.0", openssl: openssl-3.2.1, fips-enabled: true, append-configure: 'enable-fips', name-extra: 'fips' }
           - { os: ubuntu-latest, ruby: "3.0", openssl: openssl-head, git: 'git://git.openssl.org/openssl.git', branch: 'master' }
           - { os: ubuntu-latest, ruby: "3.0", openssl: openssl-head, git: 'git://git.openssl.org/openssl.git', branch: 'master', fips-enabled: true, append-configure: 'enable-fips', name-extra: 'fips' }
     steps:


### PR DESCRIPTION
This PR is to upgrade the OpenSSL and LibreSSL versions used in the CI to the latest ones.

Note the LibreSSL 3.2.1 is out of the development version. So, I removed the comment `# Development release`.
https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-3.8.2-relnotes.txt

I confirmed that the CI passed on my forked repository.
https://github.com/junaruga/ruby-openssl/actions/runs/7832921941
