### PR TITLE
pkcs7: remove default cipher from PKCS7.encrypt

### DIFF
--- a/test/openssl/test_pkcs7.rb
+++ b/test/openssl/test_pkcs7.rb
@@ -153,6 +153,11 @@ class OpenSSL::TestPKCS7 < OpenSSL::TestCase
     assert_equal(data, p7.decrypt(@rsa1024, @ee2_cert))
 
     assert_equal(data, p7.decrypt(@rsa1024))
+
+    # Default cipher has been removed in v3.3
+    assert_raise_with_message(ArgumentError, /RC2-40-CBC/) {
+      OpenSSL::PKCS7.encrypt(certs, data)
+    }
   end
 
   def test_empty_signed_data_ruby_bug_19974


### PR DESCRIPTION
Fixes the bug reported at https://github.com/ruby/ruby/pull/11515 in a different way. Defaulting to 40-bit RC2 doesn't seem right to me in the first place.

---

Require that users explicitly specify the desired algorithm. In my opinion, we are not in a position to specify the default cipher.

When OpenSSL::PKCS7.encrypt is given only two arguments, it uses "RC2-40-CBC" as the symmetric cipher algorithm. 40-bit RC2 is a US export-grade cipher and considered insecure.

Although this is technically a breaking change, the impact should be minimal. Even when OpenSSL is compiled with RC2 support and the macro OPENSSL_NO_RC2 is not defined, it will not actually work on modern systems because RC2 is part of the legacy provider.