### PR TITLE
x509attr: avoid using OpenSSL::ASN1 internals in #value=

### DIFF
--- a/ext/openssl/ossl_asn1.c
+++ b/ext/openssl/ossl_asn1.c
@@ -497,7 +497,7 @@ static VALUE class_tag_map;
 
 static int ossl_asn1_default_tag(VALUE obj);
 
-ASN1_TYPE*
+static ASN1_TYPE *
 ossl_asn1_get_asn1type(VALUE obj)
 {
     ASN1_TYPE *ret;

--- a/ext/openssl/ossl_asn1.h
+++ b/ext/openssl/ossl_asn1.h
@@ -57,8 +57,6 @@ extern VALUE cASN1Sequence, cASN1Set;                /* CONSTRUCTIVE      */
 
 extern VALUE cASN1EndOfContent;                      /* END OF CONTENT      */
 
-ASN1_TYPE *ossl_asn1_get_asn1type(VALUE);
-
 void Init_ossl_asn1(void);
 
 #endif

--- a/test/openssl/test_x509attr.rb
+++ b/test/openssl/test_x509attr.rb
@@ -48,6 +48,10 @@ class OpenSSL::TestX509Attribute < OpenSSL::TestCase
     assert_raise(TypeError) {
       attr.value = "1234"
     }
+    assert_raise(OpenSSL::X509::AttributeError) {
+      v = OpenSSL::ASN1::Set([OpenSSL::ASN1::UTF8String("1234")], 17, :EXPLICIT)
+      attr.value = v
+    }
     assert_equal(test_der, attr.to_der)
     assert_raise(OpenSSL::X509::AttributeError) {
       attr.oid = "abc123"


### PR DESCRIPTION
OpenSSL::ASN1 is being rewritten in Ruby. To make it easier, let's remove dependency to the instance variables and the internal-use function ossl_asn1_get_asn1type() outside OpenSSL::ASN1.

This also fixes the insufficient validation of the passed value with its tagging.