### PR TITLE
Add prime gem to d dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ group :development do
   gem "rake-compiler"
   gem "test-unit", "~> 3.0", ">= 3.4.6"
   gem "test-unit-ruby-core"
+  gem "prime"
   # In the case of Ruby whose rdoc is not a default gem.
   gem "rdoc"
 end


### PR DESCRIPTION
This PR removes the warning message because prime Libraly will be the default gem.

```
ruby/openssl/test/openssl/test_bn.rb:266: warning: prime was loaded from the standard library, but is not part of the default gems since Ruby 3.1.0. Add prime to your Gemfile or gemspec.
```