### PR TITLE
CI: List OpenSSL providers by openssl CLI in FIPS cases.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,7 +112,10 @@ jobs:
               echo "Git commit: $(git rev-parse HEAD)"
             fi
             # shared is required for 1.0.x.
-            ./Configure --prefix=$HOME/.openssl/${{ matrix.openssl }} --libdir=lib \
+            ./Configure \
+                --prefix=$HOME/.openssl/${{ matrix.openssl }} \
+                --libdir=lib \
+                '-Wl,-rpath,$(LIBRPATH)' \
                 shared linux-x86_64 ${{ matrix.append-configure }}
             make depend
             ;;
@@ -141,6 +144,11 @@ jobs:
 
       - name: set openssl config file path for fips.
         run: echo "OPENSSL_CONF=$(pwd)/tmp/openssl_fips.cnf" >> $GITHUB_ENV
+        if: matrix.fips-enabled
+
+      # Check if the base and fips providers are loaded.
+      - name: list providers.
+        run: $HOME/.openssl/${{ matrix.openssl }}/bin/openssl list -providers
         if: matrix.fips-enabled
 
       - name: load ruby


### PR DESCRIPTION
This PR is to add the step to list OpenSSL providers in FIPS cases.
While we are calling the logic to list the OpenSSL providers in the `rake test` or `rake test_fips`. In the case where the fips provider is not loaded, the Ruby OpenSSL aborts before printing the providers. This PR enables the CI to print the providers such cases.

I was able to find the fips provider was not loaded with the openssl-head fips case by this commit.
https://github.com/junaruga/ruby-openssl/actions/runs/10078885746/job/27864878836#step:7:1

Below is the commit message.

---

Add the step to list OpenSSL providers available on OpenSSL 3.0 or later versions to check if the base and fips providers are loaded in the FIPS cases.

We have a logic to print the OpenSSL providers in the Rake test and test_fips tasks calling the debug task.
https://github.com/ruby/openssl/blob/16aa2b2f0c10d9d2b6ccf09628d248ba9d2f3f4e/Rakefile#L72

However, if the fips provider is not loaded, the Ruby OpenSSL aborts before printing the OpenSSL providers in the Rake debug task. https://github.com/ruby/openssl/actions/runs/10077703798/job/27860837398#step:13:35

This commit enables CI to print the loaded OpenSSL providers in such case.

Added the `'-Wl,-rpath,$(LIBRPATH)'` to call the openssl cli without setting `LD_LIBRARY_PATH`.
See https://github.com/ruby/openssl/blob/master/CONTRIBUTING.md#with-different-versions-of-openssl for details.