### PR TITLE
Fix incorrect function name

### DIFF
--- a/ext/openssl/ossl_pkcs7.c
+++ b/ext/openssl/ossl_pkcs7.c
@@ -281,7 +281,7 @@ ossl_pkcs7_s_encrypt(int argc, VALUE *argv, VALUE klass)
 #elif !defined(OPENSSL_NO_RC2)
 	ciph = EVP_rc2_40_cbc();
 #elif !defined(OPENSSL_NO_AES)
-	ciph = EVP_EVP_aes_128_cbc();
+	ciph = EVP_aes_128_cbc();
 #else
 	ossl_raise(ePKCS7Error, "Must specify cipher");
 #endif


### PR DESCRIPTION
There is no such function as `EVP_EVP_aes_128_cbc()` in openssl. This should read `EVP_aes_128_cbc()`

In order to see a compilation failure due to this, it is necessary to build a version of openssl without any of the older and less secure ciphers, including omitting DES/3DES.

Previously submitted as https://github.com/ruby/ruby/pull/11515 -- resubmitting here as requested.