### PR TITLE
Various small fixes in C extension code

### DIFF
--- a/ext/openssl/ossl.c
+++ b/ext/openssl/ossl.c
@@ -1150,24 +1150,22 @@ Init_openssl(void)
     /*
      * Init components
      */
+    Init_ossl_asn1();
     Init_ossl_bn();
     Init_ossl_cipher();
     Init_ossl_config();
     Init_ossl_digest();
+    Init_ossl_engine();
     Init_ossl_hmac();
+    Init_ossl_kdf();
     Init_ossl_ns_spki();
+    Init_ossl_ocsp();
     Init_ossl_pkcs12();
     Init_ossl_pkcs7();
     Init_ossl_pkey();
+    Init_ossl_provider();
     Init_ossl_rand();
     Init_ossl_ssl();
-#ifndef OPENSSL_NO_TS
     Init_ossl_ts();
-#endif
     Init_ossl_x509();
-    Init_ossl_ocsp();
-    Init_ossl_engine();
-    Init_ossl_provider();
-    Init_ossl_asn1();
-    Init_ossl_kdf();
 }

--- a/ext/openssl/ossl.c
+++ b/ext/openssl/ossl.c
@@ -355,7 +355,7 @@ ossl_clear_error(void)
  * Any errors you see here are probably due to a bug in Ruby's OpenSSL
  * implementation.
  */
