### PR TITLE
move ractor safe macro to ossl.h

### DIFF
--- a/ext/openssl/ossl.h
+++ b/ext/openssl/ossl.h
@@ -17,6 +17,12 @@
 #include <errno.h>
 #include <ruby/io.h>
 #include <ruby/thread.h>
+#ifdef HAVE_RUBY_RACTOR_H
+#include <ruby/ractor.h>
+#else
+#define RUBY_TYPED_FROZEN_SHAREABLE 0
+#endif
+
 #include <openssl/opensslv.h>
 
 #include <openssl/err.h>

--- a/ext/openssl/ossl_bn.c
+++ b/ext/openssl/ossl_bn.c
@@ -10,10 +10,6 @@
 /* modified by Michal Rokos <m.rokos@sh.cvut.cz> */
 #include "ossl.h"
 
-#ifdef HAVE_RB_EXT_RACTOR_SAFE
-#include <ruby/ractor.h>
-#endif
-
 #define NewBN(klass) \
   TypedData_Wrap_Struct((klass), &ossl_bn_type, 0)
 #define SetBN(obj, bn) do { \


### PR DESCRIPTION
as requested [here](https://github.com/ruby/openssl/pull/808#issuecomment-2444193790)