### PR TITLE
CI: Upgrade OpenSSL versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,10 +66,10 @@ jobs:
           - openssl-1.0.2u # EOL
           - openssl-1.1.0l # EOL
           - openssl-1.1.1w # EOL
-          - openssl-3.0.14
-          - openssl-3.1.6
-          - openssl-3.2.2
-          - openssl-3.3.1
+          - openssl-3.0.15
+          - openssl-3.1.7
+          - openssl-3.2.3
+          - openssl-3.3.2
           - openssl-master
           # http://www.libressl.org/releases.html
           - libressl-3.1.5 # EOL
@@ -82,12 +82,12 @@ jobs:
           - libressl-3.8.4
           - libressl-3.9.2
         include:
-          - { name-extra: 'with fips provider', openssl: openssl-3.0.14, fips-enabled: true }
-          - { name-extra: 'with fips provider', openssl: openssl-3.1.6, fips-enabled: true }
-          - { name-extra: 'with fips provider', openssl: openssl-3.2.2, fips-enabled: true }
-          - { name-extra: 'with fips provider', openssl: openssl-3.3.1, fips-enabled: true }
+          - { name-extra: 'with fips provider', openssl: openssl-3.0.15, fips-enabled: true }
+          - { name-extra: 'with fips provider', openssl: openssl-3.1.7, fips-enabled: true }
+          - { name-extra: 'with fips provider', openssl: openssl-3.2.3, fips-enabled: true }
+          - { name-extra: 'with fips provider', openssl: openssl-3.3.2, fips-enabled: true }
           - { name-extra: 'with fips provider', openssl: openssl-master, fips-enabled: true }
-          - { name-extra: 'without legacy provider', openssl: openssl-3.3.1, append-configure: 'no-legacy' }
+          - { name-extra: 'without legacy provider', openssl: openssl-3.3.2, append-configure: 'no-legacy' }
     steps:
       - name: repo checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
This PR is to upgrade used OpenSSL version to the latest ones according to the <https://openssl-library.org/source/>. There are no new LibreSSL versions according to the <http://www.libressl.org/releases.html>.