### PR TITLE
Add X509::Certificate#tbs_bytes

### DIFF
--- a/ext/openssl/extconf.rb
+++ b/ext/openssl/extconf.rb
@@ -149,6 +149,9 @@ engines.each { |name|
   have_func("ENGINE_load_#{name}()", "openssl/engine.h")
 }
 
+# missing in libressl < 3.5
+have_func("i2d_re_X509_tbs(NULL, NULL)", x509_h)
+
 # added in 1.1.0
 if !have_struct_member("SSL", "ctx", "openssl/ssl.h") || is_libressl
   $defs.push("-DHAVE_OPAQUE_OPENSSL")

--- a/test/openssl/test_x509cert.rb
+++ b/test/openssl/test_x509cert.rb
@@ -322,6 +322,15 @@ class OpenSSL::TestX509Certificate < OpenSSL::TestCase
     end
   end
 
+  def test_tbs_precert_bytes
+    pend "LibreSSL < 3.5 does not have i2d_re_X509_tbs" if libressl? && !libressl?(3, 5, 0)
+
+    cert = issue_cert(@ca, @rsa2048, 1, [], nil, nil)
+    seq = OpenSSL::ASN1.decode(cert.tbs_bytes)
+
+    assert_equal 7, seq.value.size
+  end
+
   private
 
   def certificate_error_returns_false


### PR DESCRIPTION
Ref https://github.com/ruby/openssl/issues/519

This makes verifying embedded certificate transparency signatures significantly easier, as otherwise the alternative was manipulating the ASN1 sequence, as in https://github.com/segiddins/sigstore-cosign-verify/pull/2/commits/656d992fa816613fd9936f53ce30972c2f2f4957