### PR TITLE
Improve implementations for skipping and conditions.

### DIFF
--- a/test/openssl/test_bn.rb
+++ b/test/openssl/test_bn.rb
@@ -366,7 +366,7 @@ class OpenSSL::TestBN < OpenSSL::TestCase
       assert_equal(true, Ractor.new(@e2) { _1.negative? }.take)
       assert_include(128..255, Ractor.new { OpenSSL::BN.rand(8)}.take)
       assert_include(0...2**32, Ractor.new { OpenSSL::BN.generate_prime(32) }.take)
-      if !aws_lc? # AWS-LC does not support BN::CONSTTIME.
+      unless aws_lc? # AWS-LC does not support BN::CONSTTIME.
         assert_equal(0, Ractor.new { OpenSSL::BN.new(999).get_flags(OpenSSL::BN::CONSTTIME) }.take)
       end
       # test if shareable when frozen

--- a/test/openssl/test_bn.rb
+++ b/test/openssl/test_bn.rb
@@ -321,7 +321,7 @@ class OpenSSL::TestBN < OpenSSL::TestCase
   end
 
   def test_get_flags_and_set_flags
-    return if aws_lc? # AWS-LC does not support BN::CONSTTIME.
+    omit "AWS-LC does not support BN::CONSTTIME" if aws_lc?
 
     e = OpenSSL::BN.new(999)
 

--- a/test/openssl/test_config.rb
+++ b/test/openssl/test_config.rb
@@ -43,8 +43,7 @@ __EOD__
   end
 
   def test_s_parse_format
-    # AWS-LC removed support for parsing $foo variables.
-    return if aws_lc?
+    omit "AWS-LC removed support for parsing $foo variables" if aws_lc?
 
     c = OpenSSL::Config.parse(<<__EOC__)
  baz =qx\t                # "baz = qx"
@@ -223,8 +222,10 @@ __EOC__
   end
 
   def test_get_value_ENV
-    # LibreSSL and AWS-LC removed support for NCONF_get_string(conf, "ENV", str)
-    return if libressl? || aws_lc?
+    if libressl? || aws_lc?
+      omit 'LibreSSL and AWS-LC removed support for '\
+           'NCONF_get_string(conf, "ENV", str)'
+    end
 
     key = ENV.keys.first
     assert_not_nil(key) # make sure we have at least one ENV var.

--- a/test/openssl/test_fips.rb
+++ b/test/openssl/test_fips.rb
@@ -28,8 +28,6 @@ class OpenSSL::TestFIPS < OpenSSL::TestCase
   end
 
   def test_fips_mode_is_reentrant
-    return if aws_lc? # AWS-LC's FIPS mode is decided at compile time.
-
     assert_separately(["-ropenssl"], <<~"end;")
       OpenSSL.fips_mode = false
       OpenSSL.fips_mode = false

--- a/test/openssl/test_fips.rb
+++ b/test/openssl/test_fips.rb
@@ -37,7 +37,9 @@ class OpenSSL::TestFIPS < OpenSSL::TestCase
   end
 
   def test_fips_mode_get_with_fips_mode_set
-    omit('OpenSSL is not FIPS-capable') unless OpenSSL::OPENSSL_FIPS and !aws_lc? # AWS-LC's FIPS mode is decided at compile time.
+    unless ENV["TEST_RUBY_OPENSSL_FIPS_ENABLED"]
+      omit "Only for FIPS mode environment"
+    end
 
     assert_separately(["-ropenssl"], <<~"end;")
       begin

--- a/test/openssl/test_pkey_dh.rb
+++ b/test/openssl/test_pkey_dh.rb
@@ -29,7 +29,7 @@ class OpenSSL::TestPKeyDH < OpenSSL::PKeyTestCase
 
   def test_new_break_on_fips
     omit_on_non_fips