-VALUE
+static VALUE
 ossl_get_errors(VALUE _)
 {
     VALUE ary;

--- a/ext/openssl/ossl.h
+++ b/ext/openssl/ossl.h
@@ -39,6 +39,7 @@
 #include <openssl/dsa.h>
 #include <openssl/evp.h>
 #include <openssl/dh.h>
+#include "openssl_missing.h"
 
 #ifndef LIBRESSL_VERSION_NUMBER
 # define OSSL_IS_LIBRESSL 0
@@ -172,28 +173,25 @@ extern VALUE dOSSL;
 /*
  * Include all parts
  */
-#include "openssl_missing.h"
 #include "ossl_asn1.h"
 #include "ossl_bio.h"
 #include "ossl_bn.h"
 #include "ossl_cipher.h"
 #include "ossl_config.h"
 #include "ossl_digest.h"
+#include "ossl_engine.h"
 #include "ossl_hmac.h"
+#include "ossl_kdf.h"
 #include "ossl_ns_spki.h"
 #include "ossl_ocsp.h"
 #include "ossl_pkcs12.h"
 #include "ossl_pkcs7.h"
 #include "ossl_pkey.h"
+#include "ossl_provider.h"
 #include "ossl_rand.h"
 #include "ossl_ssl.h"
-#ifndef OPENSSL_NO_TS
-  #include "ossl_ts.h"
-#endif
+#include "ossl_ts.h"
 #include "ossl_x509.h"
-#include "ossl_engine.h"
-#include "ossl_provider.h"
-#include "ossl_kdf.h"
 
 void Init_openssl(void);
 

--- a/ext/openssl/ossl_asn1.c
+++ b/ext/openssl/ossl_asn1.c
@@ -163,23 +163,23 @@ VALUE mASN1;
 VALUE eASN1Error;
 
 VALUE cASN1Data;
-VALUE cASN1Primitive;
-VALUE cASN1Constructive;
+static VALUE cASN1Primitive;
+static VALUE cASN1Constructive;
 
-VALUE cASN1EndOfContent;
-VALUE cASN1Boolean;                           /* BOOLEAN           */
-VALUE cASN1Integer, cASN1Enumerated;          /* INTEGER           */
-VALUE cASN1BitString;                         /* BIT STRING        */
-VALUE cASN1OctetString, cASN1UTF8String;      /* STRINGs           */
-VALUE cASN1NumericString, cASN1PrintableString;
-VALUE cASN1T61String, cASN1VideotexString;
-VALUE cASN1IA5String, cASN1GraphicString;
-VALUE cASN1ISO64String, cASN1GeneralString;
-VALUE cASN1UniversalString, cASN1BMPString;
-VALUE cASN1Null;                              /* NULL              */
-VALUE cASN1ObjectId;                          /* OBJECT IDENTIFIER */
-VALUE cASN1UTCTime, cASN1GeneralizedTime;     /* TIME              */
-VALUE cASN1Sequence, cASN1Set;                /* CONSTRUCTIVE      */
+static VALUE cASN1EndOfContent;
+static VALUE cASN1Boolean;                           /* BOOLEAN           */
+static VALUE cASN1Integer, cASN1Enumerated;          /* INTEGER           */
+static VALUE cASN1BitString;                         /* BIT STRING        */
+static VALUE cASN1OctetString, cASN1UTF8String;      /* STRINGs           */
+static VALUE cASN1NumericString, cASN1PrintableString;
+static VALUE cASN1T61String, cASN1VideotexString;
+static VALUE cASN1IA5String, cASN1GraphicString;
+static VALUE cASN1ISO64String, cASN1GeneralString;
+static VALUE cASN1UniversalString, cASN1BMPString;
+static VALUE cASN1Null;                              /* NULL              */
+static VALUE cASN1ObjectId;                          /* OBJECT IDENTIFIER */
+static VALUE cASN1UTCTime, cASN1GeneralizedTime;     /* TIME              */
+static VALUE cASN1Sequence, cASN1Set;                /* CONSTRUCTIVE      */
 
 static VALUE sym_IMPLICIT, sym_EXPLICIT;
 static VALUE sym_UNIVERSAL, sym_APPLICATION, sym_CONTEXT_SPECIFIC, sym_PRIVATE;

--- a/ext/openssl/ossl_asn1.h
+++ b/ext/openssl/ossl_asn1.h
@@ -38,24 +38,6 @@ extern VALUE mASN1;
 extern VALUE eASN1Error;
 
 extern VALUE cASN1Data;
-extern VALUE cASN1Primitive;
-extern VALUE cASN1Constructive;
-
-extern VALUE cASN1Boolean;                           /* BOOLEAN           */
-extern VALUE cASN1Integer, cASN1Enumerated;          /* INTEGER           */
-extern VALUE cASN1BitString;                         /* BIT STRING        */
-extern VALUE cASN1OctetString, cASN1UTF8String;      /* STRINGs           */
-extern VALUE cASN1NumericString, cASN1PrintableString;
-extern VALUE cASN1T61String, cASN1VideotexString;
-extern VALUE cASN1IA5String, cASN1GraphicString;
-extern VALUE cASN1ISO64String, cASN1GeneralString;
-extern VALUE cASN1UniversalString, cASN1BMPString;
-extern VALUE cASN1Null;                              /* NULL              */
-extern VALUE cASN1ObjectId;                          /* OBJECT IDENTIFIER */
-extern VALUE cASN1UTCTime, cASN1GeneralizedTime;     /* TIME              */
-extern VALUE cASN1Sequence, cASN1Set;                /* CONSTRUCTIVE      */
-
-extern VALUE cASN1EndOfContent;                      /* END OF CONTENT      */
 
 void Init_ossl_asn1(void);
 

--- a/ext/openssl/ossl_bn.c
+++ b/ext/openssl/ossl_bn.c
@@ -53,7 +53,7 @@ VALUE cBN;
  *
  * Generic Error for all of OpenSSL::BN (big num)
  */
-VALUE eBNError;
+static VALUE eBNError;
 
 /*
  * Public
@@ -156,19 +156,19 @@ ossl_bn_value_ptr(volatile VALUE *ptr)
  */
 
 #ifdef HAVE_RB_EXT_RACTOR_SAFE
-void
+static void
 ossl_bn_ctx_free(void *ptr)
 {
     BN_CTX *ctx = (BN_CTX *)ptr;
     BN_CTX_free(ctx);
 }
 
-struct rb_ractor_local_storage_type ossl_bn_ctx_key_type = {
+static struct rb_ractor_local_storage_type ossl_bn_ctx_key_type = {
     NULL, // mark
     ossl_bn_ctx_free,
 };
 
-rb_ractor_local_key_t ossl_bn_ctx_key;
+static rb_ractor_local_key_t ossl_bn_ctx_key;
 
 BN_CTX *
 ossl_bn_ctx_get(void)

--- a/ext/openssl/ossl_bn.h
+++ b/ext/openssl/ossl_bn.h
@@ -11,7 +11,6 @@
 #define _OSSL_BN_H_
 
 extern VALUE cBN;
-extern VALUE eBNError;
 
 BN_CTX *ossl_bn_ctx_get(void);
 #define ossl_bn_ctx ossl_bn_ctx_get()

--- a/ext/openssl/ossl_cipher.c
+++ b/ext/openssl/ossl_cipher.c
@@ -30,8 +30,8 @@
 /*
  * Classes
  */
-VALUE cCipher;
-VALUE eCipherError;
+static VALUE cCipher;
+static VALUE eCipherError;
 static ID id_auth_tag_len, id_key_set;
 
 static VALUE ossl_cipher_alloc(VALUE klass);

--- a/ext/openssl/ossl_cipher.h
+++ b/ext/openssl/ossl_cipher.h
@@ -10,9 +10,6 @@
 #if !defined(_OSSL_CIPHER_H_)
 #define _OSSL_CIPHER_H_
 
-extern VALUE cCipher;
-extern VALUE eCipherError;
-
 const EVP_CIPHER *ossl_evp_get_cipherbyname(VALUE);
 VALUE ossl_cipher_new(const EVP_CIPHER *);
 void Init_ossl_cipher(void);

--- a/ext/openssl/ossl_digest.c
+++ b/ext/openssl/ossl_digest.c
@@ -19,8 +19,8 @@
 /*
  * Classes
  */
-VALUE cDigest;
-VALUE eDigestError;
+static VALUE cDigest;
+static VALUE eDigestError;
 
 static VALUE ossl_digest_alloc(VALUE klass);
 
@@ -96,7 +96,7 @@ ossl_digest_alloc(VALUE klass)
     return TypedData_Wrap_Struct(klass, &ossl_digest_type, 0);
 }
 
-VALUE ossl_digest_update(VALUE, VALUE);
+static VALUE ossl_digest_update(VALUE, VALUE);
 
 /*
  *  call-seq:
@@ -225,7 +225,7 @@ ossl_digest_reset(VALUE self)
  *   result = digest.digest
  *
  */
-VALUE
+static VALUE
 ossl_digest_update(VALUE self, VALUE data)
 {
     EVP_MD_CTX *ctx;

--- a/ext/openssl/ossl_digest.h
+++ b/ext/openssl/ossl_digest.h
@@ -10,9 +10,6 @@
 #if !defined(_OSSL_DIGEST_H_)
 #define _OSSL_DIGEST_H_
 
-extern VALUE cDigest;
-extern VALUE eDigestError;
-
 const EVP_MD *ossl_evp_get_digestbyname(VALUE);
 VALUE ossl_digest_new(const EVP_MD *);
 void Init_ossl_digest(void);

--- a/ext/openssl/ossl_engine.c
+++ b/ext/openssl/ossl_engine.c
@@ -37,12 +37,12 @@
  *
  * See also, https://www.openssl.org/docs/crypto/engine.html
  */
-VALUE cEngine;
+static VALUE cEngine;
 /* Document-class: OpenSSL::Engine::EngineError
  *
  * This is the generic exception for OpenSSL::Engine related errors
  */
-VALUE eEngineError;
+static VALUE eEngineError;
 
 /*
  * Private

--- a/ext/openssl/ossl_engine.h
+++ b/ext/openssl/ossl_engine.h
@@ -11,9 +11,6 @@
 #if !defined(OSSL_ENGINE_H)
 #define OSSL_ENGINE_H
 
-extern VALUE cEngine;
-extern VALUE eEngineError;
-
 void Init_ossl_engine(void);
 
 #endif /* OSSL_ENGINE_H */

--- a/ext/openssl/ossl_hmac.c
+++ b/ext/openssl/ossl_hmac.c
@@ -21,8 +21,8 @@
 /*
  * Classes
  */
-VALUE cHMAC;
-VALUE eHMACError;
+static VALUE cHMAC;
+static VALUE eHMACError;
 
 /*
  * Public

--- a/ext/openssl/ossl_hmac.h
+++ b/ext/openssl/ossl_hmac.h
@@ -10,9 +10,6 @@
 #if !defined(_OSSL_HMAC_H_)
 #define _OSSL_HMAC_H_
 
-extern VALUE cHMAC;
-extern VALUE eHMACError;
-
 void Init_ossl_hmac(void);
 
 #endif /* _OSSL_HMAC_H_ */

--- a/ext/openssl/ossl_ns_spki.c
+++ b/ext/openssl/ossl_ns_spki.c
@@ -115,11 +115,11 @@ ossl_spki_to_der(VALUE self)
 
     GetSPKI(self, spki);
     if ((len = i2d_NETSCAPE_SPKI(spki, NULL)) <= 0)
-        ossl_raise(eX509CertError, NULL);
+        ossl_raise(eSPKIError, "i2d_NETSCAPE_SPKI");
     str = rb_str_new(0, len);
     p = (unsigned char *)RSTRING_PTR(str);
     if (i2d_NETSCAPE_SPKI(spki, &p) <= 0)
-        ossl_raise(eX509CertError, NULL);
+        ossl_raise(eSPKIError, "i2d_NETSCAPE_SPKI");
     ossl_str_adjust(str, p);
 
     return str;

--- a/ext/openssl/ossl_ns_spki.c
+++ b/ext/openssl/ossl_ns_spki.c
@@ -27,9 +27,9 @@
 /*
  * Classes
  */
-VALUE mNetscape;
-VALUE cSPKI;
-VALUE eSPKIError;
+static VALUE mNetscape;
+static VALUE cSPKI;
+static VALUE eSPKIError;
 
 /*
  * Public functions

--- a/ext/openssl/ossl_ns_spki.h
+++ b/ext/openssl/ossl_ns_spki.h
@@ -10,10 +10,6 @@
 #if !defined(_OSSL_NS_SPKI_H_)
 #define _OSSL_NS_SPKI_H_
 
-extern VALUE mNetscape;
-extern VALUE cSPKI;
-extern VALUE eSPKIError;
-
 void Init_ossl_ns_spki(void);
 
 #endif /* _OSSL_NS_SPKI_H_ */

--- a/ext/openssl/ossl_ocsp.c
+++ b/ext/openssl/ossl_ocsp.c
@@ -67,13 +67,13 @@
     if(!(cid)) ossl_raise(rb_eRuntimeError, "Cert ID wasn't initialized!"); \
 } while (0)
 
-VALUE mOCSP;
-VALUE eOCSPError;
-VALUE cOCSPReq;
-VALUE cOCSPRes;
-VALUE cOCSPBasicRes;
-VALUE cOCSPSingleRes;
-VALUE cOCSPCertId;
+static VALUE mOCSP;
+static VALUE eOCSPError;
+static VALUE cOCSPReq;
+static VALUE cOCSPRes;
+static VALUE cOCSPBasicRes;
+static VALUE cOCSPSingleRes;
+static VALUE cOCSPCertId;
 
 static void
 ossl_ocsp_request_free(void *ptr)

--- a/ext/openssl/ossl_ocsp.h
+++ b/ext/openssl/ossl_ocsp.h
@@ -11,13 +11,6 @@
 #if !defined(_OSSL_OCSP_H_)
 #define _OSSL_OCSP_H_
 
-#if !defined(OPENSSL_NO_OCSP)
-extern VALUE mOCSP;
-extern VALUE cOCSPReq;
-extern VALUE cOCSPRes;
-extern VALUE cOCSPBasicRes;
-#endif
-
 void Init_ossl_ocsp(void);
 
 #endif /* _OSSL_OCSP_H_ */

--- a/ext/openssl/ossl_pkcs12.c
+++ b/ext/openssl/ossl_pkcs12.c
@@ -27,8 +27,8 @@
 /*
  * Classes
  */
-VALUE cPKCS12;
-VALUE ePKCS12Error;
+static VALUE cPKCS12;
+static VALUE ePKCS12Error;
 
 /*
  * Private

--- a/ext/openssl/ossl_pkcs12.h
+++ b/ext/openssl/ossl_pkcs12.h
@@ -5,9 +5,6 @@
 #if !defined(_OSSL_PKCS12_H_)
 #define _OSSL_PKCS12_H_
 
-extern VALUE cPKCS12;
-extern VALUE ePKCS12Error;
-
 void Init_ossl_pkcs12(void);
 
 #endif /* _OSSL_PKCS12_H_ */

--- a/ext/openssl/ossl_pkcs7.c
+++ b/ext/openssl/ossl_pkcs7.c
@@ -9,6 +9,21 @@
  */
 #include "ossl.h"
 
+#define NewPKCS7(klass) \
+    TypedData_Wrap_Struct((klass), &ossl_pkcs7_type, 0)
+#define SetPKCS7(obj, pkcs7) do { \
+    if (!(pkcs7)) { \
+        ossl_raise(rb_eRuntimeError, "PKCS7 wasn't initialized."); \
+    } \
+    RTYPEDDATA_DATA(obj) = (pkcs7); \
+} while (0)
+#define GetPKCS7(obj, pkcs7) do { \
+    TypedData_Get_Struct((obj), PKCS7, &ossl_pkcs7_type, (pkcs7)); \
+    if (!(pkcs7)) { \
+        ossl_raise(rb_eRuntimeError, "PKCS7 wasn't initialized."); \
+    } \
+} while (0)
+
 #define NewPKCS7si(klass) \
     TypedData_Wrap_Struct((klass), &ossl_pkcs7_signer_info_type, 0)
 #define SetPKCS7si(obj, p7si) do { \
