### PR TITLE
Require OpenSSL 1.1.1 or later (Drop support for 1.1.0)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,6 @@ jobs:
         name-extra: [ '' ]
         openssl:
           # https://openssl-library.org/source/
-          - openssl-1.1.0l # EOL
           - openssl-1.1.1w # EOL 2023-09-11, still used by RHEL 8 and Ubuntu 20.04
           - openssl-3.0.15 # Supported until 2026-09-07
           - openssl-3.1.7 # Supported until 2025-03-14

--- a/ext/openssl/extconf.rb
+++ b/ext/openssl/extconf.rb
@@ -115,11 +115,11 @@ version_ok = if have_macro("LIBRESSL_VERSION_NUMBER", "openssl/opensslv.h")
     try_static_assert("LIBRESSL_VERSION_NUMBER >= 0x30900000L", "openssl/opensslv.h") }
 else
   is_openssl = true
-  checking_for("OpenSSL version >= 1.1.0") {
-    try_static_assert("OPENSSL_VERSION_NUMBER >= 0x10100000L", "openssl/opensslv.h") }
+  checking_for("OpenSSL version >= 1.1.1") {
+    try_static_assert("OPENSSL_VERSION_NUMBER >= 0x10101000L", "openssl/opensslv.h") }
 end
 unless version_ok
-  raise "OpenSSL >= 1.1.0 or LibreSSL >= 3.9.0 is required"
+  raise "OpenSSL >= 1.1.1 or LibreSSL >= 3.9.0 is required"
 end
 
 # Prevent wincrypt.h from being included, which defines conflicting macro with openssl/x509.h
@@ -138,11 +138,8 @@ have_func("RAND_egd()", "openssl/rand.h")
 # added in 1.1.0, currently not in LibreSSL
 have_func("EVP_PBE_scrypt(\"\", 0, (unsigned char *)\"\", 0, 0, 0, 0, 0, NULL, 0)", evp_h)
 
-# added in 1.1.1
+# added in OpenSSL 1.1.1 and LibreSSL 3.5.0, then removed in LibreSSL 4.0.0
 have_func("EVP_PKEY_check(NULL)", evp_h)
-have_func("EVP_PKEY_new_raw_private_key(0, NULL, (unsigned char *)\"\", 0)", evp_h)
-have_func("SSL_CTX_set_ciphersuites(NULL, \"\")", ssl_h)
-have_func("SSL_CTX_set_post_handshake_auth(NULL, 0)", ssl_h)
 
 # added in 3.0.0
 have_func("SSL_set0_tmp_dh_pkey(NULL, NULL)", ssl_h)

--- a/ext/openssl/ossl_hmac.c
+++ b/ext/openssl/ossl_hmac.c
@@ -97,19 +97,11 @@ ossl_hmac_initialize(VALUE self, VALUE key, VALUE digest)
 
     GetHMAC(self, ctx);
     StringValue(key);
-#ifdef HAVE_EVP_PKEY_NEW_RAW_PRIVATE_KEY
     pkey = EVP_PKEY_new_raw_private_key(EVP_PKEY_HMAC, NULL,
                                         (unsigned char *)RSTRING_PTR(key),
                                         RSTRING_LENINT(key));
     if (!pkey)
         ossl_raise(eHMACError, "EVP_PKEY_new_raw_private_key");
-#else
-    pkey = EVP_PKEY_new_mac_key(EVP_PKEY_HMAC, NULL,
-                                (unsigned char *)RSTRING_PTR(key),
-                                RSTRING_LENINT(key));
-    if (!pkey)
-        ossl_raise(eHMACError, "EVP_PKEY_new_mac_key");
-#endif
     if (EVP_DigestSignInit(ctx, NULL, ossl_evp_get_digestbyname(digest),
                            NULL, pkey) != 1) {
         EVP_PKEY_free(pkey);

--- a/ext/openssl/ossl_rand.c
+++ b/ext/openssl/ossl_rand.c
@@ -189,9 +189,7 @@ Init_ossl_rand(void)
     rb_define_module_function(mRandom, "load_random_file", ossl_rand_load_file, 1);
     rb_define_module_function(mRandom, "write_random_file", ossl_rand_write_file, 1);
     rb_define_module_function(mRandom, "random_bytes", ossl_rand_bytes, 1);
-#if OPENSSL_VERSION_NUMBER < 0x10101000 || defined(LIBRESSL_VERSION_NUMBER)
     rb_define_alias(rb_singleton_class(mRandom), "pseudo_bytes", "random_bytes");
-#endif
 #ifdef HAVE_RAND_EGD
     rb_define_module_function(mRandom, "egd", ossl_rand_egd, 1);
     rb_define_module_function(mRandom, "egd_bytes", ossl_rand_egd_bytes, 2);

--- a/ext/openssl/ossl_ssl.c
+++ b/ext/openssl/ossl_ssl.c
@@ -109,9 +109,7 @@ parse_proto_version(VALUE str)
 	{ "TLS1", TLS1_VERSION },
 	{ "TLS1_1", TLS1_1_VERSION },
 	{ "TLS1_2", TLS1_2_VERSION },
-#ifdef TLS1_3_VERSION
 	{ "TLS1_3", TLS1_3_VERSION },
-#endif
     };
 
     if (NIL_P(str))
