### PR TITLE
Handle missing content in PKCS7

### DIFF
--- a/ext/openssl/ossl_pkcs7.c
+++ b/ext/openssl/ossl_pkcs7.c
@@ -346,6 +346,8 @@ ossl_pkcs7_initialize(int argc, VALUE *argv, VALUE self)
     BIO_free(in);
     if (!p7)
         ossl_raise(rb_eArgError, "Could not parse the PKCS7");
+    if (!p7->d.ptr)
+        ossl_raise(rb_eArgError, "No content in PKCS7");
 
     RTYPEDDATA_DATA(self) = p7;
     PKCS7_free(p7_orig);

--- a/ext/openssl/ossl_pkcs7.c
+++ b/ext/openssl/ossl_pkcs7.c
@@ -165,7 +165,11 @@ ossl_pkcs7_s_read_smime(VALUE klass, VALUE arg)
     out = NULL;
     pkcs7 = SMIME_read_PKCS7(in, &out);
     BIO_free(in);
-    if(!pkcs7) ossl_raise(ePKCS7Error, NULL);
+    if (!pkcs7)
+        ossl_raise(ePKCS7Error, "Could not parse the PKCS7");
+    if (!pkcs7->d.ptr)
+        ossl_raise(ePKCS7Error, "No content in PKCS7");
+
     data = out ? ossl_membio2str(out) : Qnil;
     SetPKCS7(ret, pkcs7);
     ossl_pkcs7_set_data(ret, data);

--- a/test/openssl/test_pkcs7.rb
+++ b/test/openssl/test_pkcs7.rb
@@ -158,6 +158,16 @@ class OpenSSL::TestPKCS7 < OpenSSL::TestCase
   def test_empty_signed_data_ruby_bug_19974
     data = "-----BEGIN PKCS7-----\nMAsGCSqGSIb3DQEHAg==\n-----END PKCS7-----\n"
     assert_raise(ArgumentError) { OpenSSL::PKCS7.new(data) }
+
+    data = <<END
+MIME-Version: 1.0
+Content-Disposition: attachment; filename="smime.p7m"
+Content-Type: application/x-pkcs7-mime; smime-type=signed-data; name="smime.p7m"
+Content-Transfer-Encoding: base64
+
+#{data}
+END
+    assert_raise(OpenSSL::PKCS7::PKCS7Error) { OpenSSL::PKCS7.read_smime(data) }
   end
 
   def test_graceful_parsing_failure #[ruby-core:43250]

--- a/test/openssl/test_pkcs7.rb
+++ b/test/openssl/test_pkcs7.rb
@@ -155,6 +155,11 @@ class OpenSSL::TestPKCS7 < OpenSSL::TestCase
     assert_equal(data, p7.decrypt(@rsa1024))
   end
 
+  def test_empty_signed_data_ruby_bug_19974
+    data = "-----BEGIN PKCS7-----\nMAsGCSqGSIb3DQEHAg==\n-----END PKCS7-----\n"
+    assert_raise(ArgumentError) { OpenSSL::PKCS7.new(data) }
+  end
+
   def test_graceful_parsing_failure #[ruby-core:43250]
     contents = File.read(__FILE__)
     assert_raise(ArgumentError) { OpenSSL::PKCS7.new(contents) }


### PR DESCRIPTION
This replaces https://github.com/ruby/openssl/pull/690.

 - Based on https://github.com/ruby/openssl/pull/690 by @jeremyevans,
 - rebased on top of maint-3.0,
 - applied the diff https://github.com/ruby/openssl/pull/690#issuecomment-2016531030 by @pkuzco,
 - corrected the exception type (`.read_smime` raises `OpenSSL::PKCS7::PKCS7Error` while `.new` raises `ArgumentError` -- which doesn't seem intentional, but that is a separate issue)