### PR TITLE
Patch and enable tests with AWS-LC

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,7 +83,7 @@ jobs:
           - { name-extra: 'with fips provider', openssl: openssl-3.4.0, fips-enabled: true }
           - { name-extra: 'with fips provider', openssl: openssl-master, fips-enabled: true }
           - { name-extra: 'without legacy provider', openssl: openssl-3.4.0, append-configure: 'no-legacy' }
-          - { openssl: aws-lc-latest, skip-warnings: true, skip-tests: true } # Remove "skip-tests" once AWS-LC tests are working.
+          - { openssl: aws-lc-latest, skip-warnings: true }
     steps:
       - name: repo checkout
         uses: actions/checkout@v4
@@ -160,7 +160,7 @@ jobs:
       - name: rake test
         run:  bundle exec rake test TESTOPTS="-v --no-show-detail-immediately"
         timeout-minutes: 5
-        if: ${{ !matrix.fips-enabled && !matrix.skip-tests }}
+        if: ${{ !matrix.fips-enabled }}
 
       # Run only the passing tests on the FIPS module as a temporary workaround.
       # TODO Fix other tests, and run all the tests on FIPS module.

--- a/test/openssl/test_asn1.rb
+++ b/test/openssl/test_asn1.rb
@@ -458,7 +458,7 @@ class  OpenSSL::TestASN1 < OpenSSL::TestCase
     encode_decode_test B(%w{ 81 00 }), OpenSSL::ASN1::ASN1Data.new(B(%w{}), 1, :CONTEXT_SPECIFIC)
     encode_decode_test B(%w{ C1 00 }), OpenSSL::ASN1::ASN1Data.new(B(%w{}), 1, :PRIVATE)
     encode_decode_test B(%w{ 1F 20 00 }), OpenSSL::ASN1::ASN1Data.new(B(%w{}), 32, :UNIVERSAL)
-    encode_decode_test B(%w{ 1F C0 20 00 }), OpenSSL::ASN1::ASN1Data.new(B(%w{}), 8224, :UNIVERSAL)
+    encode_decode_test B(%w{ 9F C0 20 00 }), OpenSSL::ASN1::ASN1Data.new(B(%w{}), 8224, :CONTEXT_SPECIFIC)
     encode_decode_test B(%w{ 41 02 AB CD }), OpenSSL::ASN1::ASN1Data.new(B(%w{ AB CD }), 1, :APPLICATION)
     encode_decode_test B(%w{ 41 81 80 } + %w{ AB CD } * 64), OpenSSL::ASN1::ASN1Data.new(B(%w{ AB CD } * 64), 1, :APPLICATION)
     encode_decode_test B(%w{ 41 82 01 00 } + %w{ AB CD } * 128), OpenSSL::ASN1::ASN1Data.new(B(%w{ AB CD } * 128), 1, :APPLICATION)

--- a/test/openssl/test_bn.rb
+++ b/test/openssl/test_bn.rb
@@ -321,6 +321,8 @@ class OpenSSL::TestBN < OpenSSL::TestCase
   end
 
   def test_get_flags_and_set_flags
+    return if aws_lc? # AWS-LC does not support BN::CONSTTIME.
+
     e = OpenSSL::BN.new(999)
 
     assert_equal(0, e.get_flags(OpenSSL::BN::CONSTTIME))
@@ -364,7 +366,9 @@ class OpenSSL::TestBN < OpenSSL::TestCase
       assert_equal(true, Ractor.new(@e2) { _1.negative? }.take)
       assert_include(128..255, Ractor.new { OpenSSL::BN.rand(8)}.take)
       assert_include(0...2**32, Ractor.new { OpenSSL::BN.generate_prime(32) }.take)
-      assert_equal(0, Ractor.new { OpenSSL::BN.new(999).get_flags(OpenSSL::BN::CONSTTIME) }.take)
+      if !aws_lc? # AWS-LC does not support BN::CONSTTIME.
+        assert_equal(0, Ractor.new { OpenSSL::BN.new(999).get_flags(OpenSSL::BN::CONSTTIME) }.take)
+      end
       # test if shareable when frozen
       assert Ractor.shareable?(@e1.freeze)
     end

--- a/test/openssl/test_config.rb
+++ b/test/openssl/test_config.rb
@@ -43,6 +43,9 @@ __EOD__
   end
 
   def test_s_parse_format
+    # AWS-LC removed support for parsing $foo variables.
+    return if aws_lc?
+
     c = OpenSSL::Config.parse(<<__EOC__)
  baz =qx\t                # "baz = qx"
 
@@ -213,13 +216,15 @@ __EOC__
     assert_raise(TypeError) do
       @it.get_value(nil, 'HOME') # not allowed unlike Config#value
     end