@@ -49,10 +64,10 @@
 /*
  * Classes
  */
-VALUE cPKCS7;
-VALUE cPKCS7Signer;
-VALUE cPKCS7Recipient;
-VALUE ePKCS7Error;
+static VALUE cPKCS7;
+static VALUE cPKCS7Signer;
+static VALUE cPKCS7Recipient;
+static VALUE ePKCS7Error;
 
 static void
 ossl_pkcs7_free(void *ptr)
@@ -60,13 +75,27 @@ ossl_pkcs7_free(void *ptr)
     PKCS7_free(ptr);
 }
 
-const rb_data_type_t ossl_pkcs7_type = {
+static const rb_data_type_t ossl_pkcs7_type = {
     "OpenSSL/PKCS7",
     {
 	0, ossl_pkcs7_free,
     },
     0, 0, RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED,
 };
+
+VALUE
+ossl_pkcs7_new(PKCS7 *p7)
+{
+    PKCS7 *new;
+    VALUE obj = NewPKCS7(cPKCS7);
+
+    new = PKCS7_dup(p7);
+    if (!new)
+        ossl_raise(ePKCS7Error, "PKCS7_dup");
+    SetPKCS7(obj, new);
+
+    return obj;
+}
 
 static void
 ossl_pkcs7_signer_info_free(void *ptr)

--- a/ext/openssl/ossl_pkcs7.h
+++ b/ext/openssl/ossl_pkcs7.h
@@ -10,27 +10,7 @@
 #if !defined(_OSSL_PKCS7_H_)
 #define _OSSL_PKCS7_H_
 
-#define NewPKCS7(klass) \
-    TypedData_Wrap_Struct((klass), &ossl_pkcs7_type, 0)
-#define SetPKCS7(obj, pkcs7) do { \
-    if (!(pkcs7)) { \
-        ossl_raise(rb_eRuntimeError, "PKCS7 wasn't initialized."); \
-    } \
-    RTYPEDDATA_DATA(obj) = (pkcs7); \
-} while (0)
-#define GetPKCS7(obj, pkcs7) do { \
-    TypedData_Get_Struct((obj), PKCS7, &ossl_pkcs7_type, (pkcs7)); \
-    if (!(pkcs7)) { \
-        ossl_raise(rb_eRuntimeError, "PKCS7 wasn't initialized."); \
-    } \
-} while (0)
-
-extern const rb_data_type_t ossl_pkcs7_type;
-extern VALUE cPKCS7;
-extern VALUE cPKCS7Signer;
-extern VALUE cPKCS7Recipient;
-extern VALUE ePKCS7Error;
-
+VALUE ossl_pkcs7_new(PKCS7 *p7);
 void Init_ossl_pkcs7(void);
 
 #endif /* _OSSL_PKCS7_H_ */

