### PR TITLE
CI: Rely on setup-ruby to install Bundler gems

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -14,8 +14,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ruby
-          bundler-cache: true
-      - run: bundle install
+          bundler-cache: true # 'bundle install' and cache gems
       - run: rake rdoc
       - name: Upload GitHub Pages artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
This PR avoids an extra invocation of bundle install.

The only place this was used like this was in https://github.com/ruby/openssl/pull/764/files 