@@ -383,7 +381,7 @@ ossl_sslctx_session_new_cb(SSL *ssl, SSL_SESSION *sess)
     return 0;
 }
 
-#if OPENSSL_VERSION_NUMBER >= 0x10101000 && !defined(LIBRESSL_VERSION_NUMBER)
+#if !OSSL_IS_LIBRESSL
 /*
  * It is only compatible with OpenSSL >= 1.1.1. Even if LibreSSL implements
  * SSL_CTX_set_keylog_callback() from v3.4.2, it does nothing (see
@@ -762,9 +760,7 @@ ossl_sslctx_setup(VALUE self)
     SSL_CTX_set_tmp_dh_callback(ctx, ossl_tmp_dh_callback);
 #endif
 
-#ifdef HAVE_SSL_CTX_SET_POST_HANDSHAKE_AUTH
     SSL_CTX_set_post_handshake_auth(ctx, 1);
-#endif
 
     val = rb_attr_get(self, id_i_cert_store);
     if (!NIL_P(val)) {
@@ -904,7 +900,7 @@ ossl_sslctx_setup(VALUE self)
 	OSSL_Debug("SSL TLSEXT servername callback added");
     }
 
-#if OPENSSL_VERSION_NUMBER >= 0x10101000 && !defined(LIBRESSL_VERSION_NUMBER)
+#if !OSSL_IS_LIBRESSL
     /*
      * It is only compatible with OpenSSL >= 1.1.1. Even if LibreSSL implements
      * SSL_CTX_set_keylog_callback() from v3.4.2, it does nothing (see
@@ -1016,7 +1012,6 @@ ossl_sslctx_set_ciphers(VALUE self, VALUE v)
     return v;
 }
 
-#ifdef HAVE_SSL_CTX_SET_CIPHERSUITES
 /*
  * call-seq:
  *    ctx.ciphersuites = "cipher1:cipher2:..."
@@ -1043,7 +1038,6 @@ ossl_sslctx_set_ciphersuites(VALUE self, VALUE v)
 
     return v;
 }
-#endif
 
 #ifndef OPENSSL_NO_DH
 /*
@@ -2829,9 +2823,7 @@ Init_ossl_ssl(void)
 			     ossl_sslctx_set_minmax_proto_version, 2);
     rb_define_method(cSSLContext, "ciphers",     ossl_sslctx_get_ciphers, 0);
     rb_define_method(cSSLContext, "ciphers=",    ossl_sslctx_set_ciphers, 1);
-#ifdef HAVE_SSL_CTX_SET_CIPHERSUITES
     rb_define_method(cSSLContext, "ciphersuites=", ossl_sslctx_set_ciphersuites, 1);
-#endif
 #ifndef OPENSSL_NO_DH
     rb_define_method(cSSLContext, "tmp_dh=", ossl_sslctx_set_tmp_dh, 1);
 #endif
@@ -2967,7 +2959,7 @@ Init_ossl_ssl(void)
 #ifdef SSL_OP_DISABLE_TLSEXT_CA_NAMES /* OpenSSL 3.0 */
     rb_define_const(mSSL, "OP_DISABLE_TLSEXT_CA_NAMES", ULONG2NUM(SSL_OP_DISABLE_TLSEXT_CA_NAMES));
 #endif
