### PR TITLE
Add to_text for PKCS7 and Timestamp::Response

### DIFF
--- a/ext/openssl/ossl_pkcs7.c
+++ b/ext/openssl/ossl_pkcs7.c
@@ -848,6 +848,25 @@ ossl_pkcs7_to_der(VALUE self)
 }
 
 static VALUE
+ossl_pkcs7_to_text(VALUE self)
+{
+    PKCS7 *pkcs7;
+    BIO *out;
+    VALUE str;
+
+    GetPKCS7(self, pkcs7);
+    if(!(out = BIO_new(BIO_s_mem())))
+        ossl_raise(ePKCS7Error, NULL);
+    if(!PKCS7_print_ctx(out, pkcs7, 0, NULL)) {
+        BIO_free(out);
+        ossl_raise(ePKCS7Error, NULL);
+    }
+    str = ossl_membio2str(out);
+
+    return str;
+}
+
+static VALUE
 ossl_pkcs7_to_pem(VALUE self)
 {
     PKCS7 *pkcs7;
@@ -1056,6 +1075,7 @@ Init_ossl_pkcs7(void)
     rb_define_method(cPKCS7, "to_pem", ossl_pkcs7_to_pem, 0);
     rb_define_alias(cPKCS7,  "to_s", "to_pem");
     rb_define_method(cPKCS7, "to_der", ossl_pkcs7_to_der, 0);
+    rb_define_method(cPKCS7, "to_text", ossl_pkcs7_to_text, 0);
 
     cPKCS7Signer = rb_define_class_under(cPKCS7, "SignerInfo", rb_cObject);
     rb_define_const(cPKCS7, "Signer", cPKCS7Signer);

--- a/ext/openssl/ossl_ts.c
+++ b/ext/openssl/ossl_ts.c
@@ -504,6 +504,25 @@ ossl_ts_req_to_der(VALUE self)
 }
 
 static VALUE
+ossl_ts_req_to_text(VALUE self)
+{
+    TS_REQ *req;
+    BIO *out;
+
+    GetTSRequest(self, req);
+
+    out = BIO_new(BIO_s_mem());
+    if (!out) ossl_raise(eTimestampError, NULL);
+
+    if (!TS_REQ_print_bio(out, req)) {
+        BIO_free(out);
+        ossl_raise(eTimestampError, NULL);
+    }
+
+    return ossl_membio2str(out);
+}
+
+static VALUE
 ossl_ts_resp_alloc(VALUE klass)
 {
     TS_RESP *resp;
@@ -755,6 +774,25 @@ ossl_ts_resp_to_der(VALUE self)
 
     GetTSResponse(self, resp);
     return asn1_to_der((void *)resp, (int (*)(void *, unsigned char **))i2d_TS_RESP);
+}
+
+static VALUE
+ossl_ts_resp_to_text(VALUE self)
+{
+    TS_RESP *resp;
+    BIO *out;
+
+    GetTSResponse(self, resp);
+
+    out = BIO_new(BIO_s_mem());
+    if (!out) ossl_raise(eTimestampError, NULL);
+
+    if (!TS_RESP_print_bio(out, resp)) {
+        BIO_free(out);
+        ossl_raise(eTimestampError, NULL);
+    }
+
+    return ossl_membio2str(out);
 }
 
 /*
@@ -1073,6 +1111,25 @@ ossl_ts_token_info_to_der(VALUE self)
     return asn1_to_der((void *)info, (int (*)(void *, unsigned char **))i2d_TS_TST_INFO);
 }
 
+static VALUE
+ossl_ts_token_info_to_text(VALUE self)
+{
+    TS_TST_INFO *info;
+    BIO *out;
+
+    GetTSTokenInfo(self, info);
+
+    out = BIO_new(BIO_s_mem());
+    if (!out) ossl_raise(eTimestampError, NULL);
+
+    if (!TS_TST_INFO_print_bio(out, info)) {
+        BIO_free(out);
+        ossl_raise(eTimestampError, NULL);
+    }
+
+    return ossl_membio2str(out);
+}
+
 static ASN1_INTEGER *
 ossl_tsfac_serial_cb(struct TS_resp_ctx *ctx, void *data)
 {
@@ -1356,6 +1413,7 @@ Init_ossl_ts(void)
     rb_define_method(cTimestampResponse, "token_info", ossl_ts_resp_get_token_info, 0);
     rb_define_method(cTimestampResponse, "tsa_certificate", ossl_ts_resp_get_tsa_certificate, 0);
     rb_define_method(cTimestampResponse, "to_der", ossl_ts_resp_to_der, 0);
+    rb_define_method(cTimestampResponse, "to_text", ossl_ts_resp_to_text, 0);
     rb_define_method(cTimestampResponse, "verify", ossl_ts_resp_verify, -1);
 
     /* Document-class: OpenSSL::Timestamp::TokenInfo
@@ -1374,6 +1432,7 @@ Init_ossl_ts(void)
     rb_define_method(cTimestampTokenInfo, "ordering", ossl_ts_token_info_get_ordering, 0);
     rb_define_method(cTimestampTokenInfo, "nonce", ossl_ts_token_info_get_nonce, 0);
     rb_define_method(cTimestampTokenInfo, "to_der", ossl_ts_token_info_to_der, 0);
+    rb_define_method(cTimestampTokenInfo, "to_text", ossl_ts_token_info_to_text, 0);
 
     /* Document-class: OpenSSL::Timestamp::Request
      * Allows to create timestamp requests or parse existing ones. A Request is
@@ -1399,6 +1458,7 @@ Init_ossl_ts(void)
     rb_define_method(cTimestampRequest, "cert_requested=", ossl_ts_req_set_cert_requested, 1);
     rb_define_method(cTimestampRequest, "cert_requested?", ossl_ts_req_get_cert_requested, 0);
     rb_define_method(cTimestampRequest, "to_der", ossl_ts_req_to_der, 0);
+    rb_define_method(cTimestampRequest, "to_text", ossl_ts_req_to_text, 0);
 
     /*
      * Indicates a successful response. Equal to +0+.

--- a/test/openssl/test_pkcs7.rb
+++ b/test/openssl/test_pkcs7.rb
@@ -227,6 +227,12 @@ END
     assert_equal(p7.to_der, OpenSSL::PKCS7.read_smime(smime).to_der)
   end
 
+  def test_to_text
+    p7 = OpenSSL::PKCS7.new
+    p7.type = "signed"
+    assert_match(/signed/, p7.to_text)
+  end
+
   def test_degenerate_pkcs7
     ca_cert_pem = <<END
 -----BEGIN CERTIFICATE-----

--- a/test/openssl/test_ts.rb
+++ b/test/openssl/test_ts.rb
@@ -323,6 +323,8 @@ _end_of_pem_
     resp = fac.create_timestamp(ee_key, ts_cert_ee, req)
     assert_equal(OpenSSL::Timestamp::Response::GRANTED, resp.status)
     assert_equal("1.2.3.4.6", resp.token_info.policy_id)
+
+    assert_match(/1\.2\.3\.4\.6/, resp.to_text)
   end
 
   def test_response_bad_purpose


### PR DESCRIPTION
I added these while trying to debug why my timestamp usage was failing, figured someone else might find them useful as well