### PR TITLE
CI: Remove workaround for Ruby-3.2 and 3.3 on Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,15 +51,6 @@ jobs:
         run:  echo "RUBY_OPENSSL_EXTCFLAGS=-Werror" >> $GITHUB_ENV
         if: ${{ !matrix.skip-warnings }}
 
-      # Workaround: Enable provider search path to load the legacy provider
-      # (legacy.dll) in OpenSSL 3 in Windows MSYS2.
-      # Remove the workaround when the issue is fixed in Ruby 3.2 and 3.3
-      # builds.
-      # https://github.com/oneclick/rubyinstaller2/issues/365
-      - name: enable windows provider search path
-        run: echo "OPENSSL_MODULES=$($env:RI_DEVKIT)\$($env:MSYSTEM_PREFIX)\lib\ossl-modules" >> $env:GITHUB_ENV
-        if: runner.os == 'Windows' && (matrix.ruby == '3.2' || matrix.ruby == '3.3')
-
       - name: compile
         run:  rake compile
 


### PR DESCRIPTION
The issue https://github.com/oneclick/rubyinstaller2/issues/365 was fixed with the 3.2.4 and 3.3.1 releases.