### PR TITLE
Require LibreSSL 3.9 or later (Drop support for 3.1-3.8)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,16 +73,8 @@ jobs:
           - openssl-3.4.0 # Supported until 2026-10-22
           - openssl-master
           # http://www.libressl.org/releases.html
-          - libressl-3.1.5 # EOL
-          - libressl-3.2.7 # EOL
-          - libressl-3.3.6 # EOL
-          - libressl-3.4.3 # EOL
-          - libressl-3.5.3 # EOL
-          - libressl-3.6.3 # EOL
-          - libressl-3.7.3 # EOL
-          - libressl-3.8.4 # EOL 2024-10-16
           - libressl-3.9.2 # Supported until 2025-04-05
-          - libressl-4.0.0
+          - libressl-4.0.0 # Supported until 2025-10-08
         include:
           - { name-extra: 'with fips provider', openssl: openssl-3.0.15, fips-enabled: true }
           - { name-extra: 'with fips provider', openssl: openssl-3.1.7, fips-enabled: true }

--- a/ext/openssl/extconf.rb
+++ b/ext/openssl/extconf.rb
@@ -123,6 +123,7 @@ version_ok = if have_macro("LIBRESSL_VERSION_NUMBER", "openssl/opensslv.h")
   checking_for("LibreSSL version >= 3.9.0") {
     try_static_assert("LIBRESSL_VERSION_NUMBER >= 0x30900000L", "openssl/opensslv.h") }
 else
+  is_openssl = true
   checking_for("OpenSSL version >= 1.0.2") {
     try_static_assert("OPENSSL_VERSION_NUMBER >= 0x10002000L", "openssl/opensslv.h") }
 end
@@ -143,11 +144,13 @@ ssl_h = "openssl/ssl.h".freeze
 
 # compile options
 have_func("RAND_egd()", "openssl/rand.h")
-engines = %w{dynamic 4758cca aep atalla chil
-             cswift nuron sureware ubsec padlock capi gmp gost cryptodev}
-engines.each { |name|
-  have_func("ENGINE_load_#{name}()", "openssl/engine.h")
-}
+if is_openssl
+  engines = %w{dynamic 4758cca aep atalla chil
+               cswift nuron sureware ubsec padlock capi gmp gost cryptodev}
+  engines.each { |name|
+    have_func("ENGINE_load_#{name}()", "openssl/engine.h")
+  }
+end
 
 # added in 1.1.0
 if !have_struct_member("SSL", "ctx", "openssl/ssl.h") || is_libressl

--- a/ext/openssl/extconf.rb
+++ b/ext/openssl/extconf.rb
@@ -120,14 +120,14 @@ end
 
 version_ok = if have_macro("LIBRESSL_VERSION_NUMBER", "openssl/opensslv.h")
   is_libressl = true
-  checking_for("LibreSSL version >= 3.1.0") {
-    try_static_assert("LIBRESSL_VERSION_NUMBER >= 0x30100000L", "openssl/opensslv.h") }
+  checking_for("LibreSSL version >= 3.9.0") {
+    try_static_assert("LIBRESSL_VERSION_NUMBER >= 0x30900000L", "openssl/opensslv.h") }
 else
   checking_for("OpenSSL version >= 1.0.2") {
     try_static_assert("OPENSSL_VERSION_NUMBER >= 0x10002000L", "openssl/opensslv.h") }
 end
 unless version_ok
-  raise "OpenSSL >= 1.0.2 or LibreSSL >= 3.1.0 is required"
+  raise "OpenSSL >= 1.0.2 or LibreSSL >= 3.9.0 is required"
 end
 
 # Prevent wincrypt.h from being included, which defines conflicting macro with openssl/x509.h
