### PR TITLE
Remove test_ed25519_not_approved_on_fips.

### DIFF
--- a/test/openssl/test_pkey.rb
+++ b/test/openssl/test_pkey.rb
@@ -150,32 +150,6 @@ class OpenSSL::TestPKey < OpenSSL::PKeyTestCase
     assert_raise(OpenSSL::PKey::PKeyError) { priv.derive(pub) }
   end
 
-  def test_ed25519_not_approved_on_fips
-    omit_on_non_fips
-    # Ed25519 is technically allowed in the OpenSSL 3.0 code as a kind of bug.
-    # So, we need to omit OpenSSL 3.0.
-    #
-    # See OpenSSL providers/fips/fipsprov.c PROV_NAMES_ED25519 entries with
-    # FIPS_DEFAULT_PROPERTIES on openssl-3.0 branch and
-    # FIPS_UNAPPROVED_PROPERTIES on openssl-3.1 branch.
-    #
-    # See also
-    # https://github.com/openssl/openssl/issues/20758#issuecomment-1639658102
-    # for details.
-    unless openssl?(3, 1, 0, 0)
-      omit 'Ed25519 is allowed in the OpenSSL 3.0 FIPS code as a kind of bug'
-    end
-
-    priv_pem = <<~EOF
-    -----BEGIN PRIVATE KEY-----
-    MC4CAQAwBQYDK2VwBCIEIEzNCJso/5banbbDRuwRTg9bijGfNaumJNqM9u1PuKb7
-    -----END PRIVATE KEY-----
-    EOF
-    assert_raise(OpenSSL::PKey::PKeyError) do
-      OpenSSL::PKey.read(priv_pem)
-    end
-  end
-
   def test_x25519
     # Test vector from RFC 7748 Section 6.1
     alice_pem = <<~EOF


### PR DESCRIPTION
This PR fixes https://github.com/ruby/openssl/issues/787.

---

This commit fixes the following failure on OpenSSL master FIPS case.

```
1) Failure: test_ed25519_not_approved_on_fips(OpenSSL::TestPKey): OpenSSL::PKey::PKeyError expected but nothing was raised.
/home/runner/work/openssl/openssl/vendor/bundle/ruby/3.0.0/gems/test-unit-ruby-core-1.0.6/lib/core_assertions.rb:462:in `assert_raise'
/home/runner/work/openssl/openssl/test/openssl/test_pkey.rb:174:in `test_ed25519_not_approved_on_fips'
     171:     MC4CAQAwBQYDK2VwBCIEIEzNCJso/5banbbDRuwRTg9bijGfNaumJNqM9u1PuKb7
     172:     -----END PRIVATE KEY-----
     173:     EOF
  => 174:     assert_raise(OpenSSL::PKey::PKeyError) do
     175:       OpenSSL::PKey.read(priv_pem)
     176:     end
     177:   end
```

Because FIPS compliance is a continually moving target. According to the [1], FIPS 140-3 *currently* allows ED25519. The ED25519 is allowed again with the latest OpenSSL FIPS by the commit [2], while it is not allowed in OpenSSL stable version 3.x FIPS.

Remove this test because we want to keep our tests stable.

[1] https://github.com/openssl/openssl/discussions/22054
[2] https://github.com/openssl/openssl/commit/5f04124aab4a477d4e58149d8f04871ff7e5ea4b