### PR TITLE
pkey: avoid creating multiple wrapper objects for single EVP_PKEY

### DIFF
--- a/ext/openssl/ossl_engine.c
+++ b/ext/openssl/ossl_engine.c
@@ -373,7 +373,7 @@ ossl_engine_load_privkey(int argc, VALUE *argv, VALUE self)
     GetEngine(self, e);
     pkey = ENGINE_load_private_key(e, sid, NULL, sdata);
     if (!pkey) ossl_raise(eEngineError, NULL);
-    obj = ossl_pkey_new(pkey);
+    obj = ossl_pkey_wrap(pkey);
     OSSL_PKEY_SET_PRIVATE(obj);
 
     return obj;
@@ -403,7 +403,7 @@ ossl_engine_load_pubkey(int argc, VALUE *argv, VALUE self)
     pkey = ENGINE_load_public_key(e, sid, NULL, sdata);
     if (!pkey) ossl_raise(eEngineError, NULL);
 
-    return ossl_pkey_new(pkey);
+    return ossl_pkey_wrap(pkey);
 }
 
 /*

--- a/ext/openssl/ossl_ns_spki.c
+++ b/ext/openssl/ossl_ns_spki.c
@@ -190,7 +190,7 @@ ossl_spki_get_public_key(VALUE self)
 	ossl_raise(eSPKIError, NULL);
     }
 
-    return ossl_pkey_new(pkey); /* NO DUP - OK */
+    return ossl_pkey_wrap(pkey);
 }
 
 /*

--- a/ext/openssl/ossl_pkcs12.c
+++ b/ext/openssl/ossl_pkcs12.c
@@ -154,9 +154,9 @@ ossl_pkcs12_s_create(int argc, VALUE *argv, VALUE self)
 }
 
 static VALUE
-ossl_pkey_new_i(VALUE arg)
+ossl_pkey_wrap_i(VALUE arg)
 {
-    return ossl_pkey_new((EVP_PKEY *)arg);
+    return ossl_pkey_wrap((EVP_PKEY *)arg);
 }
 
 static VALUE
@@ -208,7 +208,7 @@ ossl_pkcs12_initialize(int argc, VALUE *argv, VALUE self)
 	ossl_raise(ePKCS12Error, "PKCS12_parse");
     ERR_pop_to_mark();
     if (key) {
-	pkey = rb_protect(ossl_pkey_new_i, (VALUE)key, &st);
+	pkey = rb_protect(ossl_pkey_wrap_i, (VALUE)key, &st);
 	if (st) goto err;
     }
     if (x509) {

--- a/ext/openssl/ossl_pkey.c
+++ b/ext/openssl/ossl_pkey.c
@@ -39,7 +39,7 @@ const rb_data_type_t ossl_evp_pkey_type = {
 };
 
 static VALUE
-pkey_new0(VALUE arg)
+pkey_wrap0(VALUE arg)
 {
     EVP_PKEY *pkey = (EVP_PKEY *)arg;
     VALUE klass, obj;
@@ -65,12 +65,12 @@ pkey_new0(VALUE arg)
 }
 
 VALUE
-ossl_pkey_new(EVP_PKEY *pkey)
+ossl_pkey_wrap(EVP_PKEY *pkey)
 {
     VALUE obj;
     int status;
 
-    obj = rb_protect(pkey_new0, (VALUE)pkey, &status);
+    obj = rb_protect(pkey_wrap0, (VALUE)pkey, &status);
     if (status) {
 	EVP_PKEY_free(pkey);
 	rb_jump_tag(status);
@@ -239,7 +239,7 @@ ossl_pkey_new_from_data(int argc, VALUE *argv, VALUE self)
     BIO_free(bio);
     if (!pkey)
 	ossl_raise(ePKeyError, "Could not parse PKey");
-    return ossl_pkey_new(pkey);
+    return ossl_pkey_wrap(pkey);
 }
 
 static VALUE
@@ -443,7 +443,7 @@ pkey_generate(int argc, VALUE *argv, VALUE self, int genparam)
         }
     }
 
-    return ossl_pkey_new(gen_arg.pkey);
+    return ossl_pkey_wrap(gen_arg.pkey);
 }
 
 /*
@@ -664,7 +664,7 @@ ossl_pkey_new_raw_private_key(VALUE self, VALUE type, VALUE key)
     if (!pkey)
         ossl_raise(ePKeyError, "EVP_PKEY_new_raw_private_key");
 
-    return ossl_pkey_new(pkey);
+    return ossl_pkey_wrap(pkey);
 }
 #endif
 
@@ -697,7 +697,7 @@ ossl_pkey_new_raw_public_key(VALUE self, VALUE type, VALUE key)
     if (!pkey)
         ossl_raise(ePKeyError, "EVP_PKEY_new_raw_public_key");
 
-    return ossl_pkey_new(pkey);
+    return ossl_pkey_wrap(pkey);
 }
 #endif
 

--- a/ext/openssl/ossl_pkey.h
+++ b/ext/openssl/ossl_pkey.h
@@ -27,7 +27,7 @@ extern const rb_data_type_t ossl_evp_pkey_type;
 } while (0)
 
 /* Takes ownership of the EVP_PKEY */
