### PR TITLE
Cipher#update make the output string modifiable

### DIFF
--- a/ext/openssl/ossl_cipher.c
+++ b/ext/openssl/ossl_cipher.c
@@ -414,6 +414,7 @@ ossl_cipher_update(int argc, VALUE *argv, VALUE self)
     if (!ossl_cipher_update_long(ctx, (unsigned char *)RSTRING_PTR(str), &out_len, in, in_len))
 	ossl_raise(eCipherError, NULL);
     assert(out_len <= RSTRING_LEN(str));
+    rb_str_modify(str);
     rb_str_set_len(str, out_len);
 
     return str;

--- a/test/openssl/test_cipher.rb
+++ b/test/openssl/test_cipher.rb
@@ -369,6 +369,14 @@ class OpenSSL::TestCipher < OpenSSL::TestCase
     end
   end
 
+  def test_update_shared_string
+    cipher = OpenSSL::Cipher.new("aes-256-ecb").encrypt
+    cipher.random_key
+    str = ("a"*12345).freeze
+    shared_str = str.byteslice(-132..)
+    cipher.update("a"*100, shared_str)
+  end
+
   private
 
   def new_encryptor(algo, **kwargs)


### PR DESCRIPTION
[Bug #20937]

If the provided string is shared `rb_str_set_len` raises an error. So we must call `rb_str_modify` first to unshare it if necessary.