@@ -148,9 +148,6 @@ engines = %w{dynamic 4758cca aep atalla chil
 engines.each { |name|
   have_func("ENGINE_load_#{name}()", "openssl/engine.h")
 }
-
-# missing in libressl < 3.5
-have_func("i2d_re_X509_tbs(NULL, NULL)", x509_h)
 
 # added in 1.1.0
 if !have_struct_member("SSL", "ctx", "openssl/ssl.h") || is_libressl

--- a/ext/openssl/ossl.c
+++ b/ext/openssl/ossl.c
@@ -1050,7 +1050,7 @@ Init_openssl(void)
     /*
      * Init all digests, ciphers
      */
-#if !defined(LIBRESSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x10100000
+#if OSSL_OPENSSL_PREREQ(1, 1, 0) || OSSL_IS_LIBRESSL
     if (!OPENSSL_init_ssl(0, NULL))
         rb_raise(rb_eRuntimeError, "OPENSSL_init_ssl");
 #else
@@ -1075,7 +1075,7 @@ Init_openssl(void)
     /*
      * Version of OpenSSL the ruby OpenSSL extension is running with
      */
-#if !defined(LIBRESSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x10100000
+#if OSSL_OPENSSL_PREREQ(1, 1, 0) || OSSL_IS_LIBRESSL
     rb_define_const(mOSSL, "OPENSSL_LIBRARY_VERSION", rb_str_new2(OpenSSL_version(OPENSSL_VERSION)));
 #else
     rb_define_const(mOSSL, "OPENSSL_LIBRARY_VERSION", rb_str_new2(SSLeay_version(SSLEAY_VERSION)));

--- a/ext/openssl/ossl_engine.c
+++ b/ext/openssl/ossl_engine.c
@@ -47,7 +47,7 @@ static VALUE eEngineError;
 /*
  * Private
  */
-#if !defined(LIBRESSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x10100000
+#if OSSL_OPENSSL_PREREQ(1, 1, 0)
 #define OSSL_ENGINE_LOAD_IF_MATCH(engine_name, x) \
 do{\
   if(!strcmp(#engine_name, RSTRING_PTR(name))){\
@@ -163,7 +163,7 @@ ossl_engine_s_load(int argc, VALUE *argv, VALUE klass)
 static VALUE
 ossl_engine_s_cleanup(VALUE self)
 {
-#if defined(LIBRESSL_VERSION_NUMBER) || OPENSSL_VERSION_NUMBER < 0x10100000
+#if !OSSL_OPENSSL_PREREQ(1, 1, 0)
     ENGINE_cleanup();
 #endif
     return Qnil;

--- a/ext/openssl/ossl_kdf.c
+++ b/ext/openssl/ossl_kdf.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2007, 2017 Ruby/OpenSSL Project Authors
  */
 #include "ossl.h"
-#if OSSL_OPENSSL_PREREQ(1, 1, 0) || OSSL_LIBRESSL_PREREQ(3, 6, 0)
+#if OSSL_OPENSSL_PREREQ(1, 1, 0) || OSSL_IS_LIBRESSL
 # include <openssl/kdf.h>
 #endif
 
@@ -141,7 +141,7 @@ kdf_scrypt(int argc, VALUE *argv, VALUE self)
 }
 #endif
 
-#if OSSL_OPENSSL_PREREQ(1, 1, 0) || OSSL_LIBRESSL_PREREQ(3, 6, 0)
+#if OSSL_OPENSSL_PREREQ(1, 1, 0) || OSSL_IS_LIBRESSL
 /*
  * call-seq:
  *    KDF.hkdf(ikm, salt:, info:, length:, hash:) -> String
@@ -305,7 +305,7 @@ Init_ossl_kdf(void)
 #if defined(HAVE_EVP_PBE_SCRYPT)
     rb_define_module_function(mKDF, "scrypt", kdf_scrypt, -1);
 #endif
-#if OSSL_OPENSSL_PREREQ(1, 1, 0) || OSSL_LIBRESSL_PREREQ(3, 6, 0)
+#if OSSL_OPENSSL_PREREQ(1, 1, 0) || OSSL_IS_LIBRESSL
     rb_define_module_function(mKDF, "hkdf", kdf_hkdf, -1);
 #endif
 }

--- a/ext/openssl/ossl_pkey.c
+++ b/ext/openssl/ossl_pkey.c
@@ -799,7 +799,7 @@ ossl_pkey_export_traditional(int argc, VALUE *argv, VALUE self, int to_der)
 	}
     }
     else {
-#if OSSL_OPENSSL_PREREQ(1, 1, 0) || OSSL_LIBRESSL_PREREQ(3, 5, 0)
+#if OSSL_OPENSSL_PREREQ(1, 1, 0) || OSSL_IS_LIBRESSL
 	if (!PEM_write_bio_PrivateKey_traditional(bio, pkey, enc, NULL, 0,
 						  ossl_pem_passwd_cb,
 						  (void *)pass)) {
@@ -1116,7 +1116,7 @@ ossl_pkey_sign(int argc, VALUE *argv, VALUE self)
             rb_jump_tag(state);
         }
     }
-#if OSSL_OPENSSL_PREREQ(1, 1, 1) || OSSL_LIBRESSL_PREREQ(3, 4, 0)
+#if OSSL_OPENSSL_PREREQ(1, 1, 1) || OSSL_IS_LIBRESSL
     if (EVP_DigestSign(ctx, NULL, &siglen, (unsigned char *)RSTRING_PTR(data),
                        RSTRING_LEN(data)) < 1) {
         EVP_MD_CTX_free(ctx);
@@ -1221,7 +1221,7 @@ ossl_pkey_verify(int argc, VALUE *argv, VALUE self)
             rb_jump_tag(state);
         }
     }
-#if OSSL_OPENSSL_PREREQ(1, 1, 1) || OSSL_LIBRESSL_PREREQ(3, 4, 0)
+#if OSSL_OPENSSL_PREREQ(1, 1, 1) || OSSL_IS_LIBRESSL
     ret = EVP_DigestVerify(ctx, (unsigned char *)RSTRING_PTR(sig),
                            RSTRING_LEN(sig), (unsigned char *)RSTRING_PTR(data),
                            RSTRING_LEN(data));

--- a/ext/openssl/ossl_ssl.c
+++ b/ext/openssl/ossl_ssl.c
@@ -18,11 +18,6 @@
 # define OSSL_USE_NEXTPROTONEG
 #endif
 
-#if !defined(TLS1_3_VERSION) && \
-    OSSL_LIBRESSL_PREREQ(3, 2, 0) && !OSSL_LIBRESSL_PREREQ(3, 4, 0)
-#  define TLS1_3_VERSION 0x0304
-#endif
-
 #ifdef _WIN32
 #  define TO_SOCKET(s) _get_osfhandle(s)
 #else

--- a/ext/openssl/ossl_x509cert.c
+++ b/ext/openssl/ossl_x509cert.c
@@ -711,7 +711,6 @@ ossl_x509_eq(VALUE self, VALUE other)
     return !X509_cmp(a, b) ? Qtrue : Qfalse;
 }
 
-#ifdef HAVE_I2D_RE_X509_TBS
 /*
  * call-seq:
  *    cert.tbs_bytes => string
@@ -741,7 +740,6 @@ ossl_x509_tbs_bytes(VALUE self)
 
     return str;
 }
-#endif
 
 struct load_chained_certificates_arguments {
     VALUE certificates;
@@ -1035,7 +1033,5 @@ Init_ossl_x509cert(void)
     rb_define_method(cX509Cert, "add_extension", ossl_x509_add_extension, 1);
     rb_define_method(cX509Cert, "inspect", ossl_x509_inspect, 0);
     rb_define_method(cX509Cert, "==", ossl_x509_eq, 1);
-#ifdef HAVE_I2D_RE_X509_TBS
     rb_define_method(cX509Cert, "tbs_bytes", ossl_x509_tbs_bytes, 0);
-#endif
 }

--- a/ext/openssl/ossl_x509store.c
+++ b/ext/openssl/ossl_x509store.c
@@ -365,12 +365,12 @@ ossl_x509store_add_file(VALUE self, VALUE file)
         ossl_raise(eX509StoreError, "X509_STORE_add_lookup");
     if (X509_LOOKUP_load_file(lookup, path, X509_FILETYPE_PEM) != 1)
         ossl_raise(eX509StoreError, "X509_LOOKUP_load_file");
-#if OPENSSL_VERSION_NUMBER < 0x10101000 || defined(LIBRESSL_VERSION_NUMBER)
+#if !OSSL_OPENSSL_PREREQ(1, 1, 1) && !OSSL_IS_LIBRESSL
     /*
      * X509_load_cert_crl_file() which is called from X509_LOOKUP_load_file()
      * did not check the return value of X509_STORE_add_{cert,crl}(), leaking
      * "cert already in hash table" errors on the error queue, if duplicate
-     * certificates are found. This will be fixed by OpenSSL 1.1.1.
+     * certificates are found. Fixed by OpenSSL 1.1.1 and LibreSSL 3.5.0.
      */
     ossl_clear_error();
 #endif

--- a/test/openssl/test_pkey.rb
+++ b/test/openssl/test_pkey.rb
@@ -11,7 +11,7 @@ class OpenSSL::TestPKey < OpenSSL::PKeyTestCase
   end
 
   def test_generic_oid_inspect_x25519
-    omit "X25519 not supported" unless openssl?(1, 1, 0) || libressl?(3, 7, 0)
+    omit "X25519 not supported" if openssl? && !openssl?(1, 1, 0)
     omit_on_fips
 
     # X25519 private key
@@ -85,8 +85,7 @@ class OpenSSL::TestPKey < OpenSSL::PKeyTestCase
   def test_ed25519
     # Ed25519 is not FIPS-approved.
     omit_on_fips
-    # See EVP_PKEY_sign in Changelog for 3.7.0: https://github.com/libressl/portable/blob/master/ChangeLog
-    omit "Ed25519 not supported" unless openssl?(1, 1, 1) || libressl?(3, 7, 0)
+    omit "Ed25519 not supported" if openssl? && !openssl?(1, 1, 1)
 
     # Test vector from RFC 8032 Section 7.1 TEST 2
     priv_pem = <<~EOF
@@ -137,7 +136,7 @@ class OpenSSL::TestPKey < OpenSSL::PKeyTestCase
   end
 
   def test_x25519
-    omit "X25519 not supported" unless openssl?(1, 1, 0) || libressl?(3, 7, 0)
+    omit "X25519 not supported" if openssl? && !openssl?(1, 1, 0)
     omit_on_fips
 
     # Test vector from RFC 7748 Section 6.1
@@ -160,7 +159,7 @@ class OpenSSL::TestPKey < OpenSSL::PKeyTestCase
     assert_equal bob_pem, bob.public_to_pem
     assert_equal [shared_secret].pack("H*"), alice.derive(bob)
 
-    unless openssl?(1, 1, 1) || libressl?(3, 7, 0)
+    if openssl? && !openssl?(1, 1, 1)
       omit "running OpenSSL version does not have raw public key support"
     end
     alice_private = OpenSSL::PKey.new_raw_private_key("X25519", alice.raw_private_key)
@@ -176,7 +175,7 @@ class OpenSSL::TestPKey < OpenSSL::PKeyTestCase
   end
 
   def test_raw_initialize_errors
-    omit "Ed25519 not supported" unless openssl?(1, 1, 1) || libressl?(3, 7, 0)
+    omit "Ed25519 not supported" if openssl? && !openssl?(1, 1, 1)
 
     assert_raise(OpenSSL::PKey::PKeyError) { OpenSSL::PKey.new_raw_private_key("foo123", "xxx") }
     assert_raise(OpenSSL::PKey::PKeyError) { OpenSSL::PKey.new_raw_private_key("ED25519", "xxx") }

--- a/test/openssl/test_ssl.rb
+++ b/test/openssl/test_ssl.rb
@@ -1075,13 +1075,11 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
 
   def test_verify_hostname_on_connect
     ctx_proc = proc { |ctx|
-      san = "DNS:a.example.com,DNS:*.b.example.com"
-      san += ",DNS:c*.example.com,DNS:d.*.example.com" unless libressl?
       exts = [
         ["keyUsage", "keyEncipherment,digitalSignature", true],
-        ["subjectAltName", san],
+        ["subjectAltName", "DNS:a.example.com,DNS:*.b.example.com," \
+                           "DNS:c*.example.com,DNS:d.*.example.com"],
       ]
-
       ctx.cert = issue_cert(@svr, @svr_key, 4, exts, @ca_cert, @ca_key)
       ctx.key = @svr_key
     }
@@ -1103,7 +1101,6 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
         ["cx.example.com", true],
         ["d.x.example.com", false],
       ].each do |name, expected_ok|
-        next if name.start_with?('cx') if libressl?
         begin
           sock = TCPSocket.new("127.0.0.1", port)
           ssl = OpenSSL::SSL::SSLSocket.new(sock, ctx)

--- a/test/openssl/test_ssl_session.rb
+++ b/test/openssl/test_ssl_session.rb
@@ -120,7 +120,7 @@ __EOS__
       ctx.options &= ~OpenSSL::SSL::OP_NO_TICKET
       # Disable server-side session cache which is enabled by default
       ctx.session_cache_mode = OpenSSL::SSL::SSLContext::SESSION_CACHE_OFF
-      ctx.max_version = OpenSSL::SSL::TLS1_2_VERSION if libressl?(3, 2, 0)
+      ctx.max_version = OpenSSL::SSL::TLS1_2_VERSION if libressl?
     }
     start_server(ctx_proc: ctx_proc) do |port|
       sess1 = server_connect_with_session(port, nil, nil) { |ssl|

--- a/test/openssl/test_x509cert.rb
+++ b/test/openssl/test_x509cert.rb
@@ -294,8 +294,7 @@ class OpenSSL::TestX509Certificate < OpenSSL::TestCase
   def test_sign_and_verify_ed25519
     # Ed25519 is not FIPS-approved.
     omit_on_fips
-    # See ASN1_item_sign_ctx in ChangeLog for 3.8.1: https://github.com/libressl/portable/blob/master/ChangeLog
-    omit "Ed25519 not supported" unless openssl?(1, 1, 1) || libressl?(3, 8, 1)
+    omit "Ed25519 not supported" if openssl? && !openssl?(1, 1, 1)
     ed25519 = OpenSSL::PKey::generate_key("ED25519")
     cert = issue_cert(@ca, ed25519, 1, [], nil, nil, digest: nil)
     assert_equal(true, cert.verify(ed25519))
@@ -421,8 +420,6 @@ class OpenSSL::TestX509Certificate < OpenSSL::TestCase
   end
 
   def test_tbs_precert_bytes
-    pend "LibreSSL < 3.5 does not have i2d_re_X509_tbs" if libressl? && !libressl?(3, 5, 0)
-
     cert = issue_cert(@ca, @rsa2048, 1, [], nil, nil)
     seq = OpenSSL::ASN1.decode(cert.tbs_bytes)
 

--- a/test/openssl/test_x509crl.rb
+++ b/test/openssl/test_x509crl.rb
@@ -207,8 +207,7 @@ class OpenSSL::TestX509CRL < OpenSSL::TestCase
   def test_sign_and_verify_ed25519
     # Ed25519 is not FIPS-approved.
     omit_on_fips
-    # See ASN1_item_sign_ctx in ChangeLog for 3.8.1: https://github.com/libressl/portable/blob/master/ChangeLog
-    omit "Ed25519 not supported" unless openssl?(1, 1, 1) || libressl?(3, 8, 1)
+    omit "Ed25519 not supported" if openssl? && !openssl?(1, 1, 1)
     ed25519 = OpenSSL::PKey::generate_key("ED25519")
     cert = issue_cert(@ca, ed25519, 1, [], nil, nil, digest: nil)
     crl = issue_crl([], 1, Time.now, Time.now+1600, [],

--- a/test/openssl/test_x509req.rb
+++ b/test/openssl/test_x509req.rb
@@ -135,8 +135,7 @@ class OpenSSL::TestX509Request < OpenSSL::TestCase
   def test_sign_and_verify_ed25519
     # Ed25519 is not FIPS-approved.
     omit_on_fips
-    # See ASN1_item_sign_ctx in ChangeLog for 3.8.1: https://github.com/libressl/portable/blob/master/ChangeLog
-    omit "Ed25519 not supported" unless openssl?(1, 1, 1) || libressl?(3, 8, 1)
+    omit "Ed25519 not supported" if openssl? && !openssl?(1, 1, 1)
     ed25519 = OpenSSL::PKey::generate_key("ED25519")
     req = issue_csr(0, @dn, ed25519, nil)
     assert_equal(false, request_error_returns_false { req.verify(@rsa1024) })

--- a/test/openssl/test_x509store.rb
+++ b/test/openssl/test_x509store.rb
@@ -331,7 +331,7 @@ class OpenSSL::TestX509Store < OpenSSL::TestCase
   def test_add_cert_duplicate
     # Up until OpenSSL 1.1.0, X509_STORE_add_{cert,crl}() returned an error
     # if the given certificate is already in the X509_STORE
-    return if openssl?(1, 1, 0) || libressl?
+    return unless openssl? && !openssl?(1, 1, 0)
     ca1 = OpenSSL::X509::Name.parse_rfc2253("CN=Root CA")
     ca1_key = Fixtures.pkey("rsa-1")
     ca1_cert = issue_cert(ca1, ca1_key, 1, [], nil, nil)


### PR DESCRIPTION
This is part of #835.

