### PR TITLE
Improve document of `initialize_copy`

### DIFF
--- a/ext/openssl/ossl_bn.c
+++ b/ext/openssl/ossl_bn.c
@@ -929,6 +929,7 @@ BIGNUM_NUM(num_bytes)
  */
 BIGNUM_NUM(num_bits)
 
+/* :nodoc: */
 static VALUE
 ossl_bn_copy(VALUE self, VALUE other)
 {

--- a/ext/openssl/ossl_cipher.c
+++ b/ext/openssl/ossl_cipher.c
@@ -130,6 +130,7 @@ ossl_cipher_initialize(VALUE self, VALUE str)
     return self;
 }
 
+/* :nodoc: */
 static VALUE
 ossl_cipher_copy(VALUE self, VALUE other)
 {

--- a/ext/openssl/ossl_digest.c
+++ b/ext/openssl/ossl_digest.c
@@ -141,6 +141,7 @@ ossl_digest_initialize(int argc, VALUE *argv, VALUE self)
     return self;
 }
 
+/* :nodoc: */
 static VALUE
 ossl_digest_copy(VALUE self, VALUE other)
 {

--- a/ext/openssl/ossl_hmac.c
+++ b/ext/openssl/ossl_hmac.c
@@ -113,6 +113,7 @@ ossl_hmac_initialize(VALUE self, VALUE key, VALUE digest)
     return self;
 }
 
+/* :nodoc: */
 static VALUE
 ossl_hmac_copy(VALUE self, VALUE other)
 {

--- a/ext/openssl/ossl_ocsp.c
+++ b/ext/openssl/ossl_ocsp.c
@@ -173,6 +173,7 @@ ossl_ocspreq_alloc(VALUE klass)
     return obj;
 }
 
+/* :nodoc: */
 static VALUE
 ossl_ocspreq_initialize_copy(VALUE self, VALUE other)
 {
@@ -513,6 +514,7 @@ ossl_ocspres_alloc(VALUE klass)
     return obj;
 }
 
+/* :nodoc: */
 static VALUE
 ossl_ocspres_initialize_copy(VALUE self, VALUE other)
 {
@@ -669,6 +671,7 @@ ossl_ocspbres_alloc(VALUE klass)
     return obj;
 }
 
+/* :nodoc: */
 static VALUE
 ossl_ocspbres_initialize_copy(VALUE self, VALUE other)
 {
@@ -1157,6 +1160,7 @@ ossl_ocspsres_initialize(VALUE self, VALUE arg)
     return self;
 }
 
+/* :nodoc: */
 static VALUE
 ossl_ocspsres_initialize_copy(VALUE self, VALUE other)
 {
@@ -1418,6 +1422,7 @@ ossl_ocspcid_alloc(VALUE klass)
     return obj;
 }
 
+/* :nodoc: */
 static VALUE
 ossl_ocspcid_initialize_copy(VALUE self, VALUE other)
 {

--- a/ext/openssl/ossl_pkcs12.c
+++ b/ext/openssl/ossl_pkcs12.c
@@ -60,6 +60,7 @@ ossl_pkcs12_s_allocate(VALUE klass)
     return obj;
 }
 
+/* :nodoc: */
 static VALUE
 ossl_pkcs12_initialize_copy(VALUE self, VALUE other)
 {

--- a/ext/openssl/ossl_pkcs7.c
+++ b/ext/openssl/ossl_pkcs7.c
@@ -392,6 +392,7 @@ ossl_pkcs7_initialize(int argc, VALUE *argv, VALUE self)
     return self;
 }
 
+/* :nodoc: */
 static VALUE
 ossl_pkcs7_copy(VALUE self, VALUE other)
 {

--- a/ext/openssl/ossl_pkey.c
+++ b/ext/openssl/ossl_pkey.c
@@ -615,6 +615,7 @@ ossl_pkey_initialize(VALUE self)
 }
 
 #ifdef HAVE_EVP_PKEY_DUP
+/* :nodoc: */
 static VALUE
 ossl_pkey_initialize_copy(VALUE self, VALUE other)
 {

--- a/ext/openssl/ossl_pkey_dh.c
+++ b/ext/openssl/ossl_pkey_dh.c
@@ -128,6 +128,7 @@ ossl_dh_initialize(int argc, VALUE *argv, VALUE self)
 }
 
 #ifndef HAVE_EVP_PKEY_DUP
+/* :nodoc: */
 static VALUE
 ossl_dh_initialize_copy(VALUE self, VALUE other)
 {

--- a/ext/openssl/ossl_pkey_dsa.c
+++ b/ext/openssl/ossl_pkey_dsa.c
@@ -140,6 +140,7 @@ ossl_dsa_initialize(int argc, VALUE *argv, VALUE self)
 }
 
 #ifndef HAVE_EVP_PKEY_DUP
