### PR TITLE
A temporary workaround to download OpenSSL archive files.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,14 +64,6 @@ jobs:
         os: [ ubuntu-latest ]
         ruby: [ "3.0" ]
         openssl:
-          # https://www.openssl.org/source/
-          - openssl-1.0.2u # EOL
-          - openssl-1.1.0l # EOL
-          - openssl-1.1.1w # EOL
-          - openssl-3.0.13
-          - openssl-3.1.5
-          - openssl-3.2.1
-          - openssl-3.3.0
           # http://www.libressl.org/releases.html
           - libressl-3.1.5 # EOL
           - libressl-3.2.7 # EOL
@@ -84,10 +76,19 @@ jobs:
           - libressl-3.9.1
         fips-enabled: [ false ]
         include:
-          - { os: ubuntu-latest, ruby: "3.0", openssl: openssl-3.0.13, fips-enabled: true, append-configure: 'enable-fips', name-extra: 'fips' }
-          - { os: ubuntu-latest, ruby: "3.0", openssl: openssl-3.1.5, fips-enabled: true, append-configure: 'enable-fips', name-extra: 'fips' }
-          - { os: ubuntu-latest, ruby: "3.0", openssl: openssl-3.2.1, fips-enabled: true, append-configure: 'enable-fips', name-extra: 'fips' }
-          - { os: ubuntu-latest, ruby: "3.0", openssl: openssl-3.3.0, fips-enabled: true, append-configure: 'enable-fips', name-extra: 'fips' }
+          # A temporary workaround for OpenSSL source files.
+          # https://openssl-library.org/source/old/
+          - { os: ubuntu-latest, ruby: "3.0", openssl: openssl-1.0.2u, openssl-site-dir: '1.0.2' } # EOL
+          - { os: ubuntu-latest, ruby: "3.0", openssl: openssl-1.1.0l, openssl-site-dir: '1.1.0' } # EOL
+          - { os: ubuntu-latest, ruby: "3.0", openssl: openssl-1.1.1w, openssl-site-dir: '1.1.1' } # EOL
+          - { os: ubuntu-latest, ruby: "3.0", openssl: openssl-3.0.13, openssl-site-dir: '3.0' }
+          - { os: ubuntu-latest, ruby: "3.0", openssl: openssl-3.1.5, openssl-site-dir: '3.1' }
+          - { os: ubuntu-latest, ruby: "3.0", openssl: openssl-3.2.1, openssl-site-dir: '3.2' }
+          - { os: ubuntu-latest, ruby: "3.0", openssl: openssl-3.3.0, openssl-site-dir: '3.3' }
+          - { os: ubuntu-latest, ruby: "3.0", openssl: openssl-3.0.13, openssl-site-dir: '3.0', fips-enabled: true, append-configure: 'enable-fips', name-extra: 'fips' }
+          - { os: ubuntu-latest, ruby: "3.0", openssl: openssl-3.1.5, openssl-site-dir: '3.1', fips-enabled: true, append-configure: 'enable-fips', name-extra: 'fips' }
+          - { os: ubuntu-latest, ruby: "3.0", openssl: openssl-3.2.1, openssl-site-dir: '3.2', fips-enabled: true, append-configure: 'enable-fips', name-extra: 'fips' }
+          - { os: ubuntu-latest, ruby: "3.0", openssl: openssl-3.3.0, openssl-site-dir: '3.3', fips-enabled: true, append-configure: 'enable-fips', name-extra: 'fips' }
           - { os: ubuntu-latest, ruby: "3.0", openssl: openssl-head, git: 'https://github.com/openssl/openssl.git', branch: 'master' }
           - { os: ubuntu-latest, ruby: "3.0", openssl: openssl-head, git: 'https://github.com/openssl/openssl.git', branch: 'master', fips-enabled: true, append-configure: 'enable-fips', name-extra: 'fips' }
           - { os: ubuntu-latest, ruby: "3.0", openssl: openssl-head, git: 'https://github.com/openssl/openssl.git', branch: 'master', append-configure: 'no-legacy', name-extra: 'no-legacy' }
@@ -103,7 +104,7 @@ jobs:
           case ${{ matrix.openssl }} in
           openssl-*)
             if [ -z "${{ matrix.git }}" ]; then
-              curl -OL https://openssl.org/source/${{ matrix.openssl }}.tar.gz
+              curl -OL https://openssl.org/source/old/${{ matrix.openssl-site-dir }}/${{ matrix.openssl }}.tar.gz
               tar xf ${{ matrix.openssl }}.tar.gz && cd ${{ matrix.openssl }}
             else
               git clone -b ${{ matrix.branch }} --depth 1 ${{ matrix.git }} ${{ matrix.openssl }}


### PR DESCRIPTION
This PR is a temporary workaround for one of the 2 issues reported on the issue ticket https://github.com/ruby/openssl/issues/778 . I think we want to keep the CI as green as much as possible without down time. Let's apply this workaround. We can revert this commit later when I confirmed the OpenSSL site issue is fixed.

The `https://openssl.org/source/${{ matrix.openssl }}.tar.gz` links are not available right now.

See https://github.com/openssl/openssl/discussions/24984 for details.


I checked this PR on my forked repository in advance. The openssl-head fips case's failiure is another issue.
https://github.com/junaruga/ruby-openssl/actions/runs/10077294504/job/27859497255