### PR TITLE
Fix the tests using SHA-1 Probabilistic Signature Scheme (PSS) parameters.

### DIFF
--- a/test/openssl/test_pkey_rsa.rb
+++ b/test/openssl/test_pkey_rsa.rb
@@ -108,13 +108,13 @@ class OpenSSL::TestPKeyRSA < OpenSSL::PKeyTestCase
     pssopts = {
       "rsa_padding_mode" => "pss",
       "rsa_pss_saltlen" => 20,
-      "rsa_mgf1_md" => "SHA1"
+      "rsa_mgf1_md" => "SHA256"
     }
     sig_pss = key.sign("SHA256", data, pssopts)
     assert_equal 256, sig_pss.bytesize
     assert_equal true, key.verify("SHA256", sig_pss, data, pssopts)
     assert_equal true, key.verify_pss("SHA256", sig_pss, data,
-                                      salt_length: 20, mgf1_hash: "SHA1")
+                                      salt_length: 20, mgf1_hash: "SHA256")
     # Defaults to PKCS #1 v1.5 padding => verification failure
     assert_equal false, key.verify("SHA256", sig_pss, data)
 
@@ -188,22 +188,22 @@ class OpenSSL::TestPKeyRSA < OpenSSL::PKeyTestCase
     data = "Sign me!"
     invalid_data = "Sign me?"
 
-    signature = key.sign_pss("SHA256", data, salt_length: 20, mgf1_hash: "SHA1")
+    signature = key.sign_pss("SHA256", data, salt_length: 20, mgf1_hash: "SHA256")
     assert_equal 256, signature.bytesize
     assert_equal true,
-      key.verify_pss("SHA256", signature, data, salt_length: 20, mgf1_hash: "SHA1")
+      key.verify_pss("SHA256", signature, data, salt_length: 20, mgf1_hash: "SHA256")
     assert_equal true,
-      key.verify_pss("SHA256", signature, data, salt_length: :auto, mgf1_hash: "SHA1")
+      key.verify_pss("SHA256", signature, data, salt_length: :auto, mgf1_hash: "SHA256")
     assert_equal false,
-      key.verify_pss("SHA256", signature, invalid_data, salt_length: 20, mgf1_hash: "SHA1")
+      key.verify_pss("SHA256", signature, invalid_data, salt_length: 20, mgf1_hash: "SHA256")
 
-    signature = key.sign_pss("SHA256", data, salt_length: :digest, mgf1_hash: "SHA1")
+    signature = key.sign_pss("SHA256", data, salt_length: :digest, mgf1_hash: "SHA256")
     assert_equal true,
-      key.verify_pss("SHA256", signature, data, salt_length: 32, mgf1_hash: "SHA1")
+      key.verify_pss("SHA256", signature, data, salt_length: 32, mgf1_hash: "SHA256")
     assert_equal true,
-      key.verify_pss("SHA256", signature, data, salt_length: :auto, mgf1_hash: "SHA1")
+      key.verify_pss("SHA256", signature, data, salt_length: :auto, mgf1_hash: "SHA256")
     assert_equal false,
-      key.verify_pss("SHA256", signature, data, salt_length: 20, mgf1_hash: "SHA1")
+      key.verify_pss("SHA256", signature, data, salt_length: 20, mgf1_hash: "SHA256")
 
     # The sign_pss with `salt_length: :max` raises the "invalid salt length"
     # error in FIPS. We need to skip the tests in FIPS.
@@ -213,18 +213,18 @@ class OpenSSL::TestPKeyRSA < OpenSSL::PKeyTestCase
     # FIPS 186-5 section 5.4 PKCS #1
     # https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-5.pdf
     unless OpenSSL.fips_mode
-      signature = key.sign_pss("SHA256", data, salt_length: :max, mgf1_hash: "SHA1")
+      signature = key.sign_pss("SHA256", data, salt_length: :max, mgf1_hash: "SHA256")
       # Should verify on the following salt_length (sLen).
       # sLen <= emLen (octat) - 2 - hLen (octet) = 2048 / 8 - 2 - 256 / 8 = 222
       # https://datatracker.ietf.org/doc/html/rfc8017#section-9.1.1
       assert_equal true,
-        key.verify_pss("SHA256", signature, data, salt_length: 222, mgf1_hash: "SHA1")
+        key.verify_pss("SHA256", signature, data, salt_length: 222, mgf1_hash: "SHA256")
       assert_equal true,