--- a/ext/openssl/ossl_pkey.h
+++ b/ext/openssl/ossl_pkey.h
@@ -53,35 +53,24 @@ void Init_ossl_pkey(void);
  * RSA
  */
 extern VALUE cRSA;
-extern VALUE eRSAError;
-
 void Init_ossl_rsa(void);
 
 /*
  * DSA
  */
 extern VALUE cDSA;
-extern VALUE eDSAError;
-
 void Init_ossl_dsa(void);
 
 /*
  * DH
  */
 extern VALUE cDH;
-extern VALUE eDHError;
-
 void Init_ossl_dh(void);
 
 /*
  * EC
  */
 extern VALUE cEC;
-extern VALUE eECError;
-extern VALUE cEC_GROUP;
-extern VALUE eEC_GROUP;
-extern VALUE cEC_POINT;
-extern VALUE eEC_POINT;
 VALUE ossl_ec_new(EVP_PKEY *);
 void Init_ossl_ec(void);
 
@@ -136,7 +125,7 @@ static VALUE ossl_##_keytype##_set_##_group(VALUE self, VALUE v1, VALUE v2, VALU
 		BN_clear_free(bn1);					\
 		BN_clear_free(bn2);					\
 		BN_clear_free(bn3);					\
-		ossl_raise(eBNError, NULL);				\
+		ossl_raise(ePKeyError, "BN_dup");			\
 	}								\
 									\
 	if (!_type##_set0_##_group(obj, bn1, bn2, bn3)) {		\
@@ -164,7 +153,7 @@ static VALUE ossl_##_keytype##_set_##_group(VALUE self, VALUE v1, VALUE v2) \
             (orig_bn2 && !(bn2 = BN_dup(orig_bn2)))) {			\
 		BN_clear_free(bn1);					\
 		BN_clear_free(bn2);					\
-		ossl_raise(eBNError, NULL);				\
+		ossl_raise(ePKeyError, "BN_dup");			\
 	}								\
 									\
 	if (!_type##_set0_##_group(obj, bn1, bn2)) {			\

--- a/ext/openssl/ossl_pkey_dh.c
+++ b/ext/openssl/ossl_pkey_dh.c
@@ -27,7 +27,7 @@
  * Classes
  */
 VALUE cDH;
-VALUE eDHError;
+static VALUE eDHError;
 
 /*
  * Private

--- a/ext/openssl/ossl_pkey_dsa.c
+++ b/ext/openssl/ossl_pkey_dsa.c
@@ -41,7 +41,7 @@ DSA_PRIVATE(VALUE obj, OSSL_3_const DSA *dsa)
  * Classes
  */
 VALUE cDSA;
-VALUE eDSAError;
+static VALUE eDSAError;
 
 /*
  * Private

--- a/ext/openssl/ossl_pkey_ec.c
+++ b/ext/openssl/ossl_pkey_ec.c
@@ -41,11 +41,11 @@ static const rb_data_type_t ossl_ec_point_type;
 } while (0)
 
 VALUE cEC;
-VALUE eECError;
-VALUE cEC_GROUP;
-VALUE eEC_GROUP;
-VALUE cEC_POINT;
-VALUE eEC_POINT;
+static VALUE eECError;
+static VALUE cEC_GROUP;
+static VALUE eEC_GROUP;
+static VALUE cEC_POINT;
+static VALUE eEC_POINT;
 
 static ID s_GFp, s_GF2m;
 

--- a/ext/openssl/ossl_pkey_ec.c
+++ b/ext/openssl/ossl_pkey_ec.c
@@ -174,7 +174,7 @@ static VALUE ossl_ec_key_initialize(int argc, VALUE *argv, VALUE self)
     type = EVP_PKEY_base_id(pkey);
     if (type != EVP_PKEY_EC) {
         EVP_PKEY_free(pkey);
-        rb_raise(eDSAError, "incorrect pkey type: %s", OBJ_nid2sn(type));
+        rb_raise(eECError, "incorrect pkey type: %s", OBJ_nid2sn(type));
     }
     RTYPEDDATA_DATA(self) = pkey;
     return self;

--- a/ext/openssl/ossl_pkey_rsa.c
+++ b/ext/openssl/ossl_pkey_rsa.c
@@ -42,7 +42,7 @@ RSA_PRIVATE(VALUE obj, OSSL_3_const RSA *rsa)
  * Classes
  */
 VALUE cRSA;
-VALUE eRSAError;
+static VALUE eRSAError;
 
 /*
  * Private

--- a/ext/openssl/ossl_rand.c
+++ b/ext/openssl/ossl_rand.c
@@ -9,8 +9,8 @@
  */
 #include "ossl.h"
 
-VALUE mRandom;
-VALUE eRandomError;
+static VALUE mRandom;
+static VALUE eRandomError;
 
 /*
  *  call-seq:

--- a/ext/openssl/ossl_rand.h
+++ b/ext/openssl/ossl_rand.h
@@ -10,9 +10,6 @@
 #if !defined(_OSSL_RAND_H_)
 #define _OSSL_RAND_H_
 
-extern VALUE mRandom;
-extern VALUE eRandomError;
-
 void Init_ossl_rand(void);
 
 #endif /* _OSSL_RAND_H_ */

--- a/ext/openssl/ossl_ssl.c
+++ b/ext/openssl/ossl_ssl.c
@@ -35,7 +35,7 @@
 
 VALUE mSSL;
 static VALUE eSSLError;
-VALUE cSSLContext;
+static VALUE cSSLContext;
 VALUE cSSLSocket;
 
 static VALUE eSSLErrorWaitReadable;

--- a/ext/openssl/ossl_ts.c
+++ b/ext/openssl/ossl_ts.c
@@ -1589,5 +1589,9 @@ Init_ossl_ts(void)
     rb_attr(cTimestampFactory, rb_intern_const("additional_certs"), 1, 1, 0);
     rb_define_method(cTimestampFactory, "create_timestamp", ossl_tsfac_create_ts, 3);
 }