+/* :nodoc: */
 static VALUE
 ossl_dsa_initialize_copy(VALUE self, VALUE other)
 {

--- a/ext/openssl/ossl_pkey_ec.c
+++ b/ext/openssl/ossl_pkey_ec.c
@@ -191,6 +191,7 @@ static VALUE ossl_ec_key_initialize(int argc, VALUE *argv, VALUE self)
 }
 
 #ifndef HAVE_EVP_PKEY_DUP
+/* :nodoc: */
 static VALUE
 ossl_ec_key_initialize_copy(VALUE self, VALUE other)
 {
@@ -706,6 +707,7 @@ static VALUE ossl_ec_group_initialize(int argc, VALUE *argv, VALUE self)
     return self;
 }
 
+/* :nodoc: */
 static VALUE
 ossl_ec_group_initialize_copy(VALUE self, VALUE other)
 {
@@ -1261,6 +1263,7 @@ static VALUE ossl_ec_point_initialize(int argc, VALUE *argv, VALUE self)
     return self;
 }
 
+/* :nodoc: */
 static VALUE
 ossl_ec_point_initialize_copy(VALUE self, VALUE other)
 {

--- a/ext/openssl/ossl_pkey_rsa.c
+++ b/ext/openssl/ossl_pkey_rsa.c
@@ -136,6 +136,7 @@ ossl_rsa_initialize(int argc, VALUE *argv, VALUE self)
 }
 
 #ifndef HAVE_EVP_PKEY_DUP
+/* :nodoc: */
 static VALUE
 ossl_rsa_initialize_copy(VALUE self, VALUE other)
 {

--- a/ext/openssl/ossl_ssl_session.c
+++ b/ext/openssl/ossl_ssl_session.c
@@ -69,6 +69,7 @@ ossl_ssl_session_initialize(VALUE self, VALUE arg1)
     return self;
 }
 
+/* :nodoc: */
 static VALUE
 ossl_ssl_session_initialize_copy(VALUE self, VALUE other)
 {

--- a/ext/openssl/ossl_x509attr.c
+++ b/ext/openssl/ossl_x509attr.c
@@ -123,6 +123,7 @@ ossl_x509attr_initialize(int argc, VALUE *argv, VALUE self)
     return self;
 }
 
+/* :nodoc: */
 static VALUE
 ossl_x509attr_initialize_copy(VALUE self, VALUE other)
 {

--- a/ext/openssl/ossl_x509cert.c
+++ b/ext/openssl/ossl_x509cert.c
@@ -140,6 +140,7 @@ ossl_x509_initialize(int argc, VALUE *argv, VALUE self)
     return self;
 }
 
+/* :nodoc: */
 static VALUE
 ossl_x509_copy(VALUE self, VALUE other)
 {

--- a/ext/openssl/ossl_x509crl.c
+++ b/ext/openssl/ossl_x509crl.c
@@ -117,6 +117,7 @@ ossl_x509crl_initialize(int argc, VALUE *argv, VALUE self)
     return self;
 }
 
+/* :nodoc: */
 static VALUE
 ossl_x509crl_copy(VALUE self, VALUE other)
 {

--- a/ext/openssl/ossl_x509ext.c
+++ b/ext/openssl/ossl_x509ext.c
@@ -295,6 +295,7 @@ ossl_x509ext_initialize(int argc, VALUE *argv, VALUE self)
     return self;
 }
 
+/* :nodoc: */
 static VALUE
 ossl_x509ext_initialize_copy(VALUE self, VALUE other)
 {

--- a/ext/openssl/ossl_x509name.c
+++ b/ext/openssl/ossl_x509name.c
@@ -177,6 +177,7 @@ ossl_x509name_initialize(int argc, VALUE *argv, VALUE self)
     return self;
 }
 
+/* :nodoc: */
 static VALUE
 ossl_x509name_initialize_copy(VALUE self, VALUE other)
 {

--- a/ext/openssl/ossl_x509req.c
+++ b/ext/openssl/ossl_x509req.c
@@ -103,6 +103,7 @@ ossl_x509req_initialize(int argc, VALUE *argv, VALUE self)
     return self;
 }
 
+/* :nodoc: */
 static VALUE
 ossl_x509req_copy(VALUE self, VALUE other)
 {

--- a/ext/openssl/ossl_x509revoked.c
+++ b/ext/openssl/ossl_x509revoked.c
@@ -105,6 +105,7 @@ ossl_x509revoked_initialize(int argc, VALUE *argv, VALUE self)
     return self;
 }
 
+/* :nodoc: */
 static VALUE
 ossl_x509revoked_initialize_copy(VALUE self, VALUE other)
 {


### PR DESCRIPTION
I wish there were these notes when I read the document.  
The functionality is useful, especially for `Digest` and `HMAC` stuff.

I hope more people notice this somewhat hidden functionality.