### PR TITLE
Don't download OpenSSL from ftp.openssl.org anyomre

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,9 +88,9 @@ jobs:
           - { os: ubuntu-latest, ruby: "3.0", openssl: openssl-3.1.5, fips-enabled: true, append-configure: 'enable-fips', name-extra: 'fips' }
           - { os: ubuntu-latest, ruby: "3.0", openssl: openssl-3.2.1, fips-enabled: true, append-configure: 'enable-fips', name-extra: 'fips' }
           - { os: ubuntu-latest, ruby: "3.0", openssl: openssl-3.3.0, fips-enabled: true, append-configure: 'enable-fips', name-extra: 'fips' }
-          - { os: ubuntu-latest, ruby: "3.0", openssl: openssl-head, git: 'git://git.openssl.org/openssl.git', branch: 'master' }
-          - { os: ubuntu-latest, ruby: "3.0", openssl: openssl-head, git: 'git://git.openssl.org/openssl.git', branch: 'master', fips-enabled: true, append-configure: 'enable-fips', name-extra: 'fips' }
-          - { os: ubuntu-latest, ruby: "3.0", openssl: openssl-head, git: 'git://git.openssl.org/openssl.git', branch: 'master', append-configure: 'no-legacy', name-extra: 'no-legacy' }
+          - { os: ubuntu-latest, ruby: "3.0", openssl: openssl-head, git: 'https://github.com/openssl/openssl.git', branch: 'master' }
+          - { os: ubuntu-latest, ruby: "3.0", openssl: openssl-head, git: 'https://github.com/openssl/openssl.git', branch: 'master', fips-enabled: true, append-configure: 'enable-fips', name-extra: 'fips' }
+          - { os: ubuntu-latest, ruby: "3.0", openssl: openssl-head, git: 'https://github.com/openssl/openssl.git', branch: 'master', append-configure: 'no-legacy', name-extra: 'no-legacy' }
     steps:
       - name: repo checkout
         uses: actions/checkout@v4
@@ -103,7 +103,7 @@ jobs:
           case ${{ matrix.openssl }} in
           openssl-*)
             if [ -z "${{ matrix.git }}" ]; then
-              curl -OL https://ftp.openssl.org/source/${{ matrix.openssl }}.tar.gz
+              curl -OL https://openssl.org/source/${{ matrix.openssl }}.tar.gz
               tar xf ${{ matrix.openssl }}.tar.gz && cd ${{ matrix.openssl }}
             else
               git clone -b ${{ matrix.branch }} --depth 1 ${{ matrix.git }} ${{ matrix.openssl }}


### PR DESCRIPTION
OpenSSL announced that they're changing how they handle releases in this blog post: https://openssl.org/blog/blog/2024/04/30/releases-distribution-changes/

The tl;dr is that:

* ftp.openssl.org is being shut down (even for HTTP access)
* The releases at openssl.org/source will redirect to github
* git.openssl.org is also shut down (the git repo is on github)

This commit just changes over to using openss.org/source instead of ftp.openssl.org. We might also need to switch to downloading directly from Github... let's see.

It also changes to cloning the head of openssl from github too.