### PR TITLE
Configure RubyGems Trusted Publishing

### DIFF
--- a/.github/workflows/push_gem.yml
+++ b/.github/workflows/push_gem.yml
@@ -1,0 +1,51 @@
+name: Publish gem to rubygems.org
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+
+jobs:
+  push:
+    if: github.repository == 'ruby/openssl'
+    runs-on: ubuntu-latest
+
+    environment:
+      name: rubygems.org
+      url: https://rubygems.org/gems/openssl
+
+    permissions:
+      contents: write
+      id-token: write
+
+    strategy:
+      matrix:
+        ruby: [ 'ruby', 'jruby' ]
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: ${{ matrix.ruby }}
+
+      - name: Publish to RubyGems
+        uses: rubygems/release-gem@v1
+
+      - name: Create GitHub release
+        run: |
+          tag_name="$(git describe --tags --abbrev=0)"
+          gh release create "${tag_name}" --verify-tag --draft --generate-notes pkg/*.gem
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        if: matrix.ruby == 'ruby'


### PR DESCRIPTION
Added .github/workflows/push_gem.yml based on that of net-imap and psych.

If nothing goes wrong, pushing a tag named v* should publish openssl-*.gem and openssl-*-java.gem to rubygems.org, and create a draft GitHub release.

See also: https://github.com/ruby/net-imap/pull/265

This is not tested yet.