### PR TITLE
Improve AWS-LC tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,7 +93,7 @@ jobs:
         with:
           path: ~/openssl
           key: openssl-${{ runner.os }}-${{ matrix.openssl }}-${{ matrix.append-configure || 'default' }}
-        if: matrix.openssl != 'openssl-master' && matrix.openssl != 'libressl-master'
+        if: matrix.openssl != 'openssl-master' && matrix.openssl != 'libressl-master' && matrix.openssl != 'aws-lc-latest'
 
       - name: Compile OpenSSL library
         if: steps.cache-openssl.outputs.cache-hit != 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -127,7 +127,7 @@ jobs:
             git clone https://github.com/aws/aws-lc.git .
             AWS_LC_RELEASE=$(git tag --sort=-creatordate --list "v*"  | head -1)
             git checkout $AWS_LC_RELEASE
-            cmake -DCMAKE_INSTALL_PREFIX=$HOME/openssl
+            cmake -DCMAKE_INSTALL_PREFIX=$HOME/openssl -DCMAKE_INSTALL_LIBDIR=lib
             make -j4 && make install
             ;;
           *)

--- a/test/openssl/test_pkey_dh.rb
+++ b/test/openssl/test_pkey_dh.rb
@@ -18,23 +18,18 @@ class OpenSSL::TestPKeyDH < OpenSSL::PKeyTestCase
     assert_key(dh)
   end if ENV["OSSL_TEST_ALL"]
 
-  def test_new_break_on_non_fips
-    omit_on_fips if !aws_lc?
-
-    assert_nil(OpenSSL::PKey::DH.new(NEW_KEYLEN) { break })
-    assert_raise(RuntimeError) do
-      OpenSSL::PKey::DH.new(NEW_KEYLEN) { raise }
+  def test_new_break
+    unless openssl? && OpenSSL.fips_mode
+      assert_nil(OpenSSL::PKey::DH.new(NEW_KEYLEN) { break })
+      assert_raise(RuntimeError) do
+        OpenSSL::PKey::DH.new(NEW_KEYLEN) { raise }
+      end
+    else
+      # The block argument is not executed in FIPS case.
+      # See https://github.com/ruby/openssl/issues/692 for details.
+      assert(OpenSSL::PKey::DH.new(NEW_KEYLEN) { break })
+      assert(OpenSSL::PKey::DH.new(NEW_KEYLEN) { raise })
     end
-  end
-
-  def test_new_break_on_fips
-    omit_on_non_fips
-    return unless openssl? # This behavior only applies to OpenSSL.
-
-    # The block argument is not executed in FIPS case.
-    # See https://github.com/ruby/openssl/issues/692 for details.
-    assert(OpenSSL::PKey::DH.new(NEW_KEYLEN) { break })
-    assert(OpenSSL::PKey::DH.new(NEW_KEYLEN) { raise })
   end
 
   def test_derive_key


### PR DESCRIPTION
Cc: @samuel40791765

This PR is on top of another PR https://github.com/ruby/openssl/pull/862. So, please review the #862 first. Essentially 3 commits. This PR is to improve tests related to the AWS-LC non-FIPS case.

The 1st commit is to disable the cache for the AWS-LC case on CI. In the current logic of the cache key, we cannot enable the cache to get the latest version of the AWS-LC.

The 2nd commit is to specify the library directory as "lib" explicitly. The logic of compiling the AWS-LC is useful to see how to compile it. Because I saw the "lib64" directory was created without the `-DCMAKE_INSTALL_LIBDIR=lib` option on Fedora Linux 41.

The 3rd commit is to remove meaningless `aws_lc?`. As I mentioned at https://github.com/ruby/openssl/pull/860#issuecomment-2682643747, we can safely use the method `omit_on_fips` and `omit_on_non_fips` in AWS-LC cases. If the `aws_lc?` exists in the `test_new_break_on_non_fips` test to run on the AWS-LC FIPS case, that confuses me. I don't want to do it.
