### PR TITLE
Use ENV["TEST_RUBY_OPENSSL_FIPS_ENABLED"] instead of OpenSSL::OPENSSL_FIPS.

### DIFF
--- a/test/openssl/test_fips.rb
+++ b/test/openssl/test_fips.rb
@@ -37,7 +37,10 @@ class OpenSSL::TestFIPS < OpenSSL::TestCase
   end
 
   def test_fips_mode_get_with_fips_mode_set
-    omit('OpenSSL is not FIPS-capable') unless OpenSSL::OPENSSL_FIPS and !aws_lc? # AWS-LC's FIPS mode is decided at compile time.
+    return if aws_lc? # AWS-LC's FIPS mode is decided at compile time.
+    unless ENV["TEST_RUBY_OPENSSL_FIPS_ENABLED"]
+      omit "Only for FIPS mode environment"
+    end
 
     assert_separately(["-ropenssl"], <<~"end;")
       begin


### PR DESCRIPTION
This PR is cherry-picked from the 1st commit of [this PR](https://github.com/ruby/openssl/pull/860).

As OpenSSL::OPENSSL_FIPS always returns true on OpenSSL >= 3.0.0, we cannot use this constant as a flag to check whether the OpenSSL is FIPS or not. See <https://github.com/ruby/openssl/blob/d725783c5c180337f3d00efcba5b8744e0aea813/ext/openssl/ossl.c#L994-L1004>.