-    return unless openssl? # This behavior only applies to OpenSSL.
+    omit "This test only applies to OpenSSL" unless openssl?
 
     # The block argument is not executed in FIPS case.
     # See https://github.com/ruby/openssl/issues/692 for details.

--- a/test/openssl/test_pkey_dh.rb
+++ b/test/openssl/test_pkey_dh.rb
@@ -19,7 +19,7 @@ class OpenSSL::TestPKeyDH < OpenSSL::PKeyTestCase
   end if ENV["OSSL_TEST_ALL"]
 
   def test_new_break_on_non_fips
-    omit_on_fips if !aws_lc?
+    omit_on_fips unless aws_lc?
 
     assert_nil(OpenSSL::PKey::DH.new(NEW_KEYLEN) { break })
     assert_raise(RuntimeError) do

--- a/test/openssl/test_ssl.rb
+++ b/test/openssl/test_ssl.rb
@@ -39,7 +39,9 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
   end
 
   def test_ctx_options_config
-    omit "LibreSSL and AWS-LC do not support OPENSSL_CONF" if libressl? || aws_lc?
+    if libressl? || aws_lc?
+      omit "LibreSSL and AWS-LC do not support OPENSSL_CONF"
+    end
 
     Tempfile.create("openssl.cnf") { |f|
       f.puts(<<~EOF)
@@ -838,7 +840,9 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
 
     # LibreSSL 3.5.0+ doesn't support other wildcard certificates
     # (it isn't required to, as RFC states MAY, not MUST)
-    return if libressl?
+    if libressl?
+      omit "LibreSSL 3.5.0+ doesn't support some wildcard certificates"
+    end
 
     assert_equal(true, OpenSSL::SSL.verify_certificate_identity(
       create_cert_with_san('DNS:*baz.example.com'), 'foobaz.example.com'))
@@ -1412,7 +1416,9 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
   end
 
   def test_minmax_version_system_default
-    omit "LibreSSL and AWS-LC do not support OPENSSL_CONF" if libressl? || aws_lc?
+    if libressl? || aws_lc?
+      omit "LibreSSL and AWS-LC do not support OPENSSL_CONF"
+    end
 
     Tempfile.create("openssl.cnf") { |f|
       f.puts(<<~EOF)
@@ -1456,7 +1462,9 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
   end
 
   def test_respect_system_default_min
-    omit "LibreSSL and AWS-LC do not support OPENSSL_CONF" if libressl? || aws_lc?
+    if libressl? || aws_lc?
+      omit "LibreSSL and AWS-LC do not support OPENSSL_CONF"
+    end
 
     Tempfile.create("openssl.cnf") { |f|
       f.puts(<<~EOF)
@@ -1619,7 +1627,7 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
   end
 
   def test_npn_protocol_selection_ary
-    return unless OpenSSL::SSL::SSLContext.method_defined?(:npn_select_cb)
+    omit unless OpenSSL::SSL::SSLContext.method_defined?(:npn_select_cb)
 
     advertised = ["http/1.1", "spdy/2"]
     ctx_proc = proc { |ctx| ctx.npn_protocols = advertised }
@@ -1638,7 +1646,7 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
   end
 
   def test_npn_protocol_selection_enum
-    return unless OpenSSL::SSL::SSLContext.method_defined?(:npn_select_cb)
+    omit unless OpenSSL::SSL::SSLContext.method_defined?(:npn_select_cb)
 
     advertised = Object.new
     def advertised.each
@@ -1661,7 +1669,7 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
   end
 
   def test_npn_protocol_selection_cancel
-    return unless OpenSSL::SSL::SSLContext.method_defined?(:npn_select_cb)
+    omit unless OpenSSL::SSL::SSLContext.method_defined?(:npn_select_cb)
 
     ctx_proc = Proc.new { |ctx| ctx.npn_protocols = ["http/1.1"] }
     start_server(ctx_proc: ctx_proc, ignore_listener_error: true) { |port|
@@ -1673,7 +1681,7 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
   end
 
   def test_npn_advertised_protocol_too_long
-    return unless OpenSSL::SSL::SSLContext.method_defined?(:npn_select_cb)
+    omit unless OpenSSL::SSL::SSLContext.method_defined?(:npn_select_cb)
 
     ctx = OpenSSL::SSL::SSLContext.new
     assert_raise(OpenSSL::SSL::SSLError) do
@@ -1683,7 +1691,7 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
   end
 
   def test_npn_selected_protocol_too_long
-    return unless OpenSSL::SSL::SSLContext.method_defined?(:npn_select_cb)
+    omit unless OpenSSL::SSL::SSLContext.method_defined?(:npn_select_cb)
 
     ctx_proc = Proc.new { |ctx| ctx.npn_protocols = ["http/1.1"] }
     start_server(ctx_proc: ctx_proc, ignore_listener_error: true) { |port|
@@ -1774,7 +1782,7 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
 
   def test_fallback_scsv
     supported = check_supported_protocol_versions
-    return unless supported.include?(OpenSSL::SSL::TLS1_1_VERSION) &&
+    omit unless supported.include?(OpenSSL::SSL::TLS1_1_VERSION) &&
       supported.include?(OpenSSL::SSL::TLS1_2_VERSION)
 
     pend "Fallback SCSV is not supported" unless \
@@ -2023,9 +2031,9 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
   def test_security_level
     ctx = OpenSSL::SSL::SSLContext.new
     ctx.security_level = 1
-    if aws_lc? # AWS-LC does not support security levels.
+    if aws_lc?
       assert_equal(0, ctx.security_level)
-      return
+      omit "AWS-LC does not support security levels"
     end
     assert_equal(1, ctx.security_level)
 

--- a/test/openssl/test_ssl.rb
+++ b/test/openssl/test_ssl.rb
@@ -1747,7 +1747,7 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
       end
     end
 
-    if !aws_lc? # AWS-LC does not support DHE ciphersuites.
+    unless aws_lc? # AWS-LC does not support DHE ciphersuites.
       # DHE
       # TODO: SSL_CTX_set1_groups() is required for testing this with TLS 1.3
       ctx_proc2 = proc { |ctx|


### PR DESCRIPTION
Cc: @samuel40791765

This PR has 3 commits and mainly improves the things I noticed in the https://github.com/ruby/openssl/pull/855.

The 1st commit is to replace `return` with `omit` or `pend` in the tests. I believe that the `omit` and `pend` are more useful than `return` in the tests. Because we can see the skipped tests and reasons in the testing log.

Note that I think the part `pend "AWS-LC's FIPS mode is decided at compile time" ` is `pend` not `omit`. The reason we have to skip the tests is there is only one AWS-LC case compiled with a non-FIPS option in CI. I assume that we can improve this part when we add one more AWS-LC case compiled with a FIPS option.

The 2nd commit is to refactor the conditions from [this perspective](https://github.com/rubocop/ruby-style-guide?tab=readme-ov-file#if-vs-unless). I checked this PR on my forked branch. Especially the AWS-LC's skipping part in the testing result is [here](https://github.com/junaruga/ruby-openssl/actions/runs/13500788099/job/37718421311#step:10:621).

The 3rd commit is to fix a bug that the test `test_fips_mode_get_with_fips_mode_set` is not executed in OpenSSL 3.0 FIPS. According to the current implementation below, the `OpenSSL::OPENSSL_FIPS` always returns `true` on OpenSSL 3.0.0 and later versions. I checked the test `test_fips_mode_get_with_fips_mode_set` was executed on an OpenSSL 3 FIPS case, and skipped on an OpenSSL 3 non-FIPS case.

https://github.com/ruby/openssl/blob/d725783c5c180337f3d00efcba5b8744e0aea813/ext/openssl/ossl.c#L994-L1004

