### PR TITLE
.github/workflows/test.yml: stop using ubuntu-20.04 runner image

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,8 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # ubuntu-22.04 uses OpenSSL 3.0, ubuntu-20.04 uses OpenSSL 1.1.1
-        os: [ ubuntu-22.04, ubuntu-20.04, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
         ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
         exclude:
           - { os: windows-latest, ruby: truffleruby }


### PR DESCRIPTION
Use ubuntu-latest instead. ubuntu-latest currently points at ubuntu-24.04.