### PR TITLE
re-enable ENGINE support for 3.x

### DIFF
--- a/ext/openssl/ossl.h
+++ b/ext/openssl/ossl.h
@@ -65,7 +65,7 @@
 # define OSSL_3_const /* const */
 #endif
 
-#if !defined(OPENSSL_NO_ENGINE) && !OSSL_OPENSSL_PREREQ(3, 0, 0)
+#if !defined(OPENSSL_NO_ENGINE)
 # define OSSL_USE_ENGINE
 #endif
 


### PR DESCRIPTION
So far the entire experience with providers has been... not great, to put it mildly. Therefore I suggest re-enabling the OpenSSL::Engine support in ruby as it is merely deprecated but still *works*, and keeping it until upstream OpenSSL removes the API outright.