### PR TITLE
ssl: do not enable OpenSSL::SSL::OP_ALL by default

### DIFF
--- a/ext/openssl/ossl_ssl.c
+++ b/ext/openssl/ossl_ssl.c
@@ -757,7 +757,10 @@ ssl_info_cb(const SSL *ssl, int where, int val)
 }
 
 /*
- * Gets various OpenSSL options.
+ * call-seq:
+ *    ctx.options -> integer
+ *
+ * Gets various \OpenSSL options.
  */
 static VALUE
 ossl_sslctx_get_options(VALUE self)
@@ -772,7 +775,17 @@ ossl_sslctx_get_options(VALUE self)
 }
 
 /*
- * Sets various OpenSSL options.
+ * call-seq:
+ *    ctx.options = integer
+ *
+ * Sets various \OpenSSL options. The options are a bit field and can be
+ * combined with the bitwise OR operator (<tt>|</tt>). Available options are
+ * defined as constants in OpenSSL::SSL that begin with +OP_+.
+ *
+ * For backwards compatibility, passing +nil+ has the same effect as passing
+ * OpenSSL::SSL::OP_ALL.
+ *
+ * See also man page SSL_CTX_set_options(3).
  */
 static VALUE
 ossl_sslctx_set_options(VALUE self, VALUE options)

--- a/lib/openssl/ssl.rb
+++ b/lib/openssl/ssl.rb
@@ -144,7 +144,7 @@ ssbzSibBsu/6iGtCOGEoXJf//////////wIBAg==
       # used.
       def set_params(params={})
         params = DEFAULT_PARAMS.merge(params)
-        self.options = params.delete(:options) # set before min_version/max_version
+        self.options |= params.delete(:options) # set before min_version/max_version
         params.each{|name, value| self.__send__("#{name}=", value) }
         if self.verify_mode != OpenSSL::SSL::VERIFY_NONE
           unless self.ca_file or self.ca_path or self.cert_store

--- a/lib/openssl/ssl.rb
+++ b/lib/openssl/ssl.rb
@@ -125,7 +125,6 @@ ssbzSibBsu/6iGtCOGEoXJf//////////wIBAg==
       # that this form is deprecated. New applications should use #min_version=
       # and #max_version= as necessary.
       def initialize(version = nil)
-        self.options |= OpenSSL::SSL::OP_ALL
         self.ssl_version = version if version
         self.verify_mode = OpenSSL::SSL::VERIFY_NONE
         self.verify_hostname = false

--- a/test/openssl/test_ssl.rb
+++ b/test/openssl/test_ssl.rb
@@ -57,6 +57,8 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
       assert_separately([{ "OPENSSL_CONF" => f.path }, "-ropenssl"], <<~"end;")
         ctx = OpenSSL::SSL::SSLContext.new
         assert_equal OpenSSL::SSL::OP_NO_TICKET, ctx.options & OpenSSL::SSL::OP_NO_TICKET
+        ctx.set_params
+        assert_equal OpenSSL::SSL::OP_NO_TICKET, ctx.options & OpenSSL::SSL::OP_NO_TICKET
       end;
     }
   end


### PR DESCRIPTION
Respect the SSL options set by default by `SSL_CTX()` or by the system-wide OpenSSL configuration file.

`OpenSSL::SSL::SSLContext#initialize` currently adds `OpenSSL::SSL::OP_ALL` on top of the default SSL options. Let's stop doing it.

`OpenSSL::SSL::OP_ALL` is a set of options that changes OpenSSL's behavior to workaround various TLS implementation bugs. Using it is considered usually safe, but is not completely harmless.

---
Also:

**ssl: do not clear existing SSL options in `SSLContext#set_params`**

Apply SSL options set in `DEFAULT_PARAMS `without clearing existing options, which may be set by a system-wide configuration file.

With a fresh installation of OpenSSL 3.3.1, this change will enable the `OpenSSL::SSL::OP_ENABLE_MIDDLEBOX_COMPAT` option for users of `SSLContext#set_params`.

---

The last commit in this PR fixes https://github.com/ruby/openssl/issues/765.
