### PR TITLE
Fix test_create_with_mac_iter accidently setting keytype not maciter

### DIFF
--- a/ext/openssl/ossl_pkcs12.c
+++ b/ext/openssl/ossl_pkcs12.c
@@ -134,6 +134,10 @@ ossl_pkcs12_s_create(int argc, VALUE *argv, VALUE self)
     if (!NIL_P(keytype))
         ktype = NUM2INT(keytype);
 
+    if (ktype != 0 && ktype != KEY_SIG && ktype != KEY_EX) {
+        ossl_raise(rb_eArgError, "Unknown key usage type %"PRIsVALUE, INT2NUM(ktype));
+    }
+
     obj = NewPKCS12(cPKCS12);
     x509s = NIL_P(ca) ? NULL : ossl_x509_ary2sk(ca);
     p12 = PKCS12_create(passphrase, friendlyname, key, x509, x509s,
@@ -272,4 +276,8 @@ Init_ossl_pkcs12(void)
     rb_attr(cPKCS12, rb_intern("ca_certs"), 1, 0, Qfalse);
     rb_define_method(cPKCS12, "initialize", ossl_pkcs12_initialize, -1);
     rb_define_method(cPKCS12, "to_der", ossl_pkcs12_to_der, 0);
+
+    /* MSIE specific PKCS12 key usage extensions */
+    rb_define_const(cPKCS12, "KEY_EX", INT2NUM(KEY_EX));
+    rb_define_const(cPKCS12, "KEY_SIG", INT2NUM(KEY_SIG));
 }

--- a/test/openssl/test_pkcs12.rb
+++ b/test/openssl/test_pkcs12.rb
@@ -159,7 +159,6 @@ module OpenSSL
         DEFAULT_PBE_PKEYS,
         DEFAULT_PBE_CERTS,
         nil,
-        nil,
         2048
       )
 
@@ -174,6 +173,36 @@ module OpenSSL
           DEFAULT_PBE_CERTS,
           nil,
           "omg"
+        )
+      end
+    end
+
+    def test_create_with_keytype
+      OpenSSL::PKCS12.create(
+        "omg",
+        "hello",
+        @mykey,
+        @mycert,
+        [],
+        DEFAULT_PBE_PKEYS,
+        DEFAULT_PBE_CERTS,
+        nil,
+        nil,
+        OpenSSL::PKCS12::KEY_SIG
+      )
+
+      assert_raise(ArgumentError) do
+        OpenSSL::PKCS12.create(
+          "omg",
+          "hello",
+          @mykey,
+          @mycert,
+          [],
+          DEFAULT_PBE_PKEYS,
+          DEFAULT_PBE_CERTS,
+          nil,
+          nil,
+          2048
         )
       end
     end


### PR DESCRIPTION
This test was accidentally passing the value 2048 into the keytype parameter of PKCS12_create, not the mac_iter parameter (because it had one too many `nil`s in the call). This value is invalid, and will make OpenSSL perform an out-of-bounds read which is caught when compiling with ASAN.

This commit fixes the tests, and also adds some validation to PKCS12.create to make sure any keytype passed is actually valid. Since there only two valid keytype constants, and the whole feature is an export-grade crypto era thing only ever supported by old MSIE, it seems far more likely that code in the wild is using keytype similarly by mistake rather than as intended. So this validation might catch that.