### PR TITLE
Cleanups in SSL tests

### DIFF
--- a/test/openssl/test_ssl.rb
+++ b/test/openssl/test_ssl.rb
@@ -1111,7 +1111,7 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
             ssl.connect
             ssl.puts "abc"; assert_equal "abc\n", ssl.gets
           else
-            assert_handshake_error { ssl.connect }
+            assert_raise(OpenSSL::SSL::SSLError) { ssl.connect }
           end
         ensure
           ssl.close if ssl
@@ -1149,7 +1149,7 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
         sock = TCPSocket.new("127.0.0.1", port)
         ssl = OpenSSL::SSL::SSLSocket.new(sock, ctx)
         ssl.hostname = "b.example.com"
-        assert_handshake_error { ssl.connect }
+        assert_raise(OpenSSL::SSL::SSLError) { ssl.connect }
         assert_equal false, verify_callback_ok
         assert_equal OpenSSL::X509::V_ERR_HOSTNAME_MISMATCH, verify_callback_err
       ensure
@@ -1250,7 +1250,7 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
       start_server(ctx_proc: ctx_proc, ignore_listener_error: true) { |port|
         ctx = OpenSSL::SSL::SSLContext.new
         ctx.set_params(cert_store: store, verify_hostname: false)
-        assert_handshake_error { server_connect(port, ctx) { } }
+        assert_raise(OpenSSL::SSL::SSLError) { server_connect(port, ctx) }
       }
     end
   end
@@ -1283,7 +1283,7 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
               ssl.puts "abc"; assert_equal "abc\n", ssl.gets
             }
           else
-            assert_handshake_error { server_connect(port, ctx1) { } }
+            assert_raise(OpenSSL::SSL::SSLError) { server_connect(port, ctx1) }
           end
 
           # There is no version-specific SSL methods for TLS 1.3
@@ -1297,7 +1297,7 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
                 ssl.puts "abc"; assert_equal "abc\n", ssl.gets
               }
             else
-              assert_handshake_error { server_connect(port, ctx2) { } }
+              assert_raise(OpenSSL::SSL::SSLError) { server_connect(port, ctx2) }
             end
           end
         end
@@ -1338,7 +1338,7 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
             ssl.puts "abc"; assert_equal "abc\n", ssl.gets
           }
         else
-          assert_handshake_error { server_connect(port, ctx2) { } }
+          assert_raise(OpenSSL::SSL::SSLError) { server_connect(port, ctx2) }
         end
       end
     }
@@ -1357,7 +1357,7 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
             ssl.puts "abc"; assert_equal "abc\n", ssl.gets
           }
         else
-          assert_handshake_error { server_connect(port, ctx1) { } }
+          assert_raise(OpenSSL::SSL::SSLError) { server_connect(port, ctx1) }
         end
 
         # Client sets max_version
@@ -1489,7 +1489,7 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
       # Client only supports TLS 1.2
       ctx1 = OpenSSL::SSL::SSLContext.new
       ctx1.min_version = ctx1.max_version = OpenSSL::SSL::TLS1_2_VERSION
-      assert_handshake_error { server_connect(port, ctx1) { } }
+      assert_raise(OpenSSL::SSL::SSLError) { server_connect(port, ctx1) }
 
       # Client only supports TLS 1.3
       ctx2 = OpenSSL::SSL::SSLContext.new
@@ -1505,7 +1505,7 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
       # Client doesn't support TLS 1.2
       ctx1 = OpenSSL::SSL::SSLContext.new
       ctx1.options |= OpenSSL::SSL::OP_NO_TLSv1_2
-      assert_handshake_error { server_connect(port, ctx1) { } }
+      assert_raise(OpenSSL::SSL::SSLError) { server_connect(port, ctx1) }
 
       # Client supports TLS 1.2 by default
       ctx2 = OpenSSL::SSL::SSLContext.new
@@ -1654,7 +1654,7 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
       ctx = OpenSSL::SSL::SSLContext.new
       ctx.max_version = :TLS1_2
       ctx.npn_select_cb = -> (protocols) { "a" * 256 }
-      assert_handshake_error { server_connect(port, ctx) }
+      assert_raise(OpenSSL::SSL::SSLError) { server_connect(port, ctx) }
     }
   end
 

--- a/test/openssl/test_ssl.rb
+++ b/test/openssl/test_ssl.rb
@@ -1884,10 +1884,6 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
   end
 
   def test_ciphers_method_bogus_csuite