-#ifdef SSL_OP_ALLOW_NO_DHE_KEX /* OpenSSL 1.1.1 */
+#ifdef SSL_OP_ALLOW_NO_DHE_KEX /* OpenSSL 1.1.1, missing in LibreSSL */
     rb_define_const(mSSL, "OP_ALLOW_NO_DHE_KEX", ULONG2NUM(SSL_OP_ALLOW_NO_DHE_KEX));
 #endif
     rb_define_const(mSSL, "OP_DONT_INSERT_EMPTY_FRAGMENTS", ULONG2NUM(SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS));
@@ -2975,28 +2967,26 @@ Init_ossl_ssl(void)
     rb_define_const(mSSL, "OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION", ULONG2NUM(SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION));
     rb_define_const(mSSL, "OP_NO_COMPRESSION", ULONG2NUM(SSL_OP_NO_COMPRESSION));
     rb_define_const(mSSL, "OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION", ULONG2NUM(SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION));
-#ifdef SSL_OP_NO_ENCRYPT_THEN_MAC /* OpenSSL 1.1.1 */
+#ifdef SSL_OP_NO_ENCRYPT_THEN_MAC /* OpenSSL 1.1.1, missing in LibreSSL */
     rb_define_const(mSSL, "OP_NO_ENCRYPT_THEN_MAC", ULONG2NUM(SSL_OP_NO_ENCRYPT_THEN_MAC));
 #endif
-#ifdef SSL_OP_ENABLE_MIDDLEBOX_COMPAT /* OpenSSL 1.1.1 */
+#ifdef SSL_OP_ENABLE_MIDDLEBOX_COMPAT /* OpenSSL 1.1.1, missing in LibreSSL */
     rb_define_const(mSSL, "OP_ENABLE_MIDDLEBOX_COMPAT", ULONG2NUM(SSL_OP_ENABLE_MIDDLEBOX_COMPAT));
 #endif
-#ifdef SSL_OP_PRIORITIZE_CHACHA /* OpenSSL 1.1.1 */
+#ifdef SSL_OP_PRIORITIZE_CHACHA /* OpenSSL 1.1.1, missing in LibreSSL */
     rb_define_const(mSSL, "OP_PRIORITIZE_CHACHA", ULONG2NUM(SSL_OP_PRIORITIZE_CHACHA));
 #endif
-#ifdef SSL_OP_NO_ANTI_REPLAY /* OpenSSL 1.1.1 */
+#ifdef SSL_OP_NO_ANTI_REPLAY /* OpenSSL 1.1.1, missing in LibreSSL */
     rb_define_const(mSSL, "OP_NO_ANTI_REPLAY", ULONG2NUM(SSL_OP_NO_ANTI_REPLAY));
 #endif
     rb_define_const(mSSL, "OP_NO_SSLv3", ULONG2NUM(SSL_OP_NO_SSLv3));
     rb_define_const(mSSL, "OP_NO_TLSv1", ULONG2NUM(SSL_OP_NO_TLSv1));
     rb_define_const(mSSL, "OP_NO_TLSv1_1", ULONG2NUM(SSL_OP_NO_TLSv1_1));
     rb_define_const(mSSL, "OP_NO_TLSv1_2", ULONG2NUM(SSL_OP_NO_TLSv1_2));
-#ifdef SSL_OP_NO_TLSv1_3 /* OpenSSL 1.1.1 */
     rb_define_const(mSSL, "OP_NO_TLSv1_3", ULONG2NUM(SSL_OP_NO_TLSv1_3));
-#endif
     rb_define_const(mSSL, "OP_CIPHER_SERVER_PREFERENCE", ULONG2NUM(SSL_OP_CIPHER_SERVER_PREFERENCE));
     rb_define_const(mSSL, "OP_TLS_ROLLBACK_BUG", ULONG2NUM(SSL_OP_TLS_ROLLBACK_BUG));
-#ifdef SSL_OP_NO_RENEGOTIATION /* OpenSSL 1.1.1 */
+#ifdef SSL_OP_NO_RENEGOTIATION /* OpenSSL 1.1.1, missing in LibreSSL */
     rb_define_const(mSSL, "OP_NO_RENEGOTIATION", ULONG2NUM(SSL_OP_NO_RENEGOTIATION));
 #endif
     rb_define_const(mSSL, "OP_CRYPTOPRO_TLSEXT_BUG", ULONG2NUM(SSL_OP_CRYPTOPRO_TLSEXT_BUG));
@@ -3058,10 +3048,8 @@ Init_ossl_ssl(void)
     rb_define_const(mSSL, "TLS1_1_VERSION", INT2NUM(TLS1_1_VERSION));
     /* TLS 1.2 */
     rb_define_const(mSSL, "TLS1_2_VERSION", INT2NUM(TLS1_2_VERSION));
