### PR TITLE
digest: always run SHA-3 and truncated SHA-2 tests

### DIFF
--- a/test/openssl/test_digest.rb
+++ b/test/openssl/test_digest.rb
@@ -88,7 +88,6 @@ class OpenSSL::TestDigest < OpenSSL::TestCase
   end
 
   def test_sha512_truncate
-    pend "SHA512_224 is not implemented" unless digest_available?('sha512-224')
     sha512_224_a = "d5cdb9ccc769a5121d4175f2bfdd13d6310e0d3d361ea75d82108327"
     sha512_256_a = "455e518824bc0601f9fb858ff5c37d417d67c2f8e0df2babe4808858aea830f8"
 
@@ -100,7 +99,6 @@ class OpenSSL::TestDigest < OpenSSL::TestCase
   end
 
   def test_sha3
-    pend "SHA3 is not implemented" unless digest_available?('sha3-224')
     s224 = '6b4e03423667dbb73b6e15454f0eb1abd4597f9a1b078e3f5b5a6bc7'
     s256 = 'a7ffc6f8bf1ed76651c14756a061d662f580ff4de43b49fa82d80a4b80f8434a'
     s384 = '0c63a75b845e4f7d01107d852e4c2485c51a50aaaa94fc61995e71bbee983a2ac3713831264adb47fb6bd1e058d5f004'
@@ -144,11 +142,6 @@ class OpenSSL::TestDigest < OpenSSL::TestCase
     assert_not_nil(d)
     d = OpenSSL::Digest.new(oid.oid)
     assert_not_nil(d)
-  end
-
-  def digest_available?(name)
-    @digests ||= OpenSSL::Digest.digests
-    @digests.include?(name)
   end
 end
 

--- a/test/openssl/test_digest.rb
+++ b/test/openssl/test_digest.rb
@@ -103,10 +103,10 @@ class OpenSSL::TestDigest < OpenSSL::TestCase
     s256 = 'a7ffc6f8bf1ed76651c14756a061d662f580ff4de43b49fa82d80a4b80f8434a'
     s384 = '0c63a75b845e4f7d01107d852e4c2485c51a50aaaa94fc61995e71bbee983a2ac3713831264adb47fb6bd1e058d5f004'
     s512 = 'a69f73cca23a9ac5c8b567dc185a756e97c982164fe25859e0d1dcc1475c80a615b2123af1f5f94c11e3e9402c3ac558f500199d95b6d3e301758586281dcd26'
-    assert_equal(OpenSSL::Digest.hexdigest('SHA3-224', ""), s224)
-    assert_equal(OpenSSL::Digest.hexdigest('SHA3-256', ""), s256)
-    assert_equal(OpenSSL::Digest.hexdigest('SHA3-384', ""), s384)
-    assert_equal(OpenSSL::Digest.hexdigest('SHA3-512', ""), s512)
+    assert_equal(s224, OpenSSL::Digest.hexdigest('SHA3-224', ""))
+    assert_equal(s256, OpenSSL::Digest.hexdigest('SHA3-256', ""))
+    assert_equal(s384, OpenSSL::Digest.hexdigest('SHA3-384', ""))
+    assert_equal(s512, OpenSSL::Digest.hexdigest('SHA3-512', ""))
   end
 
   def test_digest_by_oid_and_name_sha2


### PR DESCRIPTION
The `pend` are no longer necessary, as they work with all OpenSSL variants we currently support. They were added in OpenSSL 1.1.1 and LibreSSL 3.8.0. They are also supported by the current AWS-LC release.

This makes the SHA-3 tests run with AWS-LC correctly. AWS-LC does not report SHA-3 in `OpenSSL::Digest.digests`.