-VALUE ossl_pkey_new(EVP_PKEY *);
+VALUE ossl_pkey_wrap(EVP_PKEY *);
 void ossl_pkey_check_public_key(const EVP_PKEY *);
 EVP_PKEY *ossl_pkey_read_generic(BIO *, VALUE);
 EVP_PKEY *GetPKeyPtr(VALUE);

--- a/ext/openssl/ossl_pkey.h
+++ b/ext/openssl/ossl_pkey.h
@@ -14,6 +14,7 @@ extern VALUE mPKey;
 extern VALUE cPKey;
 extern VALUE ePKeyError;
 extern const rb_data_type_t ossl_evp_pkey_type;
+extern int ossl_pkey_ex_ptr_idx;
 
 /* For ENGINE */
 #define OSSL_PKEY_SET_PRIVATE(obj) rb_ivar_set((obj), rb_intern("private"), Qtrue)
@@ -24,6 +25,7 @@ extern const rb_data_type_t ossl_evp_pkey_type;
     if (!(pkey)) { \
 	rb_raise(rb_eRuntimeError, "PKEY wasn't initialized!");\
     } \
+    RUBY_ASSERT(obj == (VALUE)EVP_PKEY_get_ex_data(pkey, ossl_pkey_ex_ptr_idx)); \
 } while (0)
 
 /* Takes ownership of the EVP_PKEY */

--- a/ext/openssl/ossl_pkey_dh.c
+++ b/ext/openssl/ossl_pkey_dh.c
@@ -113,6 +113,7 @@ ossl_dh_initialize(int argc, VALUE *argv, VALUE self)
         rb_raise(eDHError, "incorrect pkey type: %s", OBJ_nid2sn(type));
     }
     RTYPEDDATA_DATA(self) = pkey;
+    EVP_PKEY_set_ex_data(pkey, ossl_pkey_ex_ptr_idx, (void *)self);
     return self;
 
   legacy:
@@ -124,6 +125,7 @@ ossl_dh_initialize(int argc, VALUE *argv, VALUE self)
         ossl_raise(eDHError, "EVP_PKEY_assign_DH");
     }
     RTYPEDDATA_DATA(self) = pkey;
+    EVP_PKEY_set_ex_data(pkey, ossl_pkey_ex_ptr_idx, (void *)self);
     return self;
 }
 
@@ -164,6 +166,7 @@ ossl_dh_initialize_copy(VALUE self, VALUE other)
         ossl_raise(eDHError, "EVP_PKEY_assign_DH");
     }
     RTYPEDDATA_DATA(self) = pkey;
+    EVP_PKEY_set_ex_data(pkey, ossl_pkey_ex_ptr_idx, (void *)self);
     return self;
 }
 #endif

--- a/ext/openssl/ossl_pkey_dsa.c
+++ b/ext/openssl/ossl_pkey_dsa.c
@@ -125,6 +125,7 @@ ossl_dsa_initialize(int argc, VALUE *argv, VALUE self)
         rb_raise(eDSAError, "incorrect pkey type: %s", OBJ_nid2sn(type));
     }
     RTYPEDDATA_DATA(self) = pkey;
+    EVP_PKEY_set_ex_data(pkey, ossl_pkey_ex_ptr_idx, (void *)self);
     return self;
 
   legacy:
@@ -136,6 +137,7 @@ ossl_dsa_initialize(int argc, VALUE *argv, VALUE self)
         ossl_raise(eDSAError, "EVP_PKEY_assign_DSA");
     }
     RTYPEDDATA_DATA(self) = pkey;
+    EVP_PKEY_set_ex_data(pkey, ossl_pkey_ex_ptr_idx, (void *)self);
     return self;
 }
 
