### PR TITLE
Add build support for AWS-LC

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,6 +73,8 @@ jobs:
           # http://www.libressl.org/releases.html
           - libressl-3.9.2 # Supported until 2025-04-05
           - libressl-4.0.0 # Supported until 2025-10-08
+          # https://github.com/aws/aws-lc/tags
+          - aws-lc-latest
         include:
           - { name-extra: 'with fips provider', openssl: openssl-3.0.15, fips-enabled: true }
           - { name-extra: 'with fips provider', openssl: openssl-3.1.7, fips-enabled: true }
@@ -81,6 +83,7 @@ jobs:
           - { name-extra: 'with fips provider', openssl: openssl-3.4.0, fips-enabled: true }
           - { name-extra: 'with fips provider', openssl: openssl-master, fips-enabled: true }
           - { name-extra: 'without legacy provider', openssl: openssl-3.4.0, append-configure: 'no-legacy' }
+          - { openssl: aws-lc-latest, skip-warnings: true, skip-tests: true } # Remove "skip-tests" once AWS-LC tests are working.
     steps:
       - name: repo checkout
         uses: actions/checkout@v4
@@ -120,6 +123,13 @@ jobs:
             ./configure --prefix=$HOME/openssl
             make -j4 && make install
             ;;
+          aws-lc-*)
+            git clone https://github.com/aws/aws-lc.git .
+            AWS_LC_RELEASE=$(git tag --sort=-creatordate --list "v*"  | head -1)
+            git checkout $AWS_LC_RELEASE
+            cmake -DCMAKE_INSTALL_PREFIX=$HOME/openssl
+            make -j4 && make install
+            ;;
           *)
             false
             ;;
@@ -150,7 +160,7 @@ jobs:
       - name: rake test
         run:  bundle exec rake test TESTOPTS="-v --no-show-detail-immediately"
         timeout-minutes: 5
-        if: ${{ !matrix.fips-enabled }}
+        if: ${{ !matrix.fips-enabled && !matrix.skip-tests }}
 
       # Run only the passing tests on the FIPS module as a temporary workaround.
       # TODO Fix other tests, and run all the tests on FIPS module.

--- a/ext/openssl/ossl.c
+++ b/ext/openssl/ossl.c
@@ -404,7 +404,7 @@ ossl_fips_mode_get(VALUE self)
     VALUE enabled;
     enabled = EVP_default_properties_is_fips_enabled(NULL) ? Qtrue : Qfalse;
     return enabled;
-#elif defined(OPENSSL_FIPS)
+#elif defined(OPENSSL_FIPS) || defined(OPENSSL_IS_AWSLC)
     VALUE enabled;
     enabled = FIPS_mode() ? Qtrue : Qfalse;
     return enabled;
@@ -439,7 +439,7 @@ ossl_fips_mode_set(VALUE self, VALUE enabled)
         }
     }
     return enabled;
-#elif defined(OPENSSL_FIPS)
+#elif defined(OPENSSL_FIPS) || defined(OPENSSL_IS_AWSLC)
     if (RTEST(enabled)) {
 	int mode = FIPS_mode();
 	if(!mode && !FIPS_mode_set(1)) /* turning on twice leads to an error */
@@ -1004,6 +1004,8 @@ Init_openssl(void)
                     Qtrue
 #elif defined(OPENSSL_FIPS)
 		    Qtrue
+#elif defined(OPENSSL_IS_AWSLC) // AWS-LC FIPS can only be enabled during compile time.
+            FIPS_mode() ? Qtrue : Qfalse
 #else
 		    Qfalse
 #endif

--- a/ext/openssl/ossl_pkcs12.c
+++ b/ext/openssl/ossl_pkcs12.c
@@ -134,9 +134,15 @@ ossl_pkcs12_s_create(int argc, VALUE *argv, VALUE self)
     if (!NIL_P(keytype))
         ktype = NUM2INT(keytype);
 
+#if defined(OPENSSL_IS_AWSLC)
+    if (ktype != 0) {
+        ossl_raise(rb_eArgError, "Unknown key usage type %"PRIsVALUE, INT2NUM(ktype));
+    }
+#else
     if (ktype != 0 && ktype != KEY_SIG && ktype != KEY_EX) {
         ossl_raise(rb_eArgError, "Unknown key usage type %"PRIsVALUE, INT2NUM(ktype));
     }
+#endif
 
     obj = NewPKCS12(cPKCS12);
     x509s = NIL_P(ca) ? NULL : ossl_x509_ary2sk(ca);
@@ -316,7 +322,9 @@ Init_ossl_pkcs12(void)
     rb_define_method(cPKCS12, "to_der", ossl_pkcs12_to_der, 0);
     rb_define_method(cPKCS12, "set_mac", pkcs12_set_mac, -1);
 
+#if !defined(OPENSSL_IS_AWSLC)
     /* MSIE specific PKCS12 key usage extensions */
     rb_define_const(cPKCS12, "KEY_EX", INT2NUM(KEY_EX));
     rb_define_const(cPKCS12, "KEY_SIG", INT2NUM(KEY_SIG));
+#endif
 }