-    # fallback to 'default' ugly...
-    assert_equal('.', @it.get_value('unknown', 'HOME'))
+    unless aws_lc? # AWS-LC does not support the fallback
+      # fallback to 'default' ugly...
+      assert_equal('.', @it.get_value('unknown', 'HOME'))
+    end
   end
 
   def test_get_value_ENV
-    # LibreSSL removed support for NCONF_get_string(conf, "ENV", str)
-    return if libressl?
+    # LibreSSL and AWS-LC removed support for NCONF_get_string(conf, "ENV", str)
+    return if libressl? || aws_lc?
 
     key = ENV.keys.first
     assert_not_nil(key) # make sure we have at least one ENV var.

--- a/test/openssl/test_fips.rb
+++ b/test/openssl/test_fips.rb
@@ -28,6 +28,8 @@ class OpenSSL::TestFIPS < OpenSSL::TestCase
   end
 
   def test_fips_mode_is_reentrant
+    return if aws_lc? # AWS-LC's FIPS mode is decided at compile time.
+
     assert_separately(["-ropenssl"], <<~"end;")
       OpenSSL.fips_mode = false
       OpenSSL.fips_mode = false
@@ -35,7 +37,7 @@ class OpenSSL::TestFIPS < OpenSSL::TestCase
   end
 
   def test_fips_mode_get_with_fips_mode_set
-    omit('OpenSSL is not FIPS-capable') unless OpenSSL::OPENSSL_FIPS
+    omit('OpenSSL is not FIPS-capable') unless OpenSSL::OPENSSL_FIPS and !aws_lc? # AWS-LC's FIPS mode is decided at compile time.
 
     assert_separately(["-ropenssl"], <<~"end;")
       begin

--- a/test/openssl/test_pkcs12.rb
+++ b/test/openssl/test_pkcs12.rb
@@ -178,6 +178,8 @@ module OpenSSL
     end
 
     def test_create_with_keytype
+      omit "AWS-LC does not support KEY_SIG and KEY_EX" if aws_lc?
+
       OpenSSL::PKCS12.create(
         "omg",
         "hello",

--- a/test/openssl/test_pkey_dh.rb
+++ b/test/openssl/test_pkey_dh.rb
@@ -123,11 +123,22 @@ class OpenSSL::TestPKeyDH < OpenSSL::PKeyTestCase
     ]))
     assert_equal(true, dh1.params_ok?)
 
-    dh2 = OpenSSL::PKey::DH.new(OpenSSL::ASN1::Sequence([
-      OpenSSL::ASN1::Integer(dh0.p + 1),
-      OpenSSL::ASN1::Integer(dh0.g)
-    ]))
-    assert_equal(false, dh2.params_ok?)
+    # AWS-LC automatically does parameter checks on the parsed params.
+    if aws_lc?
+      assert_raise(OpenSSL::PKey::DHError) {
+        OpenSSL::PKey::DH.new(OpenSSL::ASN1::Sequence([
+          OpenSSL::ASN1::Integer(dh0.p + 1),
+          OpenSSL::ASN1::Integer(dh0.g)
+        ]))
+      }
+    else
+      dh2 = OpenSSL::PKey::DH.new(OpenSSL::ASN1::Sequence([
+        OpenSSL::ASN1::Integer(dh0.p + 1),
+        OpenSSL::ASN1::Integer(dh0.g)
+      ]))
+      assert_equal(false, dh2.params_ok?)
+    end
+
   end
 
   def test_params

--- a/test/openssl/test_pkey_dh.rb
+++ b/test/openssl/test_pkey_dh.rb
@@ -19,7 +19,7 @@ class OpenSSL::TestPKeyDH < OpenSSL::PKeyTestCase
   end if ENV["OSSL_TEST_ALL"]
 
   def test_new_break_on_non_fips
-    omit_on_fips
+    omit_on_fips if !aws_lc?
 
     assert_nil(OpenSSL::PKey::DH.new(NEW_KEYLEN) { break })
     assert_raise(RuntimeError) do
@@ -29,6 +29,7 @@ class OpenSSL::TestPKeyDH < OpenSSL::PKeyTestCase
 
   def test_new_break_on_fips
     omit_on_non_fips
+    return unless openssl? # This behavior only applies to OpenSSL.
 
     # The block argument is not executed in FIPS case.
     # See https://github.com/ruby/openssl/issues/692 for details.

--- a/test/openssl/test_pkey_dsa.rb
+++ b/test/openssl/test_pkey_dsa.rb
@@ -92,19 +92,19 @@ class OpenSSL::TestPKeyDSA < OpenSSL::PKeyTestCase
     sig = key.syssign(digest)
     assert_equal true, key.sysverify(digest, sig)
     assert_equal false, key.sysverify(digest, invalid_sig)
-    assert_raise(OpenSSL::PKey::DSAError) { key.sysverify(digest, malformed_sig) }
+    assert_sign_verify_false_or_error{ key.sysverify(digest, malformed_sig) }
     assert_equal true, key.verify_raw(nil, sig, digest)
     assert_equal false, key.verify_raw(nil, invalid_sig, digest)