-#ifdef TLS1_3_VERSION /* OpenSSL 1.1.1 */
     /* TLS 1.3 */
     rb_define_const(mSSL, "TLS1_3_VERSION", INT2NUM(TLS1_3_VERSION));
-#endif
 
 
     sym_exception = ID2SYM(rb_intern_const("exception"));

--- a/ext/openssl/ossl_x509.c
+++ b/ext/openssl/ossl_x509.c
@@ -130,7 +130,7 @@ Init_ossl_x509(void)
 #if defined(X509_V_ERR_PROXY_SUBJECT_NAME_VIOLATION) /* OpenSSL 1.1.0, missing in LibreSSL */
     DefX509Const(V_ERR_PROXY_SUBJECT_NAME_VIOLATION);
 #endif
-#if defined(X509_V_ERR_OCSP_VERIFY_NEEDED)
+#if defined(X509_V_ERR_OCSP_VERIFY_NEEDED) /* OpenSSL 1.1.1, missing in LibreSSL */
     DefX509Const(V_ERR_OCSP_VERIFY_NEEDED);
     DefX509Const(V_ERR_OCSP_VERIFY_FAILED);
     DefX509Const(V_ERR_OCSP_CERT_UNKNOWN);

--- a/ext/openssl/ossl_x509store.c
+++ b/ext/openssl/ossl_x509store.c
@@ -357,15 +357,6 @@ ossl_x509store_add_file(VALUE self, VALUE file)
         ossl_raise(eX509StoreError, "X509_STORE_add_lookup");
     if (X509_LOOKUP_load_file(lookup, path, X509_FILETYPE_PEM) != 1)
         ossl_raise(eX509StoreError, "X509_LOOKUP_load_file");
-#if !OSSL_OPENSSL_PREREQ(1, 1, 1) && !OSSL_IS_LIBRESSL
-    /*
-     * X509_load_cert_crl_file() which is called from X509_LOOKUP_load_file()
-     * did not check the return value of X509_STORE_add_{cert,crl}(), leaking
-     * "cert already in hash table" errors on the error queue, if duplicate
-     * certificates are found. Fixed by OpenSSL 1.1.1 and LibreSSL 3.5.0.
-     */
-    ossl_clear_error();
-#endif
 
     return self;
 }

--- a/test/openssl/test_pkey.rb
+++ b/test/openssl/test_pkey.rb
@@ -84,7 +84,6 @@ class OpenSSL::TestPKey < OpenSSL::PKeyTestCase
   def test_ed25519
     # Ed25519 is not FIPS-approved.
     omit_on_fips
-    omit "Ed25519 not supported" if openssl? && !openssl?(1, 1, 1)
 
     # Test vector from RFC 8032 Section 7.1 TEST 2
     priv_pem = <<~EOF
@@ -157,9 +156,6 @@ class OpenSSL::TestPKey < OpenSSL::PKeyTestCase
     assert_equal bob_pem, bob.public_to_pem
     assert_equal [shared_secret].pack("H*"), alice.derive(bob)
 
-    if openssl? && !openssl?(1, 1, 1)
-      omit "running OpenSSL version does not have raw public key support"
-    end
     alice_private = OpenSSL::PKey.new_raw_private_key("X25519", alice.raw_private_key)
     bob_public = OpenSSL::PKey.new_raw_public_key("X25519", bob.raw_public_key)
     assert_equal alice_private.private_to_pem,
@@ -173,8 +169,6 @@ class OpenSSL::TestPKey < OpenSSL::PKeyTestCase
   end
 
   def test_raw_initialize_errors
-    omit "Ed25519 not supported" if openssl? && !openssl?(1, 1, 1)
-
     assert_raise(OpenSSL::PKey::PKeyError) { OpenSSL::PKey.new_raw_private_key("foo123", "xxx") }
     assert_raise(OpenSSL::PKey::PKeyError) { OpenSSL::PKey.new_raw_private_key("ED25519", "xxx") }
     assert_raise(OpenSSL::PKey::PKeyError) { OpenSSL::PKey.new_raw_public_key("foo123", "xxx") }

