### PR TITLE
Set time directly on the x509 store

### DIFF
--- a/ext/openssl/extconf.rb
+++ b/ext/openssl/extconf.rb
@@ -190,6 +190,7 @@ have_func("TS_VERIFY_CTX_add_flags(NULL, 0)", ts_h)
 have_func("TS_RESP_CTX_set_time_cb(NULL, NULL, NULL)", ts_h)
 have_func("EVP_PBE_scrypt(\"\", 0, (unsigned char *)\"\", 0, 0, 0, 0, 0, NULL, 0)", evp_h)
 have_func("SSL_CTX_set_post_handshake_auth(NULL, 0)", ssl_h)
+have_func("X509_STORE_get0_param(NULL)", x509_h)
 
 # added in 1.1.1
 have_func("EVP_PKEY_check(NULL)", evp_h)

--- a/ext/openssl/ossl_x509store.c
+++ b/ext/openssl/ossl_x509store.c
@@ -223,7 +223,6 @@ ossl_x509store_initialize(int argc, VALUE *argv, VALUE self)
     rb_iv_set(self, "@error", Qnil);
     rb_iv_set(self, "@error_string", Qnil);
     rb_iv_set(self, "@chain", Qnil);
-    rb_iv_set(self, "@time", Qnil);
 
     return self;
 }
@@ -329,7 +328,16 @@ ossl_x509store_set_trust(VALUE self, VALUE trust)
 static VALUE
 ossl_x509store_set_time(VALUE self, VALUE time)
 {
-    rb_iv_set(self, "@time", time);
+    X509_STORE *store;
+    X509_VERIFY_PARAM *param;
+
+    GetX509Store(self, store);
+#if HAVE_X509_STORE_GET0_PARAM
+    param = X509_STORE_get0_param(store);
+#else
+    param = store->param;
+#endif
+    X509_VERIFY_PARAM_set_time(param, NUM2LONG(rb_Integer(time)));
     return time;
 }
 
@@ -564,7 +572,6 @@ ossl_x509stctx_new(X509_STORE_CTX *ctx)
 static VALUE ossl_x509stctx_set_flags(VALUE, VALUE);
 static VALUE ossl_x509stctx_set_purpose(VALUE, VALUE);
 static VALUE ossl_x509stctx_set_trust(VALUE, VALUE);
-static VALUE ossl_x509stctx_set_time(VALUE, VALUE);
 
 /*
  * call-seq:
@@ -575,7 +582,7 @@ static VALUE ossl_x509stctx_set_time(VALUE, VALUE);
 static VALUE
 ossl_x509stctx_initialize(int argc, VALUE *argv, VALUE self)
 {
-    VALUE store, cert, chain, t;
+    VALUE store, cert, chain;
     X509_STORE_CTX *ctx;
     X509_STORE *x509st;
     X509 *x509 = NULL;
@@ -599,8 +606,6 @@ ossl_x509stctx_initialize(int argc, VALUE *argv, VALUE self)
         sk_X509_pop_free(x509s, X509_free);
         ossl_raise(eX509StoreError, "X509_STORE_CTX_init");
     }
-    if (!NIL_P(t = rb_iv_get(store, "@time")))
-	ossl_x509stctx_set_time(self, t);
     rb_iv_set(self, "@verify_callback", rb_iv_get(store, "@verify_callback"));
     rb_iv_set(self, "@cert", cert);
 

--- a/ext/openssl/ossl_x509store.c
+++ b/ext/openssl/ossl_x509store.c
@@ -332,7 +332,7 @@ ossl_x509store_set_time(VALUE self, VALUE time)
     X509_VERIFY_PARAM *param;
 
     GetX509Store(self, store);
-#if HAVE_X509_STORE_GET0_PARAM
+#ifdef HAVE_X509_STORE_GET0_PARAM
     param = X509_STORE_get0_param(store);
 #else
     param = store->param;


### PR DESCRIPTION
Instead of an ivar, so other ossl functions that take a store (such as `OpenSSL::Timestamp::Response#verify`) will use the correct time when verifying