### PR TITLE
Introduce basic support for `close_read` and `close_write`.

### DIFF
--- a/lib/openssl/ssl.rb
+++ b/lib/openssl/ssl.rb
@@ -459,6 +459,17 @@ ssbzSibBsu/6iGtCOGEoXJf//////////wIBAg==
         nil
       end
 
+      # Close the stream for reading.
+      def close_read
+        # Unsupported and ignored.
+        # Just don't read any more.
+      end
+
+      # Close the stream for writing.
+      def close_write
+        stop
+      end
+
       private
 
       def using_anon_cipher?

--- a/lib/openssl/ssl.rb
+++ b/lib/openssl/ssl.rb
@@ -460,12 +460,27 @@ ssbzSibBsu/6iGtCOGEoXJf//////////wIBAg==
       end
 
       # Close the stream for reading.
+      # This method is ignored by OpenSSL as there is no reasonable way to
+      # implement it, but exists for compatibility with IO.
       def close_read
         # Unsupported and ignored.
         # Just don't read any more.
       end
 
-      # Close the stream for writing.
+      # Closes the stream for writing. The behavior of this method depends on
+      # the version of OpenSSL and the TLS protocol in use.
+      # 
+      # In TLS 1.3 and later:
+      # - Sends a 'close_notify' alert to the peer.
+      # - Does not wait for the peer's 'close_notify' alert in response.
+      # 
+      # In TLS 1.2 and earlier:
+      # - Sends a 'close_notify' alert to the peer.
+      # - Waits for the peer's 'close_notify' alert in response.
+      # 
+      # Therefore, on TLS 1.2, this method will cause the connection to be
+      # completely shut down. On TLS 1.3, the connection will remain open for
+      # reading only.
       def close_write
         stop
       end

--- a/lib/openssl/ssl.rb
+++ b/lib/openssl/ssl.rb
@@ -469,15 +469,15 @@ ssbzSibBsu/6iGtCOGEoXJf//////////wIBAg==
 
       # Closes the stream for writing. The behavior of this method depends on
       # the version of OpenSSL and the TLS protocol in use.
-      # 
-      # In TLS 1.3 and later:
+      #
       # - Sends a 'close_notify' alert to the peer.
       # - Does not wait for the peer's 'close_notify' alert in response.
-      # 
+      #
       # In TLS 1.2 and earlier:
-      # - Sends a 'close_notify' alert to the peer.
-      # - Waits for the peer's 'close_notify' alert in response.
-      # 
+      # - On receipt of a 'close_notify' alert, responds with a 'close_notify'
+      #   alert of its own and close down the connection immediately,
+      #   discarding any pending writes.
+      #
       # Therefore, on TLS 1.2, this method will cause the connection to be
       # completely shut down. On TLS 1.3, the connection will remain open for
       # reading only.

--- a/test/openssl/test_ssl.rb
+++ b/test/openssl/test_ssl.rb
@@ -117,6 +117,30 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
     }
   end
 
+  def test_socket_close_write
+    server_proc = proc do |ctx, ssl|
+      message = ssl.read
+      ssl.write(message)
+      ssl.close_write
+    ensure
+      ssl.close
+    end
+    
+    start_server(server_proc: server_proc) do |port|
+      ctx = OpenSSL::SSL::SSLContext.new
+      ssl = OpenSSL::SSL::SSLSocket.open("127.0.0.1", port, context: ctx)
+      ssl.sync_close = true
+      ssl.connect
+
+      message = "abc"*1024
+      ssl.write message
+      ssl.close_write
+      assert_equal message, ssl.read
+    ensure
+      ssl&.close
+    end
+  end
+
   def test_add_certificate
     ctx_proc = -> ctx {
       # Unset values set by start_server


### PR DESCRIPTION
Introduce `SSLSocket#close_read` and `SSLSocket#close_write` + relevant test.

`#close_read` is a no-op and exists to match the expected interface of `IO`.

`#close_write` uses `#stop` which in testing appears to do what we want.

Fixes <https://github.com/ruby/openssl/issues/609>.