### PR TITLE
pkcs7: fix test failure on RHEL 9

### DIFF
--- a/test/openssl/test_pkcs7.rb
+++ b/test/openssl/test_pkcs7.rb
@@ -204,7 +204,7 @@ END
   end
 
   def test_graceful_parsing_failure #[ruby-core:43250]
-    contents = File.read(__FILE__)
+    contents = "not a valid PKCS #7 PEM block"
     assert_raise(ArgumentError) { OpenSSL::PKCS7.new(contents) }
   end
 


### PR DESCRIPTION
The test case `test_split_content` fails on RHEL 9 and Fedora 41 because their OpenSSL packages do not accept SHA-1 signatures. This was only caught after commit 69fd7f886313 added the missing assertion.

While the example PKCS#7 structures could be simply regenerated with SHA-256, this test case could be simplified because it is checking two different things.

Replace `test_split_content` with separate test cases: one verifying `signed-data` `authenticatedAttributes` and another for decoding BER input.

Fixes https://github.com/ruby/openssl/issues/875