### PR TITLE
Make "rake debug" protective for a Ruby OpenSSL loading error.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -72,7 +72,7 @@ task :debug do
       Providers: #{providers_str}
     MESSAGE
   EOF
-  ruby %Q(-I./lib -ropenssl -ve'#{ruby_code}')
+  ruby %Q(-I./lib -ropenssl.so -ve'#{ruby_code}')
 end
 
 task :default => :test


### PR DESCRIPTION
This PR is to make "rake debug" enhance, on the way suggested at https://github.com/ruby/openssl/pull/780#issuecomment-2250383833. I didn't need to take the `rake debug` out from `Rakefile`. Because the ruby code is executed in the child process by the `ruby %Q(-I./lib -ropenssl.so -ve'#{ruby_code}')` in the `Rakefile`.

---

We experienced a FIPS case specific Ruby OpenSSL error in the loading process of Ruby OpenSSL by calling the `ruby -ropenssl` (`require 'openssl'`) built with OpenSSL master branch which includes the commit <https://github.com/openssl/openssl/commit/6d47e819f2101f0219ddee67e855701e7bc3a716> but doesn't include the commit <https://github.com/openssl/openssl/commit/3c6e11495975a4eda4cc5886080afed6203711ac> fixing the issue.

The following error happened at `lib/openssl.rb:22` calling the `lib/openssl/ssl.rb` with the OpenSSL commit
<14e46600c68ece74970462a60ad20703221747a1> which is between the above 2 commits.

```
$ OPENSSL_CONF=/home/jaruga/.local/openssl-3.4.0-dev-fips-debug-14e46600c6/ssl/openssl_fips.cnf \
  bundle exec rake debug
...
ruby 3.4.0dev (2024-07-22T08:33:07Z master 82aee1a946) [x86_64-linux]
/home/jaruga/var/git/ruby/openssl/lib/openssl/pkey.rb:132:in 'OpenSSL::PKey::DH#initialize': could not parse pkey (OpenSSL::PKey::DHError)
  from /home/jaruga/var/git/ruby/openssl/lib/openssl/pkey.rb:132:in 'Class#new'
  from /home/jaruga/var/git/ruby/openssl/lib/openssl/pkey.rb:132:in 'OpenSSL::PKey::DH.new'
  from /home/jaruga/var/git/ruby/openssl/lib/openssl/ssl.rb:36:in '<class:SSLContext>'
  from /home/jaruga/var/git/ruby/openssl/lib/openssl/ssl.rb:23:in '<module:SSL>'
  from /home/jaruga/var/git/ruby/openssl/lib/openssl/ssl.rb:22:in '<module:OpenSSL>'
  from /home/jaruga/var/git/ruby/openssl/lib/openssl/ssl.rb:21:in '<top (required)>'
  from /home/jaruga/var/git/ruby/openssl/lib/openssl.rb:22:in 'Kernel#require_relative'
  from /home/jaruga/var/git/ruby/openssl/lib/openssl.rb:22:in '<top (required)>'
  from /home/jaruga/.local/ruby-3.4.0dev-debug-82aee1a946/lib/ruby/3.4.0+0/bundled_gems.rb:71:in 'Kernel.require'
  from /home/jaruga/.local/ruby-3.4.0dev-debug-82aee1a946/lib/ruby/3.4.0+0/bundled_gems.rb:71:in 'block (2 levels) in Kernel#replace_require'
rake aborted!
```

This commit enables the `rake debug` still to print the debugging values in such cases. In this case, the `rake debug` prints only the base provider without fips provider. That was a bug of OpenSSL.

```
$ OPENSSL_CONF=/home/jaruga/.local/openssl-3.4.0-dev-fips-debug-14e46600c6/ssl/openssl_fips.cnf \
  bundle exec rake debug
...
ruby 3.4.0dev (2024-07-22T08:33:07Z master 82aee1a946) [x86_64-linux]
OpenSSL::OPENSSL_VERSION: OpenSSL 3.4.0-dev
OpenSSL::OPENSSL_LIBRARY_VERSION: OpenSSL 3.4.0-dev
OpenSSL::OPENSSL_VERSION_NUMBER: 30400000
OpenSSL::LIBRESSL_VERSION_NUMBER: undefined
FIPS enabled: true
Providers: base
```