### PR TITLE
read: don't clear buffer when nothing can be read

### DIFF
--- a/ext/openssl/ossl_ssl.c
+++ b/ext/openssl/ossl_ssl.c
@@ -1958,9 +1958,11 @@ ossl_ssl_read_internal(int argc, VALUE *argv, VALUE self, int nonblock)
 	else
 	    rb_str_modify_expand(str, ilen - RSTRING_LEN(str));
     }
-    rb_str_set_len(str, 0);
-    if (ilen == 0)
-	return str;
+
+    if (ilen == 0) {
+        rb_str_set_len(str, 0);
+        return str;
+    }
 
     VALUE io = rb_attr_get(self, id_i_io);
 

--- a/test/openssl/test_pair.rb
+++ b/test/openssl/test_pair.rb
@@ -250,12 +250,17 @@ module OpenSSL::TestPairM
 
       buf = +"garbage"
       assert_equal :wait_readable, s2.read_nonblock(100, buf, exception: false)
-      assert_equal "", buf
+      assert_equal "garbage", buf
 
       s1.close
       buf = +"garbage"
-      assert_equal nil, s2.read(100, buf)
+      assert_nil s2.read(100, buf)
       assert_equal "", buf
+
+      buf = +"garbage"
+      ret = s2.read(0, buf)
+      assert_same buf, ret
+      assert_equal "", ret
     }
   end
 


### PR DESCRIPTION
To be consistent with regular Ruby IOs:

```ruby
r, _ = IO.pipe
buf = "garbage".b
r.read_nonblock(10, buf, exception: false) # => :wait_readable
p buf # => "garbage"
```

Ref: https://github.com/redis-rb/redis-client/commit/98b8944460a11f8508217bda71cfc10cb2190d4d