--- a/ext/openssl/ossl_ssl.c
+++ b/ext/openssl/ossl_ssl.c
@@ -705,7 +705,9 @@ ossl_sslctx_setup(VALUE self)
     SSL_CTX_set_tmp_dh_callback(ctx, ossl_tmp_dh_callback);
 #endif
 
+#if !defined(OPENSSL_IS_AWSLC) /* AWS-LC has no support for TLS 1.3 PHA. */
     SSL_CTX_set_post_handshake_auth(ctx, 1);
+#endif
 
     val = rb_attr_get(self, id_i_cert_store);
     if (!NIL_P(val)) {

--- a/test/openssl/utils.rb
+++ b/test/openssl/utils.rb
@@ -103,7 +103,7 @@ module OpenSSL::TestUtils
   end
 
   def openssl?(major = nil, minor = nil, fix = nil, patch = 0, status = 0)
-    return false if OpenSSL::OPENSSL_VERSION.include?("LibreSSL")
+    return false if OpenSSL::OPENSSL_VERSION.include?("LibreSSL") || OpenSSL::OPENSSL_VERSION.include?("AWS-LC")
     return true unless major
     OpenSSL::OPENSSL_VERSION_NUMBER >=
       major * 0x10000000 + minor * 0x100000 + fix * 0x1000 + patch * 0x10 +
@@ -114,6 +114,10 @@ module OpenSSL::TestUtils
     version = OpenSSL::OPENSSL_VERSION.scan(/LibreSSL (\d+)\.(\d+)\.(\d+).*/)[0]
     return false unless version
     !major || (version.map(&:to_i) <=> [major, minor, fix]) >= 0
+  end
+
+  def aws_lc?
+    OpenSSL::OPENSSL_VERSION.include?("AWS-LC")
   end
 end
 


### PR DESCRIPTION
Follow up from https://github.com/ruby/openssl/issues/833

This contribution is to add basic build support for AWS-LC in the ruby/openssl gem. These changes represent the build portion of [a larger patch](https://github.com/aws/aws-lc/tree/main/tests/ci/integration/ruby_patch) in the AWS-LC's Ruby integration CI.

### CI changes 
1. I've split the patch up to make it easier to digest, but that forces my hand to turn off testing in the AWS-LC CI for the time being. However, do let me know if you would prefer to review the tests adjustments in the same PR and I can remove the temporary CI workaround :).
2. AWS-LC has a few no-op functions and we use the `-Wdeprecated-declarations` to alert the consuming application of these. I've leveraged the `skip-warnings` CI option so that the build doesn't fail.

### Build adjustments
1. AWS-LC FIPS mode is decided at compile time. This is different from OpenSSL's togglable FIPS switch, so I've adjusted the build to account for this.
2. AWS-LC does not support for the two `KEY_SIG` or `KEY_EX` flags that were only ever supported by old MSIE.
3. AWS-LC has no current support post handshake authentication in TLS 1.3.
4. `EC_GROUP` structures for named curves in AWS-LC are constant, static, and immutable by default. This means that `EC_GROUP_set_*` functions are essentially no-ops due to the immutability of the structure. We've introduced a new API for consumers that depend on the OpenSSL's default mutability of the `EC_GROUP` structure called `EC_GROUP_new_by_curve_name_mutable`. Since Ruby has a bit of functionality that's dependent on the mutability of these structures, I've made the corresponding adjustments to allow things to work as expected.