### PR TITLE
Reduce OpenSSL::Buffering#do_write overhead

### DIFF
--- a/lib/openssl/buffering.rb
+++ b/lib/openssl/buffering.rb
@@ -37,8 +37,8 @@ module OpenSSL::Buffering
       end
     end
 
-    alias_method :concat, :append_as_bytes
-    alias_method :<<, :append_as_bytes
+    undef_method :concat
+    undef_method :<<
   end
 
   ##
@@ -73,7 +73,7 @@ module OpenSSL::Buffering
 
   def fill_rbuff
     begin
-      @rbuffer << self.sysread(BLOCK_SIZE)
+      @rbuffer.append_as_bytes(self.sysread(BLOCK_SIZE))
     rescue Errno::EAGAIN
       retry
     rescue EOFError
@@ -450,10 +450,10 @@ module OpenSSL::Buffering
   def puts(*args)
     s = Buffer.new
     if args.empty?
-      s << "\n"
+      s.append_as_bytes("\n")
     end
     args.each{|arg|
-      s << arg.to_s
+      s.append_as_bytes(arg.to_s)
       s.sub!(/(?<!\n)\z/, "\n")
     }
     do_write(s)
@@ -467,7 +467,7 @@ module OpenSSL::Buffering
 
   def print(*args)
     s = Buffer.new
-    args.each{ |arg| s << arg.to_s }
+    args.each{ |arg| s.append_as_bytes(arg.to_s) }
     do_write(s)
     nil
   end

--- a/test/openssl/test_buffering.rb
+++ b/test/openssl/test_buffering.rb
@@ -31,7 +31,7 @@ class OpenSSL::TestBuffering < OpenSSL::TestCase
     end
 
     def syswrite(str)
-      @io << str
+      @io.append_as_bytes(str)
       str.size
     end
   end


### PR DESCRIPTION
[[Bug #20972]](https://bugs.ruby-lang.org/issues/20972)

The `rb_str_new_freeze` was added in https://github.com/ruby/openssl/issues/452 to better handle concurrent use of a Socket, but SSL sockets can't be used concurrently AFAIK, so we might as well just error cleanly.

By using `rb_str_locktmp` we can ensure attempts at concurrent write will raise an error, be we avoid causing a copy of the bytes.

We also use the newer `String#append_as_bytes` method when available to save on some more copies.