-    omit "Old #{OpenSSL::OPENSSL_LIBRARY_VERSION}" if
-      year = OpenSSL::OPENSSL_LIBRARY_VERSION[/\A OpenSSL\s+[01]\..*\s\K\d+\z/x] and
-      year.to_i <= 2018
-
     ssl_ctx = OpenSSL::SSL::SSLContext.new
 
     assert_raise_with_message(

--- a/test/openssl/test_ssl.rb
+++ b/test/openssl/test_ssl.rb
@@ -645,7 +645,7 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
 
   def test_post_connect_check_with_anon_ciphers
     ctx_proc = -> ctx {
-      ctx.ssl_version = :TLSv1_2
+      ctx.max_version = OpenSSL::SSL::TLS1_2_VERSION
       ctx.ciphers = "aNULL"
       ctx.tmp_dh = Fixtures.pkey("dh-1")
       ctx.security_level = 0
@@ -653,7 +653,7 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
 
     start_server(ctx_proc: ctx_proc) { |port|
       ctx = OpenSSL::SSL::SSLContext.new
-      ctx.ssl_version = :TLSv1_2
+      ctx.max_version = OpenSSL::SSL::TLS1_2_VERSION
       ctx.ciphers = "aNULL"
       ctx.security_level = 0
       server_connect(port, ctx) { |ssl|
@@ -1688,12 +1688,12 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
   def test_get_ephemeral_key
     # kRSA
     ctx_proc1 = proc { |ctx|
-      ctx.ssl_version = :TLSv1_2
+      ctx.max_version = OpenSSL::SSL::TLS1_2_VERSION
       ctx.ciphers = "kRSA"
     }
     start_server(ctx_proc: ctx_proc1, ignore_listener_error: true) do |port|
       ctx = OpenSSL::SSL::SSLContext.new
-      ctx.ssl_version = :TLSv1_2
+      ctx.max_version = OpenSSL::SSL::TLS1_2_VERSION
       ctx.ciphers = "kRSA"
       begin
         server_connect(port, ctx) { |ssl| assert_nil ssl.tmp_key }
@@ -1704,15 +1704,15 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
     end
 
     # DHE
-    # TODO: How to test this with TLS 1.3?
+    # TODO: SSL_CTX_set1_groups() is required for testing this with TLS 1.3
     ctx_proc2 = proc { |ctx|
-      ctx.ssl_version = :TLSv1_2
+      ctx.max_version = OpenSSL::SSL::TLS1_2_VERSION
       ctx.ciphers = "EDH"
       ctx.tmp_dh = Fixtures.pkey("dh-1")
     }
     start_server(ctx_proc: ctx_proc2) do |port|
       ctx = OpenSSL::SSL::SSLContext.new
-      ctx.ssl_version = :TLSv1_2
+      ctx.max_version = OpenSSL::SSL::TLS1_2_VERSION
       ctx.ciphers = "EDH"
       server_connect(port, ctx) { |ssl|
         assert_instance_of OpenSSL::PKey::DH, ssl.tmp_key

--- a/test/openssl/test_ssl.rb
+++ b/test/openssl/test_ssl.rb
@@ -348,27 +348,27 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
       empty_store = OpenSSL::X509::Store.new
 
       # Valid certificate, SSL_VERIFY_PEER
+      ctx = OpenSSL::SSL::SSLContext.new
+      ctx.verify_mode = OpenSSL::SSL::VERIFY_PEER
+      ctx.cert_store = populated_store
       assert_nothing_raised {
-        ctx = OpenSSL::SSL::SSLContext.new
-        ctx.verify_mode = OpenSSL::SSL::VERIFY_PEER
-        ctx.cert_store = populated_store
         server_connect(port, ctx) { |ssl| ssl.puts("abc"); ssl.gets }
       }
 
       # Invalid certificate, SSL_VERIFY_NONE
+      ctx = OpenSSL::SSL::SSLContext.new
+      ctx.verify_mode = OpenSSL::SSL::VERIFY_NONE
+      ctx.cert_store = empty_store
       assert_nothing_raised {
-        ctx = OpenSSL::SSL::SSLContext.new
-        ctx.verify_mode = OpenSSL::SSL::VERIFY_NONE
-        ctx.cert_store = empty_store
         server_connect(port, ctx) { |ssl| ssl.puts("abc"); ssl.gets }
       }
 
       # Invalid certificate, SSL_VERIFY_PEER
-      assert_handshake_error {
-        ctx = OpenSSL::SSL::SSLContext.new
-        ctx.verify_mode = OpenSSL::SSL::VERIFY_PEER
-        ctx.cert_store = empty_store
-        server_connect(port, ctx) { |ssl| ssl.puts("abc"); ssl.gets }
+      ctx = OpenSSL::SSL::SSLContext.new
+      ctx.verify_mode = OpenSSL::SSL::VERIFY_PEER
+      ctx.cert_store = empty_store
+      assert_raise(OpenSSL::SSL::SSLError) {
+        server_connect(port, ctx)
       }
     }
   end

--- a/test/openssl/test_ssl.rb
+++ b/test/openssl/test_ssl.rb
@@ -1639,12 +1639,11 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
   def test_npn_advertised_protocol_too_long
     return unless OpenSSL::SSL::SSLContext.method_defined?(:npn_select_cb)
 
-    ctx_proc = Proc.new { |ctx| ctx.npn_protocols = ["a" * 256] }
-    start_server_version(:TLSv1_2, ctx_proc) { |port|
-      ctx = OpenSSL::SSL::SSLContext.new
-      ctx.npn_select_cb = -> (protocols) { protocols.first }
-      assert_handshake_error { server_connect(port, ctx) }
-    }
+    ctx = OpenSSL::SSL::SSLContext.new
+    assert_raise(OpenSSL::SSL::SSLError) do
+      ctx.npn_protocols = ["a" * 256]
+      ctx.setup
+    end
   end
 
   def test_npn_selected_protocol_too_long

--- a/test/openssl/test_ssl_session.rb
+++ b/test/openssl/test_ssl_session.rb
@@ -5,7 +5,9 @@ if defined?(OpenSSL::SSL)
 
 class OpenSSL::TestSSLSession < OpenSSL::SSLTestCase
   def test_session
-    ctx_proc = proc { |ctx| ctx.ssl_version = :TLSv1_2 }
+    ctx_proc = proc { |ctx|
+      ctx.max_version = OpenSSL::SSL::TLS1_2_VERSION
+    }
     start_server(ctx_proc: ctx_proc) do |port|
       server_connect_with_session(port, nil, nil) { |ssl|
         session = ssl.session
@@ -143,7 +145,7 @@ __EOS__
 
   def test_server_session_cache
     ctx_proc = Proc.new do |ctx|
-      ctx.ssl_version = :TLSv1_2
+      ctx.max_version = OpenSSL::SSL::TLS1_2_VERSION
       ctx.options |= OpenSSL::SSL::OP_NO_TICKET
     end
 
@@ -197,7 +199,7 @@ __EOS__
       10.times do |i|
         connections = i
         cctx = OpenSSL::SSL::SSLContext.new
-        cctx.ssl_version = :TLSv1_2
+        cctx.max_version = OpenSSL::SSL::TLS1_2_VERSION
         server_connect_with_session(port, cctx, first_session) { |ssl|
           ssl.puts("abc"); assert_equal "abc\n", ssl.gets
           first_session ||= ssl.session
@@ -299,11 +301,11 @@ __EOS__
     connections = nil
     called = {}
     cctx = OpenSSL::SSL::SSLContext.new
-    cctx.ssl_version = :TLSv1_2
+    cctx.max_version = OpenSSL::SSL::TLS1_2_VERSION
     sctx = nil
     ctx_proc = Proc.new { |ctx|
       sctx = ctx
-      ctx.ssl_version = :TLSv1_2
+      ctx.max_version = OpenSSL::SSL::TLS1_2_VERSION
       ctx.options |= OpenSSL::SSL::OP_NO_TICKET
 
       # get_cb is called whenever a client proposed to resume a session but

--- a/test/openssl/utils.rb
+++ b/test/openssl/utils.rb
@@ -192,7 +192,7 @@ class OpenSSL::SSLTestCase < OpenSSL::TestCase
     end
   end
 
-  def start_server(verify_mode: OpenSSL::SSL::VERIFY_NONE, start_immediately: true,
+  def start_server(verify_mode: OpenSSL::SSL::VERIFY_NONE,
                    ctx_proc: nil, server_proc: method(:readwrite_loop),
                    accept_proc: proc{},
                    ignore_listener_error: false, &block)
@@ -212,7 +212,6 @@ class OpenSSL::SSLTestCase < OpenSSL::TestCase
       port = tcps.connect_address.ip_port
 
       ssls = OpenSSL::SSL::SSLServer.new(tcps, ctx)
-      ssls.start_immediately = start_immediately
 
       threads = []
       begin


### PR DESCRIPTION
This PR contains several mostly-unrelated small improvements in the test code for `OpenSSL::SSL`.

---
**ssl: remove start_immediately kwarg from test helper start_server**

The keyword argument is no longer used by any test cases.

---
**ssl: remove start_server_version from tests**

Use start_server instead of start_server_version.

start_server_version is a wrapper around start_server that forces the
server to a specific protocol version using the now-deprecated method
SSLSocket#ssl_version=, but it does more than that. The slightly
different method signature and default values are confusing. Let's
use start_server directly.

---
**ssl: fix test case test_npn_advertised_protocol_too_long**

The list of NPN protocols is validated in SSLContext#setup.

The assert_handshake_error is misleading. The client is unable to start
a handshake at all because the server is not running.

---
**ssl: refactor test case test_verify_mode_server_cert**

Minimize the amount of code inside the assert_raise block to avoid
accidentally catching a wrong exception.

---
**ssl: fix misuse of assert_handshake_error in tests**

assert_handshake_error is useful for checking handshake failures
triggered by the peer, as the underlying socket may be closed
prematurely, leading to different exceptions depending on the platform
and timing.

However, when the local end aborts a handshake, the only possible
exception is OpenSSL::SSL::SSLError. Use stricter assertions in such
cases.

---
**ssl: prefer SSLContext#max_version= in tests**

Avoid using the deprecated OpenSSL::SSL::SSLContext#ssl_version= outside
the tests specifically written for it.

---
**Revert "Skip a new test when old OpenSSL"**

This reverts commit 8c96a69b0d470107240dcf31aa6f9c6e9c617ce1.

This is no longer necessary since we do not support OpenSSL 1.1.0
anymore.

