### PR TITLE
Support signing requests and CRLs using ED25519

### DIFF
--- a/ext/openssl/ossl_x509crl.c
+++ b/ext/openssl/ossl_x509crl.c
@@ -350,7 +350,11 @@ ossl_x509crl_sign(VALUE self, VALUE key, VALUE digest)
 
     GetX509CRL(self, crl);
     pkey = GetPrivPKeyPtr(key); /* NO NEED TO DUP */
-    md = ossl_evp_get_digestbyname(digest);
+    if (NIL_P(digest)) {
+	md = NULL; /* needed for some key types, e.g. Ed25519 */
+    } else {
+	md = ossl_evp_get_digestbyname(digest);
+    }
     if (!X509_CRL_sign(crl, pkey, md)) {
 	ossl_raise(eX509CRLError, NULL);
     }

--- a/ext/openssl/ossl_x509req.c
+++ b/ext/openssl/ossl_x509req.c
@@ -312,7 +312,11 @@ ossl_x509req_sign(VALUE self, VALUE key, VALUE digest)
 
     GetX509Req(self, req);
     pkey = GetPrivPKeyPtr(key); /* NO NEED TO DUP */
-    md = ossl_evp_get_digestbyname(digest);
+    if (NIL_P(digest)) {
+        md = NULL; /* needed for some key types, e.g. Ed25519 */
+    } else {
+        md = ossl_evp_get_digestbyname(digest);
+    }
     if (!X509_REQ_sign(req, pkey, md)) {
 	ossl_raise(eX509ReqError, NULL);
     }

--- a/test/openssl/test_pkey.rb
+++ b/test/openssl/test_pkey.rb
@@ -90,6 +90,8 @@ class OpenSSL::TestPKey < OpenSSL::PKeyTestCase
   def test_ed25519
     # Ed25519 is not FIPS-approved.
     omit_on_fips
+    # See EVP_PKEY_sign in Changelog for 3.7.0: https://github.com/libressl/portable/blob/master/ChangeLog
+    omit "Ed25519 not supported" unless openssl?(1, 1, 1) || libressl?(3, 7, 0)
 
     # Test vector from RFC 8032 Section 7.1 TEST 2
     priv_pem = <<~EOF
@@ -102,15 +104,8 @@ class OpenSSL::TestPKey < OpenSSL::PKeyTestCase
     MCowBQYDK2VwAyEAPUAXw+hDiVqStwqnTRt+vJyYLM8uxJaMwM1V8Sr0Zgw=
     -----END PUBLIC KEY-----
     EOF
-    begin
-      priv = OpenSSL::PKey.read(priv_pem)
-      pub = OpenSSL::PKey.read(pub_pem)
-    rescue OpenSSL::PKey::PKeyError => e
-      # OpenSSL < 1.1.1
-      pend "Ed25519 is not implemented" unless openssl?(1, 1, 1)
-
-      raise e
-    end
+    priv = OpenSSL::PKey.read(priv_pem)
+    pub = OpenSSL::PKey.read(pub_pem)
     assert_instance_of OpenSSL::PKey::PKey, priv
     assert_instance_of OpenSSL::PKey::PKey, pub
     assert_equal priv_pem, priv.private_to_pem

--- a/test/openssl/test_x509cert.rb
+++ b/test/openssl/test_x509cert.rb
@@ -292,24 +292,11 @@ class OpenSSL::TestX509Certificate < OpenSSL::TestCase
   end
 
   def test_sign_and_verify_ed25519
-    # See test_ed25519 in test_pkey.rb
-
     # Ed25519 is not FIPS-approved.
     omit_on_fips
-
-    begin
-      ed25519  = OpenSSL::PKey::generate_key("ED25519")
-    rescue OpenSSL::PKey::PKeyError => e
-      # OpenSSL < 1.1.1
-      #
-      pend "Ed25519 is not implemented" unless openssl?(1, 1, 1)
-
-      raise e
-    end
-
     # See ASN1_item_sign_ctx in ChangeLog for 3.8.1: https://github.com/libressl/portable/blob/master/ChangeLog
-    pend 'ASN1 signing with Ed25519 not yet working' unless openssl? or libressl?(3, 8, 1)
-
+    omit "Ed25519 not supported" unless openssl?(1, 1, 1) || libressl?(3, 8, 1)
+    ed25519 = OpenSSL::PKey::generate_key("ED25519")
     cert = issue_cert(@ca, ed25519, 1, [], nil, nil, digest: nil)
     assert_equal(true, cert.verify(ed25519))
   end


### PR DESCRIPTION
Allow requests and CRLs to be signed using Ed25519 private keys by passing a nil digest. This is similar to commit b0fc100091207d7eab20a349433ccbd8260c6ddd when signing certs.

Note Ed25519 keys do not implement the same `public_key` method, so the test must special case RSA and DSA.