### PR TITLE
CI: Upgrade OpenSSL and LibreSSL versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,11 +65,12 @@ jobs:
           # https://openssl-library.org/source/
           - openssl-1.0.2u # EOL
           - openssl-1.1.0l # EOL
-          - openssl-1.1.1w # EOL
-          - openssl-3.0.15
-          - openssl-3.1.7
-          - openssl-3.2.3
-          - openssl-3.3.2
+          - openssl-1.1.1w # EOL 2023-09-11, still used by RHEL 8 and Ubuntu 20.04
+          - openssl-3.0.15 # Supported until 2026-09-07
+          - openssl-3.1.7 # Supported until 2025-03-14
+          - openssl-3.2.3 # Supported until 2025-11-23
+          - openssl-3.3.2 # Supported until 2026-04-09
+          - openssl-3.4.0 # Supported until 2026-10-22
           - openssl-master
           # http://www.libressl.org/releases.html
           - libressl-3.1.5 # EOL
@@ -79,15 +80,17 @@ jobs:
           - libressl-3.5.3 # EOL
           - libressl-3.6.3 # EOL
           - libressl-3.7.3 # EOL
-          - libressl-3.8.4
-          - libressl-3.9.2
+          - libressl-3.8.4 # EOL 2024-10-16
+          - libressl-3.9.2 # Supported until 2025-04-05
+          - libressl-4.0.0
         include:
           - { name-extra: 'with fips provider', openssl: openssl-3.0.15, fips-enabled: true }
           - { name-extra: 'with fips provider', openssl: openssl-3.1.7, fips-enabled: true }
           - { name-extra: 'with fips provider', openssl: openssl-3.2.3, fips-enabled: true }
           - { name-extra: 'with fips provider', openssl: openssl-3.3.2, fips-enabled: true }
+          - { name-extra: 'with fips provider', openssl: openssl-3.4.0, fips-enabled: true }
           - { name-extra: 'with fips provider', openssl: openssl-master, fips-enabled: true }
-          - { name-extra: 'without legacy provider', openssl: openssl-3.3.2, append-configure: 'no-legacy' }
+          - { name-extra: 'without legacy provider', openssl: openssl-3.4.0, append-configure: 'no-legacy' }
     steps:
       - name: repo checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Add OpenSSL 3.4.0 and LibreSSL 4.0.0. LibreSSL 3.8.x is marked as EOL.