### PR TITLE
Remove "gemspec" from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,5 @@
 source "https://rubygems.org"
 
-gemspec
-
 gem "rake"
 gem "rake-compiler"
 gem "test-unit", "~> 3.0", ">= 3.4.6"


### PR DESCRIPTION
The local lib directory may contain an incomplete openssl library.

The "gemspec" line in Gemfile causes "bundle exec" to put the lib directory in the load path. Although our Rakefile does not use openssl itself, it still indirectly tries to load it as a RubyGems dependency.