-        key.verify_pss("SHA256", signature, data, salt_length: :auto, mgf1_hash: "SHA1")
+        key.verify_pss("SHA256", signature, data, salt_length: :auto, mgf1_hash: "SHA256")
     end
 
     assert_raise(OpenSSL::PKey::RSAError) {
-      key.sign_pss("SHA256", data, salt_length: 223, mgf1_hash: "SHA1")
+      key.sign_pss("SHA256", data, salt_length: 223, mgf1_hash: "SHA256")
     }
   end
 


### PR DESCRIPTION
Fedora OpenSSL 3.5 on rawhide stopped accepting SHA-1 PSS[1] parameters. This is different from the SHA-1 signatures which Fedora OpenSSL stopped accepting since Fedora 41.[2]

This commit fixes the following test failures related to the SHA-1 PSS parameters with Fedora OpenSSL 3.5.
Note these failures are the downstream Fedora OpenSSL RPM specific. The tests pass without this commit with the upstream OpenSSL 3.5. Though the test failures are Fedora rawhide (Fedora 43) specific right now, I want to contribute this fix to this project. Because Ruby project manages Fedora and RHEL servers.

I heard from a maintainer of the Fedora OpenSSL that the following patch `0018-RH-Allow-disabling-of-SHA1-signatures.patch` on the rawhide branch in the [Fedora OpenSSL (rpms/openssl) package repository](https://src.fedoraproject.org/rpms/openssl) disables the SHA-1 PSS parameters. However, I haven't debugged Fedora OpenSSL with the patch by myself, and I am not sure which part of the patch actually disables it.

https://src.fedoraproject.org/rpms/openssl/blob/5f41d6a8f54cae29768a24ad72bf9daf521ce462/f/0018-RH-Allow-disabling-of-SHA1-signatures.patch

For the change, I replaced the `SHA1` with `SHA256` which I randomly picked up from the series of the `SHANNN`. What do you think?

```
$ rpm -q openssl-libs openssl-devel
openssl-libs-3.5.0-2.fc43.x86_64
openssl-devel-3.5.0-2.fc43.x86_64

$ bundle exec rake test
...
E
===============================================================================================
Error: test_sign_verify_options(OpenSSL::TestPKeyRSA): OpenSSL::PKey::PKeyError: EVP_PKEY_CTX_ctrl_str(ctx, "rsa_mgf1_md", "SHA1"): digest not allowed (digest=SHA1)
/mnt/git/ruby/openssl/test/openssl/test_pkey_rsa.rb:113:in 'Hash#each'
/mnt/git/ruby/openssl/test/openssl/test_pkey_rsa.rb:113:in 'OpenSSL::PKey::PKey#sign'
/mnt/git/ruby/openssl/test/openssl/test_pkey_rsa.rb:113:in 'OpenSSL::TestPKeyRSA#test_sign_verify_options'
     110:       "rsa_pss_saltlen" => 20,
     111:       "rsa_mgf1_md" => "SHA1"
     112:     }
  => 113:     sig_pss = key.sign("SHA256", data, pssopts)
     114:     assert_equal 256, sig_pss.bytesize
     115:     assert_equal true, key.verify("SHA256", sig_pss, data, pssopts)
     116:     assert_equal true, key.verify_pss("SHA256", sig_pss, data,
===============================================================================================
E
===============================================================================================
Error: test_sign_verify_pss(OpenSSL::TestPKeyRSA): OpenSSL::PKey::RSAError: digest not allowed (digest=SHA1)
/mnt/git/ruby/openssl/test/openssl/test_pkey_rsa.rb:191:in 'OpenSSL::PKey::RSA#sign_pss'
/mnt/git/ruby/openssl/test/openssl/test_pkey_rsa.rb:191:in 'OpenSSL::TestPKeyRSA#test_sign_verify_pss'
     188:     data = "Sign me!"
     189:     invalid_data = "Sign me?"
     190:
  => 191:     signature = key.sign_pss("SHA256", data, salt_length: 20, mgf1_hash: "SHA1")
     192:     assert_equal 256, signature.bytesize
     193:     assert_equal true,
     194:       key.verify_pss("SHA256", signature, data, salt_length: 20, mgf1_hash: "SHA1")
===============================================================================================
...
577 tests, 4186 assertions, 0 failures, 2 errors, 0 pendings, 3 omissions, 0 notifications
```

[1] https://en.wikipedia.org/wiki/Probabilistic_signature_scheme
[2] https://fedoraproject.org/wiki/Changes/OpenSSLDistrustSHA1SigVer