### PR TITLE
[DOC] Replace removed method in example for OpenSSL::Config#to_s

### DIFF
--- a/ext/openssl/ossl_config.c
+++ b/ext/openssl/ossl_config.c
@@ -305,7 +305,7 @@ static IMPLEMENT_LHASH_DOALL_ARG_FN(dump_conf_value, CONF_VALUE, VALUE)
  *
  * Gets the parsable form of the current configuration.
  *
- * Given the following configurating file being loaded:
+ * Given the following configuration file being loaded:
  *
  *   config = OpenSSL::Config.load('baz.cnf')
  *     #=> #<OpenSSL::Config sections=["default"]>

--- a/ext/openssl/ossl_config.c
+++ b/ext/openssl/ossl_config.c
@@ -305,18 +305,16 @@ static IMPLEMENT_LHASH_DOALL_ARG_FN(dump_conf_value, CONF_VALUE, VALUE)
  *
  * Gets the parsable form of the current configuration.
  *
- * Given the following configuration being created:
+ * Given the following configurating file being loaded:
  *
- *   config = OpenSSL::Config.new
- *     #=> #<OpenSSL::Config sections=[]>
- *   config['default'] = {"foo"=>"bar","baz"=>"buz"}
- *     #=> {"foo"=>"bar", "baz"=>"buz"}
+ *   config = OpenSSL::Config.load('baz.cnf')
+ *     #=> #<OpenSSL::Config sections=["default"]>
  *   puts config.to_s
  *     #=> [ default ]
  *     #   foo=bar
  *     #   baz=buz
  *
- * You can parse get the serialized configuration using #to_s and then parse
+ * You can get the serialized configuration using #to_s and then parse
  * it later:
  *
  *   serialized_config = config.to_s


### PR DESCRIPTION
`OpenSSL::Config#[]=` is used in `OpenSSL::Config#to_s` example, 

https://github.com/ruby/openssl/blob/8367b16642f3a325d2344df6d9bcff6dd4f11393/ext/openssl/ossl_config.c#L308-L313

even though it was removed by #342 .

> Other two methods are removed because the corresponding functions
> disappeared in OpenSSL 1.1.0.
>
> - OpenSSL::Config#add_value
> - OpenSSL::Config#[]=

```ruby
irb(main):001> RUBY_VERSION
=> "3.3.5"
irb(main):002> OpenSSL::VERSION
=> "3.2.0"
irb(main):003> OpenSSL::OPENSSL_VERSION
=> "OpenSSL 3.0.2 15 Mar 2022"
irb(main):004> config = OpenSSL::Config.new
=> #<OpenSSL::Config sections=[]>
irb(main):005> config['default'] = {"foo"=>"bar","baz"=>"buz"}
(irb):5:in `<main>': undefined method `[]=' for an instance of OpenSSL::Config (NoMethodError)
```