### PR TITLE
test_provider.rb: Make a legacy provider test optional.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,6 +100,7 @@ jobs:
           - { os: ubuntu-latest, ruby: "3.0", openssl: openssl-3.2.1, fips-enabled: true, append-configure: 'enable-fips', name-extra: 'fips' }
           - { os: ubuntu-latest, ruby: "3.0", openssl: openssl-head, git: 'git://git.openssl.org/openssl.git', branch: 'master' }
           - { os: ubuntu-latest, ruby: "3.0", openssl: openssl-head, git: 'git://git.openssl.org/openssl.git', branch: 'master', fips-enabled: true, append-configure: 'enable-fips', name-extra: 'fips' }
+          - { os: ubuntu-latest, ruby: "3.0", openssl: openssl-head, git: 'git://git.openssl.org/openssl.git', branch: 'master', append-configure: 'no-legacy', name-extra: 'no-legacy' }
     steps:
       - name: repo checkout
         uses: actions/checkout@v4

--- a/test/openssl/test_provider.rb
+++ b/test/openssl/test_provider.rb
@@ -13,13 +13,13 @@ class OpenSSL::TestProvider < OpenSSL::TestCase
 
   def test_openssl_provider_names
     with_openssl <<-'end;'
-      legacy_provider = OpenSSL::Provider.load("legacy")
+      base_provider = OpenSSL::Provider.load("base")
       assert_equal(2, OpenSSL::Provider.provider_names.size)
-      assert_includes(OpenSSL::Provider.provider_names, "legacy")
+      assert_includes(OpenSSL::Provider.provider_names, "base")
 
-      assert_equal(true, legacy_provider.unload)
+      assert_equal(true, base_provider.unload)
       assert_equal(1, OpenSSL::Provider.provider_names.size)
-      assert_not_includes(OpenSSL::Provider.provider_names, "legacy")
+      assert_not_includes(OpenSSL::Provider.provider_names, "base")
     end;
   end
 
@@ -34,7 +34,12 @@ class OpenSSL::TestProvider < OpenSSL::TestCase
 
   def test_openssl_legacy_provider
     with_openssl(<<-'end;')
-      OpenSSL::Provider.load("legacy")
+      begin
+        OpenSSL::Provider.load("legacy")
+      rescue OpenSSL::Provider::ProviderError
+        omit "Only for OpenSSL with legacy provider"
+      end
+
       algo = "RC4"
       data = "a" * 1000
       key = OpenSSL::Random.random_bytes(16)

--- a/test/openssl/test_provider.rb
+++ b/test/openssl/test_provider.rb
@@ -12,8 +12,6 @@ class OpenSSL::TestProvider < OpenSSL::TestCase
   end
 
   def test_openssl_provider_names
-    omit if /freebsd/ =~ RUBY_PLATFORM
-
     with_openssl <<-'end;'
       legacy_provider = OpenSSL::Provider.load("legacy")
       assert_equal(2, OpenSSL::Provider.provider_names.size)
@@ -35,8 +33,6 @@ class OpenSSL::TestProvider < OpenSSL::TestCase
   end
 
   def test_openssl_legacy_provider
-    omit if /freebsd/ =~ RUBY_PLATFORM
-
     with_openssl(<<-'end;')
       OpenSSL::Provider.load("legacy")
       algo = "RC4"


### PR DESCRIPTION
This PR is to omit (skip) tests requiring the legacy provider if it is not loadable. The issue was found by another PR https://github.com/ruby/openssl/pull/718.

---

In some cases, the legacy provider is not installed intentionally. So, we omit a test requiring the legacy provider if the legacy provider is not loadable.

In the test_openssl_provider_names test, we use base provider instead of legacy provider, because we would expect the base provider is always loadable in OpenSSL 3 for now.

You can see the list of the standard providers below.
https://wiki.openssl.org/index.php/OpenSSL_3.0#Providers

---

This PR has 2 commits. The 1st commit is to add the no-legacy case to the CI. I chose OpenSSL head branch for the no-legacy case. Because we can notice soon if the specification around the legacy provider is changed. The 2nd commit is to omit (skip) a test requiring the legacy provider. In the `test_openssl_provider_names`, I replaced the used legacy provider with base provider. We don't need to use the legacy provider in the test.

I tested this PR on my forked repository.

Below is the CI result on the 1st commit. The no-legacy case failed as expected.
https://github.com/junaruga/ruby-openssl/actions/runs/7834063675/job/21376475009

Below is the CI result on the 2nd commit. the no-legacy case passed with the omitted message "Omission: Only for OpenSSL with legacy provider".
https://github.com/junaruga/ruby-openssl/actions/runs/7834165493/job/21376788379#step:12:632