-
+#else /* OPENSSL_NO_TS */
+void
+Init_ossl_ts(void)
+{
+}
 #endif

--- a/ext/openssl/ossl_ts.c
+++ b/ext/openssl/ossl_ts.c
@@ -691,21 +691,12 @@ static VALUE
 ossl_ts_resp_get_token(VALUE self)
 {
     TS_RESP *resp;
-    PKCS7 *p7, *copy;
-    VALUE obj;
+    PKCS7 *p7;
 
     GetTSResponse(self, resp);
     if (!(p7 = TS_RESP_get_token(resp)))
         return Qnil;
-
-    obj = NewPKCS7(cPKCS7);
-
-    if (!(copy = PKCS7_dup(p7)))
-        ossl_raise(eTimestampError, NULL);
-
-    SetPKCS7(obj, copy);
-
-    return obj;
+    return ossl_pkcs7_new(p7);
 }
 
 /*

--- a/ext/openssl/ossl_ts.c
+++ b/ext/openssl/ossl_ts.c
@@ -161,8 +161,11 @@ get_asn1obj(ASN1_OBJECT *obj)
         ret = rb_str_new2(OBJ_nid2sn(nid));
     else{
         if (!(out = BIO_new(BIO_s_mem())))
-            ossl_raise(eX509AttrError, NULL);
-        i2a_ASN1_OBJECT(out, obj);
+            ossl_raise(eTimestampError, "BIO_new(BIO_s_mem())");
+        if (i2a_ASN1_OBJECT(out, obj) <= 0) {
+            BIO_free(out);
+            ossl_raise(eTimestampError, "i2a_ASN1_OBJECT");
+        }
         ret = ossl_membio2str(out);
     }
 

--- a/ext/openssl/ossl_x509.h
+++ b/ext/openssl/ossl_x509.h
@@ -28,7 +28,6 @@ void Init_ossl_x509(void);
  * X509Attr
  */
 extern VALUE cX509Attr;