-    assert_raise(OpenSSL::PKey::PKeyError) { key.verify_raw(nil, malformed_sig, digest) }
+    assert_sign_verify_false_or_error { key.verify_raw(nil, malformed_sig, digest) }
 
     # Sign by #sign_raw
     sig = key.sign_raw(nil, digest)
     assert_equal true, key.sysverify(digest, sig)
     assert_equal false, key.sysverify(digest, invalid_sig)
-    assert_raise(OpenSSL::PKey::DSAError) { key.sysverify(digest, malformed_sig) }
+    assert_sign_verify_false_or_error { key.sysverify(digest, malformed_sig) }
     assert_equal true, key.verify_raw(nil, sig, digest)
     assert_equal false, key.verify_raw(nil, invalid_sig, digest)
-    assert_raise(OpenSSL::PKey::PKeyError) { key.verify_raw(nil, malformed_sig, digest) }
+    assert_sign_verify_false_or_error { key.verify_raw(nil, malformed_sig, digest) }
   end
 
   def test_DSAPrivateKey

--- a/test/openssl/test_pkey_ec.rb
+++ b/test/openssl/test_pkey_ec.rb
@@ -152,19 +152,19 @@ class OpenSSL::TestEC < OpenSSL::PKeyTestCase
     sig = key.dsa_sign_asn1(data1)
     assert_equal true, key.dsa_verify_asn1(data1, sig)
     assert_equal false, key.dsa_verify_asn1(data2, sig)
-    assert_raise(OpenSSL::PKey::ECError) { key.dsa_verify_asn1(data1, malformed_sig) }
+    assert_sign_verify_false_or_error { key.dsa_verify_asn1(data1, malformed_sig) }
     assert_equal true, key.verify_raw(nil, sig, data1)
     assert_equal false, key.verify_raw(nil, sig, data2)
-    assert_raise(OpenSSL::PKey::PKeyError) { key.verify_raw(nil, malformed_sig, data1) }
+    assert_sign_verify_false_or_error { key.verify_raw(nil, malformed_sig, data1) }
 
     # Sign by #sign_raw
     sig = key.sign_raw(nil, data1)
     assert_equal true, key.dsa_verify_asn1(data1, sig)
     assert_equal false, key.dsa_verify_asn1(data2, sig)
-    assert_raise(OpenSSL::PKey::ECError) { key.dsa_verify_asn1(data1, malformed_sig) }
+    assert_sign_verify_false_or_error { key.dsa_verify_asn1(data1, malformed_sig) }
     assert_equal true, key.verify_raw(nil, sig, data1)
     assert_equal false, key.verify_raw(nil, sig, data2)
-    assert_raise(OpenSSL::PKey::PKeyError) { key.verify_raw(nil, malformed_sig, data1) }
+    assert_sign_verify_false_or_error{ key.verify_raw(nil, malformed_sig, data1) }
   end
 
   def test_dsa_sign_asn1_FIPS186_3

--- a/test/openssl/test_pkey_ec.rb
+++ b/test/openssl/test_pkey_ec.rb
@@ -309,7 +309,10 @@ class OpenSSL::TestEC < OpenSSL::PKeyTestCase
     assert_equal group1.to_der, group2.to_der
     assert_equal group1, group2
     group2.asn1_flag ^=OpenSSL::PKey::EC::NAMED_CURVE
-    assert_not_equal group1.to_der, group2.to_der
+    # AWS-LC does not support serializing explicit curves.
+    unless aws_lc?
+      assert_not_equal group1.to_der, group2.to_der
+    end
     assert_equal group1, group2
 
     group3 = group1.dup

--- a/test/openssl/utils.rb
+++ b/test/openssl/utils.rb
@@ -286,6 +286,14 @@ class OpenSSL::PKeyTestCase < OpenSSL::TestCase
       assert_equal base.send(comp), test.send(comp)
     }
   end
+
+  def assert_sign_verify_false_or_error
+    ret = yield
+  rescue => e
+    assert_kind_of(OpenSSL::PKey::PKeyError, e)
+  else
+    assert_equal(false, ret)
+  end
 end
 
 module OpenSSL::Certs


### PR DESCRIPTION
Second follow up from https://github.com/ruby/openssl/issues/833

This contribution should be the next and final phase for adding support for AWS-LC in the ruby/openssl gem. These changes represent the build portion of [a larger patch](https://github.com/aws/aws-lc/tree/main/tests/ci/integration/ruby_patch) in the AWS-LC's Ruby integration CI. With this change, all tests have been accounted for and reenabled in the CI.

I understand that this patch is a bit large, so I've broken everything up to into smaller documented commits that'll make things easier to digest. I've also tried following a similar commit messaging pattern that the maintainers use.
However, do feel free to let me know if I should make separate PR contributions for some of these or if there are any changes within the commit messages that I should adjust. Thank you!!