### PR TITLE
asn1: check for missing EOC in indefinite length encoding

### DIFF
--- a/ext/openssl/ossl_asn1.c
+++ b/ext/openssl/ossl_asn1.c
@@ -797,10 +797,12 @@ int_ossl_asn1_decode0_cons(unsigned char **pp, long max_len, long length,
 	*num_read += inner_read;
 	available_len -= inner_read;
 
-	if (indefinite &&
-	    ossl_asn1_tag(value) == V_ASN1_EOC &&
-	    ossl_asn1_get_tag_class(value) == sym_UNIVERSAL) {
-	    break;
+	if (indefinite) {
+            if (ossl_asn1_tag(value) == V_ASN1_EOC &&
+                ossl_asn1_get_tag_class(value) == sym_UNIVERSAL)
+                break;
+            if (available_len == 0)
+                ossl_raise(eASN1Error, "EOC missing in indefinite length encoding");
 	}
 	rb_ary_push(ary, value);
     }

--- a/test/openssl/test_asn1.rb
+++ b/test/openssl/test_asn1.rb
@@ -389,6 +389,11 @@ class  OpenSSL::TestASN1 < OpenSSL::TestCase
     ])
     expected.indefinite_length = true
     encode_test B(%w{ 30 80 04 01 00 00 00 }), expected
+
+    # Missing EOC at the end of contents octets
+    assert_raise(OpenSSL::ASN1::ASN1Error) {
+      OpenSSL::ASN1.decode(B(%w{ 30 80 01 01 FF }))
+    }
   end
 
   def test_set


### PR DESCRIPTION
EOC octets are required at the end of contents of a constructed encoding that uses the indefinite length form. This cannot be assumed from the end of the input. Raise an exception when necessary.