### PR TITLE
OpenSSL::ASN1.decode supports fractional times & time zones

### DIFF
--- a/ext/openssl/extconf.rb
+++ b/ext/openssl/extconf.rb
@@ -140,6 +140,7 @@ evp_h = "openssl/evp.h".freeze
 x509_h = "openssl/x509.h".freeze
 ts_h = "openssl/ts.h".freeze
 ssl_h = "openssl/ssl.h".freeze
+asn1_h = "openssl/asn1.h".freeze
 
 # compile options
 have_func("RAND_egd()", "openssl/rand.h")
@@ -192,6 +193,7 @@ have_func("SSL_CTX_set_post_handshake_auth(NULL, 0)", ssl_h)
 have_func("EVP_PKEY_check(NULL)", evp_h)
 have_func("EVP_PKEY_new_raw_private_key(0, NULL, (unsigned char *)\"\", 0)", evp_h)
 have_func("SSL_CTX_set_ciphersuites(NULL, \"\")", ssl_h)
+have_func("ASN1_TIME_to_tm(NULL, NULL)", asn1_h)
 
 # added in 3.0.0
 have_func("SSL_set0_tmp_dh_pkey(NULL, NULL)", ssl_h)

--- a/test/openssl/test_asn1.rb
+++ b/test/openssl/test_asn1.rb
@@ -399,6 +399,20 @@ class  OpenSSL::TestASN1 < OpenSSL::TestCase
   def test_utctime
     encode_decode_test B(%w{ 17 0D }) + "160908234339Z".b,
       OpenSSL::ASN1::UTCTime.new(Time.utc(2016, 9, 8, 23, 43, 39))
+
+    if openssl?(1, 1, 1)
+      decode_test B(%w{ 17 11 }) + "500908234339+0930".b,
+        OpenSSL::ASN1::UTCTime.new(Time.new(1950, 9, 8, 23, 43, 39, "+09:30"))
+      decode_test B(%w{ 17 0F }) + "5009082343-0930".b,
+        OpenSSL::ASN1::UTCTime.new(Time.new(1950, 9, 8, 23, 43, 0, "-09:30"))
+      assert_raise(OpenSSL::ASN1::ASN1Error) {
+        OpenSSL::ASN1.decode(B(%w{ 17 0C }) + "500908234339".b)
+      }
+      assert_raise(OpenSSL::ASN1::ASN1Error) {
+        OpenSSL::ASN1.decode(B(%w{ 17 0D }) + "500908234339Y".b)
+      }
+    end
+
     begin
       # possible range of UTCTime is 1969-2068 currently
       encode_decode_test B(%w{ 17 0D }) + "690908234339Z".b,
@@ -406,17 +420,6 @@ class  OpenSSL::TestASN1 < OpenSSL::TestCase
     rescue OpenSSL::ASN1::ASN1Error
       pend "No negative time_t support?"
     end
-    # not implemented
-    # decode_test B(%w{ 17 11 }) + "500908234339+0930".b,
-    #   OpenSSL::ASN1::UTCTime.new(Time.new(1950, 9, 8, 23, 43, 39, "+09:30"))
-    # decode_test B(%w{ 17 0F }) + "5009082343-0930".b,
-    #   OpenSSL::ASN1::UTCTime.new(Time.new(1950, 9, 8, 23, 43, 0, "-09:30"))
-    # assert_raise(OpenSSL::ASN1::ASN1Error) {
-    #   OpenSSL::ASN1.decode(B(%w{ 17 0C }) + "500908234339".b)
-    # }
-    # assert_raise(OpenSSL::ASN1::ASN1Error) {
-    #   OpenSSL::ASN1.decode(B(%w{ 17 0D }) + "500908234339Y".b)
-    # }
   end
 
   def test_generalizedtime
