### PR TITLE
Removed needless workaround again

### DIFF
--- a/test/openssl/test_ossl.rb
+++ b/test/openssl/test_ossl.rb
@@ -42,12 +42,6 @@ class OpenSSL::OSSL < OpenSSL::SSLTestCase
   end
 
   def test_memcmp_timing
-    begin
-      require "benchmark"
-    rescue LoadError
-      pend "Benchmark is not available in this environment. Please install it with `gem install benchmark`."
-    end
-
     # Ensure using fixed_length_secure_compare takes almost exactly the same amount of time to compare two different strings.
     # Regular string comparison will short-circuit on the first non-matching character, failing this test.
     # NOTE: this test may be susceptible to noise if the system running the tests is otherwise under load.


### PR DESCRIPTION
I'm not sure why https://github.com/ruby/openssl/commit/b0acc1a48eec67cf3837c466e7a6abb043c5150a is available on HEAD.

I removed that again.