-extern VALUE eX509AttrError;
 
 VALUE ossl_x509attr_new(X509_ATTRIBUTE *);
 X509_ATTRIBUTE *GetX509AttrPtr(VALUE);
@@ -38,7 +37,6 @@ void Init_ossl_x509attr(void);
  * X509Cert
  */
 extern VALUE cX509Cert;
-extern VALUE eX509CertError;
 
 VALUE ossl_x509_new(X509 *);
 X509 *GetX509CertPtr(VALUE);
@@ -48,9 +46,6 @@ void Init_ossl_x509cert(void);
 /*
  * X509CRL
  */
-extern VALUE cX509CRL;
-extern VALUE eX509CRLError;
-
 VALUE ossl_x509crl_new(X509_CRL *);
 X509_CRL *GetX509CRLPtr(VALUE);
 void Init_ossl_x509crl(void);
@@ -59,8 +54,6 @@ void Init_ossl_x509crl(void);
  * X509Extension
  */
 extern VALUE cX509Ext;
-extern VALUE cX509ExtFactory;
-extern VALUE eX509ExtError;
 
 VALUE ossl_x509ext_new(X509_EXTENSION *);
 X509_EXTENSION *GetX509ExtPtr(VALUE);
@@ -69,9 +62,6 @@ void Init_ossl_x509ext(void);
 /*
  * X509Name
  */