@@ -424,24 +427,26 @@ class  OpenSSL::TestASN1 < OpenSSL::TestCase
       OpenSSL::ASN1::GeneralizedTime.new(Time.utc(2016, 12, 8, 19, 34, 29))
     encode_decode_test B(%w{ 18 0F }) + "99990908234339Z".b,
       OpenSSL::ASN1::GeneralizedTime.new(Time.utc(9999, 9, 8, 23, 43, 39))
-    # not implemented
-    # decode_test B(%w{ 18 13 }) + "20161208193439+0930".b,
-    #   OpenSSL::ASN1::GeneralizedTime.new(Time.new(2016, 12, 8, 19, 34, 39, "+09:30"))
-    # decode_test B(%w{ 18 11 }) + "201612081934-0930".b,
-    #   OpenSSL::ASN1::GeneralizedTime.new(Time.new(2016, 12, 8, 19, 34, 0, "-09:30"))
-    # decode_test B(%w{ 18 11 }) + "201612081934-09".b,
-    #   OpenSSL::ASN1::GeneralizedTime.new(Time.new(2016, 12, 8, 19, 34, 0, "-09:00"))
-    # decode_test B(%w{ 18 0D }) + "2016120819.5Z".b,
-    #   OpenSSL::ASN1::GeneralizedTime.new(Time.utc(2016, 12, 8, 19, 30, 0))
-    # decode_test B(%w{ 18 0D }) + "2016120819,5Z".b,
-    #   OpenSSL::ASN1::GeneralizedTime.new(Time.utc(2016, 12, 8, 19, 30, 0))
-    # decode_test B(%w{ 18 0F }) + "201612081934.5Z".b,
-    #   OpenSSL::ASN1::GeneralizedTime.new(Time.utc(2016, 12, 8, 19, 34, 30))
-    # decode_test B(%w{ 18 11 }) + "20161208193439.5Z".b,
-    #   OpenSSL::ASN1::GeneralizedTime.new(Time.utc(2016, 12, 8, 19, 34, 39.5))
-    # assert_raise(OpenSSL::ASN1::ASN1Error) {
-    #   OpenSSL::ASN1.decode(B(%w{ 18 0D }) + "201612081934Y".b)
-    # }
+
+    if openssl?(1, 1, 1)
+      decode_test B(%w{ 18 13 }) + "20161208193439+0930".b,
+        OpenSSL::ASN1::GeneralizedTime.new(Time.new(2016, 12, 8, 19, 34, 39, "+09:30"))
+      decode_test B(%w{ 18 11 }) + "201612081934-0930".b,
+        OpenSSL::ASN1::GeneralizedTime.new(Time.new(2016, 12, 8, 19, 34, 0, "-09:30"))
+      # decode_test B(%w{ 18 0F }) + "201612081934-09".b,
+      #   OpenSSL::ASN1::GeneralizedTime.new(Time.new(2016, 12, 8, 19, 34, 0, "-09:00"))
+      # decode_test B(%w{ 18 0D }) + "2016120819.5Z".b,
+      #   OpenSSL::ASN1::GeneralizedTime.new(Time.utc(2016, 12, 8, 19, 30, 0))
+      # decode_test B(%w{ 18 0D }) + "2016120819,5Z".b,
+      #   OpenSSL::ASN1::GeneralizedTime.new(Time.utc(2016, 12, 8, 19, 30, 0))
+      # decode_test B(%w{ 18 0F }) + "201612081934.5Z".b,
+      #   OpenSSL::ASN1::GeneralizedTime.new(Time.utc(2016, 12, 8, 19, 34, 30))
+      decode_test B(%w{ 18 11 }) + "20161208193439.5Z".b,
+        OpenSSL::ASN1::GeneralizedTime.new(Time.utc(2016, 12, 8, 19, 34, 39.5))
+      assert_raise(OpenSSL::ASN1::ASN1Error) {
+        OpenSSL::ASN1.decode(B(%w{ 18 0D }) + "201612081934Y".b)
+      }
+    end
   end
 
   def test_basic_asn1data


### PR DESCRIPTION
Using ASN1_TIME_to_tm added in openssl 1.1.1

Closes https://github.com/ruby/openssl/issues/725