--- a/test/openssl/test_pkey_dh.rb
+++ b/test/openssl/test_pkey_dh.rb
@@ -111,7 +111,7 @@ class OpenSSL::TestPKeyDH < OpenSSL::PKeyTestCase
     # applying the following commits in OpenSSL 1.1.1d to make `DH_check`
     # function pass the RFC 7919 FFDHE group texts.
     # https://github.com/openssl/openssl/pull/9435
-    unless openssl?(1, 1, 1, 4)
+    if openssl? && !openssl?(1, 1, 1, 4)
       pend 'DH check for RFC 7919 FFDHE group texts is not implemented'
     end
 

--- a/test/openssl/test_ssl_session.rb
+++ b/test/openssl/test_ssl_session.rb
@@ -250,7 +250,6 @@ __EOS__
   end
 
   def test_ctx_client_session_cb_tls13
-    omit "TLS 1.3 not supported" unless tls13_supported?
     omit "LibreSSL does not call session_new_cb in TLS 1.3" if libressl?
 
     start_server do |port|
@@ -274,7 +273,6 @@ __EOS__
   end
 
   def test_ctx_client_session_cb_tls13_exception
-    omit "TLS 1.3 not supported" unless tls13_supported?
     omit "LibreSSL does not call session_new_cb in TLS 1.3" if libressl?
 
     server_proc = lambda do |ctx, ssl|
@@ -375,11 +373,6 @@ __EOS__
       connections = 2
       sess2 = server_connect_with_session(port, cctx, sess0.dup) { |ssl|
         ssl.puts("abc"); assert_equal "abc\n", ssl.gets
-        if !ssl.session_reused? && openssl?(1, 1, 0) && !openssl?(1, 1, 0, 7)
-          # OpenSSL >= 1.1.0, < 1.1.0g
-          pend "External session cache is not working; " \
-            "see https://github.com/openssl/openssl/pull/4014"
-        end
         assert_equal true, ssl.session_reused?
         ssl.session
       }

--- a/test/openssl/test_x509cert.rb
+++ b/test/openssl/test_x509cert.rb
@@ -294,7 +294,6 @@ class OpenSSL::TestX509Certificate < OpenSSL::TestCase
   def test_sign_and_verify_ed25519
     # Ed25519 is not FIPS-approved.
     omit_on_fips
-    omit "Ed25519 not supported" if openssl? && !openssl?(1, 1, 1)
     ed25519 = OpenSSL::PKey::generate_key("ED25519")
     cert = issue_cert(@ca, ed25519, 1, [], nil, nil, digest: nil)
     assert_equal(true, cert.verify(ed25519))

--- a/test/openssl/test_x509crl.rb
+++ b/test/openssl/test_x509crl.rb
@@ -207,7 +207,6 @@ class OpenSSL::TestX509CRL < OpenSSL::TestCase
   def test_sign_and_verify_ed25519
     # Ed25519 is not FIPS-approved.
     omit_on_fips
-    omit "Ed25519 not supported" if openssl? && !openssl?(1, 1, 1)
     ed25519 = OpenSSL::PKey::generate_key("ED25519")
     cert = issue_cert(@ca, ed25519, 1, [], nil, nil, digest: nil)
     crl = issue_crl([], 1, Time.now, Time.now+1600, [],

--- a/test/openssl/test_x509req.rb
+++ b/test/openssl/test_x509req.rb
@@ -135,7 +135,6 @@ class OpenSSL::TestX509Request < OpenSSL::TestCase
   def test_sign_and_verify_ed25519
     # Ed25519 is not FIPS-approved.
     omit_on_fips
-    omit "Ed25519 not supported" if openssl? && !openssl?(1, 1, 1)
     ed25519 = OpenSSL::PKey::generate_key("ED25519")
     req = issue_csr(0, @dn, ed25519, nil)
     assert_equal(false, request_error_returns_false { req.verify(@rsa1024) })

--- a/test/openssl/utils.rb
+++ b/test/openssl/utils.rb
@@ -186,14 +186,6 @@ class OpenSSL::SSLTestCase < OpenSSL::TestCase
     @server = nil
   end
 
-  def tls13_supported?
-    return false unless defined?(OpenSSL::SSL::TLS1_3_VERSION)
-    ctx = OpenSSL::SSL::SSLContext.new
-    ctx.min_version = ctx.max_version = OpenSSL::SSL::TLS1_3_VERSION
-    true
-  rescue
-  end
-
   def readwrite_loop(ctx, ssl)
     while line = ssl.gets
       ssl.write(line)


### PR DESCRIPTION
This is part 3 of 3 for #835.