-extern VALUE cX509Name;
-extern VALUE eX509NameError;
-
 VALUE ossl_x509name_new(X509_NAME *);
 X509_NAME *GetX509NamePtr(VALUE);
 void Init_ossl_x509name(void);
@@ -79,9 +69,6 @@ void Init_ossl_x509name(void);
 /*
  * X509Request
  */
-extern VALUE cX509Req;
-extern VALUE eX509ReqError;
-
 X509_REQ *GetX509ReqPtr(VALUE);
 void Init_ossl_x509req(void);
 
@@ -89,7 +76,6 @@ void Init_ossl_x509req(void);
  * X509Revoked
  */
 extern VALUE cX509Rev;
-extern VALUE eX509RevError;
 
 VALUE ossl_x509revoked_new(X509_REVOKED *);
 X509_REVOKED *DupX509RevokedPtr(VALUE);
@@ -98,12 +84,7 @@ void Init_ossl_x509revoked(void);
 /*
  * X509Store and X509StoreContext
  */
-extern VALUE cX509Store;
-extern VALUE cX509StoreContext;
-extern VALUE eX509StoreError;
-
 X509_STORE *GetX509StorePtr(VALUE);
-
 void Init_ossl_x509store(void);
 
 /*

--- a/ext/openssl/ossl_x509attr.c
+++ b/ext/openssl/ossl_x509attr.c
@@ -28,7 +28,7 @@
  * Classes
  */
 VALUE cX509Attr;
-VALUE eX509AttrError;
+static VALUE eX509AttrError;
 
 static void
 ossl_x509attr_free(void *ptr)

--- a/ext/openssl/ossl_x509cert.c
+++ b/ext/openssl/ossl_x509cert.c
@@ -28,7 +28,7 @@
  * Classes
  */
 VALUE cX509Cert;
-VALUE eX509CertError;
+static VALUE eX509CertError;
 
 static void
 ossl_x509_free(void *ptr)

--- a/ext/openssl/ossl_x509crl.c
+++ b/ext/openssl/ossl_x509crl.c
@@ -27,8 +27,8 @@
 /*
  * Classes
  */
