### PR TITLE
ossl config: shareable when frozen

### DIFF
--- a/ext/openssl/ossl_config.c
+++ b/ext/openssl/ossl_config.c
@@ -456,6 +456,6 @@ Init_ossl_config(void)
      * The default system configuration file for OpenSSL.
      */
     path = CONF_get1_default_config_file();
-    path_str = ossl_buf2str(path, rb_long2int(strlen(path)));
+    path_str = rb_obj_freeze(ossl_buf2str(path, rb_long2int(strlen(path))));
     rb_define_const(cConfig, "DEFAULT_CONFIG_FILE", path_str);
 }

--- a/ext/openssl/ossl_config.c
+++ b/ext/openssl/ossl_config.c
@@ -87,6 +87,7 @@ config_s_parse(VALUE klass, VALUE str)
 
     bio = ossl_obj2bio(&str);
     config_load_bio(conf, bio); /* Consumes BIO */
+    rb_obj_freeze(obj);
     return obj;
 }
 
@@ -144,6 +145,7 @@ config_initialize(int argc, VALUE *argv, VALUE self)
             ossl_raise(eConfigError, "BIO_new_file");
         config_load_bio(conf, bio); /* Consumes BIO */
     }
+    rb_obj_freeze(self);
     return self;
 }
 
@@ -158,6 +160,7 @@ config_initialize_copy(VALUE self, VALUE other)
     rb_check_frozen(self);
     bio = ossl_obj2bio(&str);
     config_load_bio(conf, bio); /* Consumes BIO */
+    rb_obj_freeze(self);
     return self;
 }
 

--- a/ext/openssl/ossl_config.c
+++ b/ext/openssl/ossl_config.c
@@ -22,7 +22,7 @@ static const rb_data_type_t ossl_config_type = {
     {
         0, nconf_free,
     },
-    0, 0, RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED,
+    0, 0, RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED | RUBY_TYPED_FROZEN_SHAREABLE,
 };
 
 CONF *

--- a/test/openssl/test_config.rb
+++ b/test/openssl/test_config.rb
@@ -277,6 +277,15 @@ __EOC__
     assert_equal(@it.sections.sort, c2.sections.sort)
   end
 
+  if respond_to?(:ractor)
+    ractor
+    def test_ractor
+      assert(Ractor.shareable?(@it))
+      assert(Ractor.shareable?(OpenSSL::Config.parse("[empty]\n")))
+      assert(Ractor.shareable?(OpenSSL::Config::DEFAULT_CONFIG_FILE))
+    end
+  end
+
   private
 
   def in_tmpdir(*args)

--- a/test/openssl/test_config.rb
+++ b/test/openssl/test_config.rb
@@ -39,6 +39,7 @@ __EOD__
     assert_equal("[ default ]\n\n", c.to_s)
     c = OpenSSL::Config.parse(@it.to_s)
     assert_equal(['CA_default', 'ca', 'default'], c.sections.sort)
+    assert_predicate(c, :frozen?)
   end
 
   def test_s_parse_format
@@ -188,6 +189,7 @@ __EOC__
     c = OpenSSL::Config.new
     assert_equal("", c.to_s)
     assert_equal([], c.sections)
+    assert_predicate(c, :frozen?)
   end
 
   def test_initialize_with_empty_file
@@ -268,8 +270,10 @@ __EOC__
   def test_dup
     assert_equal(['CA_default', 'ca', 'default'], @it.sections.sort)
     c1 = @it.dup
+    assert_predicate(c1, :frozen?)
     assert_equal(@it.sections.sort, c1.sections.sort)
     c2 = @it.clone
+    assert_predicate(c2, :frozen?)
     assert_equal(@it.sections.sort, c2.sections.sort)
   end
 


### PR DESCRIPTION
should probably be initialized as frozen, given no state modifications