@@ -164,6 +166,7 @@ ossl_dsa_initialize_copy(VALUE self, VALUE other)
         ossl_raise(eDSAError, "EVP_PKEY_assign_DSA");
     }
     RTYPEDDATA_DATA(self) = pkey;
+    EVP_PKEY_set_ex_data(pkey, ossl_pkey_ex_ptr_idx, (void *)self);
 
     return self;
 }

--- a/ext/openssl/ossl_pkey_rsa.c
+++ b/ext/openssl/ossl_pkey_rsa.c
@@ -121,6 +121,7 @@ ossl_rsa_initialize(int argc, VALUE *argv, VALUE self)
         rb_raise(eRSAError, "incorrect pkey type: %s", OBJ_nid2sn(type));
     }
     RTYPEDDATA_DATA(self) = pkey;
+    EVP_PKEY_set_ex_data(pkey, ossl_pkey_ex_ptr_idx, (void *)self);
     return self;
 
   legacy:
@@ -132,6 +133,7 @@ ossl_rsa_initialize(int argc, VALUE *argv, VALUE self)
         ossl_raise(eRSAError, "EVP_PKEY_assign_RSA");
     }
     RTYPEDDATA_DATA(self) = pkey;
+    EVP_PKEY_set_ex_data(pkey, ossl_pkey_ex_ptr_idx, (void *)self);
     return self;
 }
 
@@ -159,6 +161,7 @@ ossl_rsa_initialize_copy(VALUE self, VALUE other)
         ossl_raise(eRSAError, "EVP_PKEY_assign_RSA");
     }
     RTYPEDDATA_DATA(self) = pkey;
+    EVP_PKEY_set_ex_data(pkey, ossl_pkey_ex_ptr_idx, (void *)self);
 
     return self;
 }

--- a/ext/openssl/ossl_ssl.c
+++ b/ext/openssl/ossl_ssl.c
@@ -2575,7 +2575,7 @@ ossl_ssl_tmp_key(VALUE self)
     GetSSL(self, ssl);
     if (!SSL_get_server_tmp_key(ssl, &key))
 	return Qnil;
-    return ossl_pkey_new(key);
+    return ossl_pkey_wrap(key);
 }
 #endif /* !defined(OPENSSL_NO_SOCK) */
 

--- a/ext/openssl/ossl_x509cert.c
+++ b/ext/openssl/ossl_x509cert.c
@@ -506,7 +506,7 @@ ossl_x509_get_public_key(VALUE self)
 	ossl_raise(eX509CertError, NULL);
     }
 
-    return ossl_pkey_new(pkey); /* NO DUP - OK */
+    return ossl_pkey_wrap(pkey);
 }
 
 /*

--- a/ext/openssl/ossl_x509req.c
+++ b/ext/openssl/ossl_x509req.c
@@ -286,7 +286,7 @@ ossl_x509req_get_public_key(VALUE self)
 	ossl_raise(eX509ReqError, NULL);
     }
 
-    return ossl_pkey_new(pkey); /* NO DUP - OK */
+    return ossl_pkey_wrap(pkey);
 }
 
 static VALUE

--- a/test/openssl/test_x509cert.rb
+++ b/test/openssl/test_x509cert.rb
@@ -42,6 +42,17 @@ class OpenSSL::TestX509Certificate < OpenSSL::TestCase
     }
   end
 
+  def test_public_key_instance
+    # Repeated calls of X509_get_pubkey() return the same EVP_PKEY object with
+    # increased reference count
+    cert = OpenSSL::X509::Certificate.new
+    cert.public_key = @rsa2048
+
+    p1 = cert.public_key
+    p2 = cert.public_key
+    assert_same(p1, p2)
+  end
+
   def test_validity
     now = Time.at(Time.now.to_i + 0.9)
     cert = issue_cert(@ca, @rsa2048, 1, [], nil, nil,


### PR DESCRIPTION
Currently, it is possible to create multiple OpenSSL::PKey::PKey instances that wrap the same EVP_PKEY object through ossl_pkey_wrap(). This behavior was not intentional and doesn't offer any useful functionality.

As a result, the frozen state of an OpenSSL::PKey::PKey instance is meaningless. An upcoming change to make OpenSSL classes shareable between ractors relies on the assumption that frozen objects are thread-safe without the GVL.

Let's keep track of the wrapper Ruby object associated with EVP_PKEY to ensure that only one Ruby object wraps a given EVP_PKEY.

While other OpenSSL types have reference counters, EVP_PKEY is the only type in ruby/openssl where duplicate wrapper objects can be created.