### PR TITLE
ts: use TS_VERIFY_CTX_set0_{store,certs}() on OpenSSL 3.4

### DIFF
--- a/ext/openssl/extconf.rb
+++ b/ext/openssl/extconf.rb
@@ -144,13 +144,15 @@ have_func("EVP_PKEY_check(NULL)", evp_h)
 # added in 3.0.0
 have_func("SSL_set0_tmp_dh_pkey(NULL, NULL)", ssl_h)
 have_func("ERR_get_error_all(NULL, NULL, NULL, NULL, NULL)", "openssl/err.h")
-have_func("TS_VERIFY_CTX_set_certs(NULL, NULL)", ts_h)
 have_func("SSL_CTX_load_verify_file(NULL, \"\")", ssl_h)
 have_func("BN_check_prime(NULL, NULL, NULL)", "openssl/bn.h")
 have_func("EVP_MD_CTX_get0_md(NULL)", evp_h)
 have_func("EVP_MD_CTX_get_pkey_ctx(NULL)", evp_h)
 have_func("EVP_PKEY_eq(NULL, NULL)", evp_h)
 have_func("EVP_PKEY_dup(NULL)", evp_h)
+
+# added in 3.4.0
+have_func("TS_VERIFY_CTX_set0_certs(NULL, NULL)", ts_h)
 
 Logging::message "=== Checking done. ===\n"
 

--- a/ext/openssl/openssl_missing.h
+++ b/ext/openssl/openssl_missing.h
@@ -13,10 +13,6 @@
 #include "ruby/config.h"
 
 /* added in 3.0.0 */
-#if !defined(HAVE_TS_VERIFY_CTX_SET_CERTS)
-#  define TS_VERIFY_CTX_set_certs(ctx, crts) TS_VERIFY_CTS_set_certs(ctx, crts)
-#endif
-
 #ifndef HAVE_EVP_MD_CTX_GET0_MD
 #  define EVP_MD_CTX_get0_md(ctx) EVP_MD_CTX_md(ctx)
 #endif


### PR DESCRIPTION
TS_VERIFY_CTX_set_certs() and TS_VERIFY_CTX_set_store() are deprecated in OpenSSL 3.4 in favor of the new functions with "set0" in the names.

Increment the reference counter of X509_STORE before setting it to TS_VERIFY_CTX. We avoided doing this to work around a bug that was present in OpenSSL < 1.0.2, fixed by openssl/openssl@bff9ce4db38b.

Fixes #837