### PR TITLE
ssl: separate SSLContext#min_version= and #max_version=

### DIFF
--- a/lib/openssl/ssl.rb
+++ b/lib/openssl/ssl.rb
@@ -154,43 +154,6 @@ ssbzSibBsu/6iGtCOGEoXJf//////////wIBAg==
       end
 
       # call-seq:
-      #    ctx.min_version = OpenSSL::SSL::TLS1_2_VERSION
-      #    ctx.min_version = :TLS1_2
-      #    ctx.min_version = nil
-      #
-      # Sets the lower bound on the supported SSL/TLS protocol version. The
-      # version may be specified by an integer constant named
-      # OpenSSL::SSL::*_VERSION, a Symbol, or +nil+ which means "any version".
-      #
-      # Be careful that you don't overwrite OpenSSL::SSL::OP_NO_{SSL,TLS}v*
-      # options by #options= once you have called #min_version= or
-      # #max_version=.
-      #
-      # === Example
-      #   ctx = OpenSSL::SSL::SSLContext.new
-      #   ctx.min_version = OpenSSL::SSL::TLS1_1_VERSION
-      #   ctx.max_version = OpenSSL::SSL::TLS1_2_VERSION
-      #
-      #   sock = OpenSSL::SSL::SSLSocket.new(tcp_sock, ctx)
-      #   sock.connect # Initiates a connection using either TLS 1.1 or TLS 1.2
-      def min_version=(version)
-        set_minmax_proto_version(version, @max_proto_version ||= nil)
-        @min_proto_version = version
-      end
-
-      # call-seq:
-      #    ctx.max_version = OpenSSL::SSL::TLS1_2_VERSION
-      #    ctx.max_version = :TLS1_2
-      #    ctx.max_version = nil
-      #
-      # Sets the upper bound of the supported SSL/TLS protocol version. See
-      # #min_version= for the possible values.
-      def max_version=(version)
-        set_minmax_proto_version(@min_proto_version ||= nil, version)
-        @max_proto_version = version
-      end
-
-      # call-seq:
       #    ctx.ssl_version = :TLSv1
       #    ctx.ssl_version = "SSLv23"
       #
@@ -214,8 +177,7 @@ ssbzSibBsu/6iGtCOGEoXJf//////////wIBAg==
         end
         version = METHODS_MAP[meth.intern] or
           raise ArgumentError, "unknown SSL method `%s'" % meth
-        set_minmax_proto_version(version, version)
-        @min_proto_version = @max_proto_version = version
+        self.min_version = self.max_version = version
       end
 
       METHODS_MAP = {


### PR DESCRIPTION
Make these methods simple wrappers around SSL_CTX_set_{min,max}_proto_version().

When we introduced these methods in commit 18603949d316 (#142), which went to v2.1.0, we added a private method to SSLContext that set both the minimum and maximum protocol versions at the same time. This was to allow emulating the behavior using SSL options on older OpenSSL versions that lack SSL_CTX_set_{min,max}_proto_version(). Since we no longer support OpenSSL 1.0.2, the related code has already been removed.

In OpenSSL 1.1.1 or later, setting the minimum or maximum version to 0 is not equivalent to leaving it unset. Similar to SSL options, which we avoid overwriting as of commit 00bec0d905d5 and commit 77c3db2d6587 (#767), a system-wide configuration file may define a default protocol version bounds. Setting the minimum version should not unset the maximum version, and vice versa.