### PR TITLE
Avoid calling sk_*() with NULL

### DIFF
--- a/ext/openssl/ossl.c
+++ b/ext/openssl/ossl.c
@@ -69,16 +69,9 @@ ossl_##name##_sk2ary(const STACK_OF(type) *sk)	\
     int i, num;					\
     VALUE ary;					\
 						\
-    if (!sk) {					\
-	OSSL_Debug("empty sk!");		\
-	return Qnil;				\
-    }						\
+    RUBY_ASSERT(sk != NULL);			\
     num = sk_##type##_num(sk);			\
-    if (num < 0) {				\
-	OSSL_Debug("items in sk < -1???");	\
-	return rb_ary_new();			\
-    }						\
-    ary = rb_ary_new2(num);			\
+    ary = rb_ary_new_capa(num);			\
 						\
     for (i=0; i<num; i++) {			\
 	t = sk_##type##_value(sk, i);		\

--- a/ext/openssl/ossl_ssl.c
+++ b/ext/openssl/ossl_ssl.c
@@ -2450,7 +2450,7 @@ ossl_ssl_get_peer_finished(VALUE self)
 
 /*
  * call-seq:
- *    ssl.client_ca => [x509name, ...]
+ *    ssl.client_ca => [x509name, ...] or nil
  *
  * Returns the list of client CAs. Please note that in contrast to
  * SSLContext#client_ca= no array of X509::Certificate is returned but
@@ -2468,6 +2468,8 @@ ossl_ssl_get_client_ca_list(VALUE self)
     GetSSL(self, ssl);
 
     ca = SSL_get_client_CA_list(ssl);
+    if (!ca)
+        return Qnil;
     return ossl_x509name_sk2ary(ca);
 }
 

--- a/ext/openssl/ossl_x509cert.c
+++ b/ext/openssl/ossl_x509cert.c
@@ -619,10 +619,7 @@ ossl_x509_get_extensions(VALUE self)
 
     GetX509(self, x509);
     count = X509_get_ext_count(x509);
-    if (count < 0) {
-	return rb_ary_new();
-    }
-    ary = rb_ary_new2(count);
+    ary = rb_ary_new_capa(count);
     for (i=0; i<count; i++) {
 	ext = X509_get_ext(x509, i); /* NO DUP - don't free! */
 	rb_ary_push(ary, ossl_x509ext_new(ext));

--- a/ext/openssl/ossl_x509crl.c
+++ b/ext/openssl/ossl_x509crl.c
@@ -276,21 +276,19 @@ ossl_x509crl_get_revoked(VALUE self)
 {
     X509_CRL *crl;
     int i, num;
-    X509_REVOKED *rev;
-    VALUE ary, revoked;
+    STACK_OF(X509_REVOKED) *sk;
+    VALUE ary;
 
     GetX509CRL(self, crl);
-    num = sk_X509_REVOKED_num(X509_CRL_get_REVOKED(crl));
-    if (num < 0) {
-	OSSL_Debug("num < 0???");
-	return rb_ary_new();
-    }
-    ary = rb_ary_new2(num);
+    sk = X509_CRL_get_REVOKED(crl);
+    if (!sk)
+        return rb_ary_new();
+
+    num = sk_X509_REVOKED_num(sk);
+    ary = rb_ary_new_capa(num);
     for(i=0; i<num; i++) {
-	/* NO DUP - don't free! */
-	rev = sk_X509_REVOKED_value(X509_CRL_get_REVOKED(crl), i);
-	revoked = ossl_x509revoked_new(rev);
-	rb_ary_push(ary, revoked);
+	X509_REVOKED *rev = sk_X509_REVOKED_value(sk, i);
+	rb_ary_push(ary, ossl_x509revoked_new(rev));
     }
 
     return ary;

--- a/ext/openssl/ossl_x509crl.c
+++ b/ext/openssl/ossl_x509crl.c
@@ -449,11 +449,7 @@ ossl_x509crl_get_extensions(VALUE self)
 
     GetX509CRL(self, crl);
     count = X509_CRL_get_ext_count(crl);
-    if (count < 0) {
-	OSSL_Debug("count < 0???");
-	return rb_ary_new();
-    }
-    ary = rb_ary_new2(count);
+    ary = rb_ary_new_capa(count);
     for (i=0; i<count; i++) {
 	ext = X509_CRL_get_ext(crl, i); /* NO DUP - don't free! */
 	rb_ary_push(ary, ossl_x509ext_new(ext));

--- a/ext/openssl/ossl_x509name.c
+++ b/ext/openssl/ossl_x509name.c
@@ -354,11 +354,7 @@ ossl_x509name_to_a(VALUE self)
 
     GetX509Name(self, name);
     entries = X509_NAME_entry_count(name);
-    if (entries < 0) {
-	OSSL_Debug("name entries < 0!");
-	return rb_ary_new();
-    }
-    ret = rb_ary_new2(entries);
+    ret = rb_ary_new_capa(entries);
     for (i=0; i<entries; i++) {
 	if (!(entry = X509_NAME_get_entry(name, i))) {
 	    ossl_raise(eX509NameError, NULL);

--- a/ext/openssl/ossl_x509revoked.c
+++ b/ext/openssl/ossl_x509revoked.c
@@ -194,11 +194,7 @@ ossl_x509revoked_get_extensions(VALUE self)
 
     GetX509Rev(self, rev);
     count = X509_REVOKED_get_ext_count(rev);
-    if (count < 0) {
-	OSSL_Debug("count < 0???");
-	return rb_ary_new();
-    }
-    ary = rb_ary_new2(count);
+    ary = rb_ary_new_capa(count);
     for (i=0; i<count; i++) {
 	ext = X509_REVOKED_get_ext(rev, i);
 	rb_ary_push(ary, ossl_x509ext_new(ext));


### PR DESCRIPTION
Use explicit NULL checks before interacting with `STACK_OF(*)`. `ossl_*_sk2ary()` must no longer be called with NULL.

Checks for when `sk_*_num()` returns a negative number are removed. This can only happen when the stack is NULL.

This PR also cleans up unreachable code involving NULL stacks:

---
**pkcs7: add a test case for the data content type**

While it is not useful alone, it is still a valid content type. Some
methods on OpenSSL::PKCS7 are only meant to work with the signed-data or
enveloped-data. Add some assertions for their behavior with unsupported
content types. The next patches will update the relevant code.

---
**x509: do not check for negative return from X509_*_get_ext_count()**

These functions are wrappers of X509v3_get_ext_count(). The
implementation can never return a negative number, and this behavior is
documented in the man page.

---
**x509name: do not check for negative return from X509_NAME_entry_count()**

The function never returns a negative number.