-VALUE cX509CRL;
-VALUE eX509CRLError;
+static VALUE cX509CRL;
+static VALUE eX509CRLError;
 
 static void
 ossl_x509crl_free(void *ptr)

--- a/ext/openssl/ossl_x509ext.c
+++ b/ext/openssl/ossl_x509ext.c
@@ -41,8 +41,8 @@
  * Classes
  */
 VALUE cX509Ext;
-VALUE cX509ExtFactory;
-VALUE eX509ExtError;
+static VALUE cX509ExtFactory;
+static VALUE eX509ExtError;
 
 static void
 ossl_x509ext_free(void *ptr)

--- a/ext/openssl/ossl_x509name.c
+++ b/ext/openssl/ossl_x509name.c
@@ -32,8 +32,8 @@
 /*
  * Classes
  */
-VALUE cX509Name;
-VALUE eX509NameError;
+static VALUE cX509Name;
+static VALUE eX509NameError;
 
 static void
 ossl_x509name_free(void *ptr)

--- a/ext/openssl/ossl_x509req.c
+++ b/ext/openssl/ossl_x509req.c
@@ -27,8 +27,8 @@
 /*
  * Classes
  */
-VALUE cX509Req;
-VALUE eX509ReqError;
+static VALUE cX509Req;
+static VALUE eX509ReqError;
 
 static void
 ossl_x509req_free(void *ptr)

--- a/ext/openssl/ossl_x509revoked.c
+++ b/ext/openssl/ossl_x509revoked.c
@@ -28,7 +28,7 @@
  * Classes
  */
 VALUE cX509Rev;
-VALUE eX509RevError;
+static VALUE eX509RevError;
 
 static void
 ossl_x509rev_free(void *ptr)

--- a/ext/openssl/ossl_x509store.c
+++ b/ext/openssl/ossl_x509store.c
@@ -108,9 +108,9 @@ ossl_verify_cb_call(VALUE proc, int ok, X509_STORE_CTX *ctx)
 /*
  * Classes
  */
-VALUE cX509Store;
-VALUE cX509StoreContext;
-VALUE eX509StoreError;
+static VALUE cX509Store;
+static VALUE cX509StoreContext;
+static VALUE eX509StoreError;
 
 static void
 ossl_x509store_mark(void *ptr)

--- a/ext/openssl/ossl_x509store.c
+++ b/ext/openssl/ossl_x509store.c
@@ -636,7 +636,7 @@ ossl_x509stctx_verify(VALUE self)
         ossl_clear_error();
         return Qfalse;
       default:
-        ossl_raise(eX509CertError, "X509_verify_cert");
+        ossl_raise(eX509StoreError, "X509_verify_cert");
     }
 }
 


### PR DESCRIPTION
This is a collection of various otherwise unrelated tree-wide fixes.

---
**pkey/ec: fix exception class in OpenSSL::PKey::EC.new**

Fix a copy-and-paste error introduced in commit 74f6c6175688 (pkey:
allocate EVP_PKEY on #initialize, 2021-04-12).

It should raise OpenSSL::PKey::ECError instead of
OpenSSL::PKey::DSAError.

---
**ns_spki: fix exception class in OpenSSL::Netscape::SPKI#to_der**

It should raise OpenSSL::Netscape::SPKIError instead of
OpenSSL::X509::CertificateError.

No test cases covered this because it only occurs in exceptional
cases, such as memory allocation failure.

---
**x509store: fix exception class in OpenSSL::X509::StoreContext#verify**

Follow-up commit 0789643d7333 (openssl: clear OpenSSL error
queue before return to Ruby, 2016-05-18). It should raise
OpenSSL::X509::StoreError instead of OpenSSL::X509::CertificateError.

---
**ts: avoid using OpenSSL::PKCS7's internals**

Internals of OpenSSL::PKCS7 should be kept within ossl_pkcs7.c.

Add a new ossl_pkcs7_new() function for duplicating and wrapping an
OpenSSL PKCS7 object in OpenSSL::PKCS7. This follows the convention
used by other ossl_*_new() functions.

---
**ts: fix exception class raised when getting an OID name**

get_asn1obj() is used by several methods in OpenSSL::Timestamp to get
the string representation of an OID. On an error, such as memory
allocation failure, it can raise OpenSSL::X509::AttributeError. It
should be OpenSSL::Timestamp::TimestampError instead.

---
**Mark variables and functions as static whenever possible**


---
**Call Init_ossl_*() functions in alphabetical order**

It was originally sorted in alphabetical order, but it has been broken
over time. Let's fix it.

