### PR TITLE
Skip PKCS7 with indefinite length test in AWS-LC

### DIFF
--- a/test/openssl/test_pkcs7.rb
+++ b/test/openssl/test_pkcs7.rb
@@ -308,6 +308,8 @@ END
   end
 
   def test_split_content
+     pend "AWS-LC ASN.1 parsers has no current support for parsing indefinite BER constructed strings" if aws_lc?
+
      pki_message_pem = <<END
 -----BEGIN PKCS7-----
 MIIHSwYJKoZIhvcNAQcCoIIHPDCCBzgCAQExCzAJBgUrDgMCGgUAMIIDiAYJKoZI
@@ -376,14 +378,9 @@ tcH961onq8Tme2ICaCzk
 END
     pki_msg = OpenSSL::PKCS7.new(pki_message_pem)
     store = OpenSSL::X509::Store.new
-    pki_msg.verify(nil, store, nil, OpenSSL::PKCS7::NOVERIFY)
+    assert_equal(true, pki_msg.verify(nil, store, nil, OpenSSL::PKCS7::NOVERIFY))
     p7enc = OpenSSL::PKCS7.new(pki_msg.data)
-    # AWS-LC uses explicit OCTET STRING headers when encoding PKCS7 EncryptedContent,
-    # while OpenSSL traditionally uses indefinite-length encoding (ASN1_TFLG_NDEF)
-    # in its PKCS7 implementation.
-    unless aws_lc?
-      assert_equal(pki_message_content_pem, p7enc.to_pem)
-    end
+    assert_equal(pki_message_content_pem, p7enc.to_pem)
   end
 end
 


### PR DESCRIPTION
Extension from this original thread regarding the PKCS7 test we skipped in AWS-LC: https://github.com/ruby/openssl/pull/855#discussion_r1954311654

We've been doing more investigations against the PKCS7 issue like we promised. It turns out @rhenium was right in that this was an issue with "decoding" indefinite BER rather than "encoding". `ASN1_TFLG_NDEF` is in charge of encoding indefinite BER for PKCS7 in OpenSSL, but that's only used in the "PKCS7 streaming APIs" and is not used by default. The PKCS7 test file has indefinite BER within it, which AWS-LC was not properly decoding.

AWS-LC had been decoding the indefinite BER to an unusable output. Instead of allowing an invalid state to be parsed, we've decided to revert https://github.com/aws/aws-lc/commit/2a722260329a62e0682410060f84cf144960afe4 (with https://github.com/aws/aws-lc/commit/1a1eb18bd35a6ad1277d46a4fca70e1f4901c77e) until we've actually fixed our parsing for indefinite BER. The Ruby PKCS7 test will bail earlier with the new changes, so we thought it'd be best for us to help you update to minimize churn.

Changes:
1. We'll be looking to fix our parsing for indefinite BER constructed strings in AWS-LC soon, so I've marked the test as `pend` for now and removed the AWS-LC specific logic at the end. 
2. I've added an assertion to verify that `OpenSSL::PKCS7.verify` behaves correctly before doing content comparisons. I noticed this was failing in AWS-LC and will be fixed with https://github.com/aws/aws-lc/pull/2264. This shouldn't effect OpenSSL/LibreSSL builds and should improve the test.