### PR TITLE
ssl: remove cert_store from start_server test helper

### DIFF
--- a/test/openssl/utils.rb
+++ b/test/openssl/utils.rb
@@ -201,11 +201,7 @@ class OpenSSL::SSLTestCase < OpenSSL::TestCase
                    accept_proc: proc{},
                    ignore_listener_error: false, &block)
     IO.pipe {|stop_pipe_r, stop_pipe_w|
-      store = OpenSSL::X509::Store.new
-      store.add_cert(@ca_cert)
-      store.purpose = OpenSSL::X509::PURPOSE_SSL_CLIENT
       ctx = OpenSSL::SSL::SSLContext.new
-      ctx.cert_store = store
       ctx.cert = @svr_cert
       ctx.key = @svr_key
       ctx.verify_mode = verify_mode


### PR DESCRIPTION
OpenSSL::SSL::SSLContext#cert_store= uses SSL_CTX_set_cert_store(). The store is used for verifying peer certificates and for building certificate chains to be sent to the peer if there is no chain explicitly provided by SSLContext#extra_chain_cert=.

Do not specify it in the common test helper start_server, as most callers do not require either function. Instead, update individual test cases that use client certificates to explicitly specify it in ctx_proc. A more direct test case is added to verify the latter function.