### PR TITLE
[CI] Rakefile - require 'bundler/shared_helpers'

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 require 'rake/testtask'
 require 'rdoc/task'
-require 'bundler/gem_tasks'
+require 'bundler/shared_helpers'
 
 begin
   require 'rake/extensiontask'


### PR DESCRIPTION
Alternative to #758

This does not cache gems.