### PR TITLE
[CI] test.yml - use `bundle exec`, use setup-ruby bundler-cache, fixes Windows issue

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,8 +20,6 @@ jobs:
         os: [ ubuntu-22.04, ubuntu-20.04, macos-latest, windows-latest ]
         ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
         exclude:
-          # uses non-standard MSYS2 OpenSSL 3 package
-          - { os: windows-latest, ruby: head }
           - { os: windows-latest, ruby: truffleruby }
           - { os: windows-latest, ruby: truffleruby-head }
           - { os: macos-latest,   ruby: truffleruby }
@@ -38,9 +36,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-
-      - name: depends
-        run:  bundle install
+          bundler-cache: true # `bundle install` and cache
 
       # Enable the verbose option in mkmf.rb to print the compiling commands.
       - name: enable mkmf verbose
@@ -52,10 +48,10 @@ jobs:
         if: ${{ !matrix.skip-warnings }}
 
       - name: compile
-        run:  rake compile
+        run:  bundle exec rake compile
 
       - name: test
-        run:  rake test TESTOPTS="-v --no-show-detail-immediately"
+        run:  bundle exec rake test TESTOPTS="-v --no-show-detail-immediately"
         timeout-minutes: 5
 
   test-openssls:


### PR DESCRIPTION
I saw this [comment](https://github.com/ruby/openssl/pull/756#issuecomment-2100177620), which referred to [failing tests](https://github.com/ruby/openssl/actions/runs/8999647687) on Windows for Ruby 3.0 thru 3.2.

I'm not exactly sure what the issue is, as it involves setup-ruby updating Bundler without updating RubyGems, which is done to some Windows Rubies due to a lack of a bash `bin/bundle` file.

Also, at present, two items:

1. CI is using Bundler with a Gemfile, but it's not using `bundle exec`. This works, as Bundler defaults to installing gems such that one doesn't need `bundle exec`.

2. Because of the above, every CI job is downloading and installing the gems, although `setup-ruby` can cache them.

This PR removes the `bundle install` step, and uses `setup-ruby`'s  `bundler-cache` option.  It also runs steps with `bundle exec`.

All jobs passed in my fork...