### PR TITLE
ssl: fix SSLSocket#syswrite with String-convertible objects

### DIFF
--- a/ext/openssl/ossl_ssl.c
+++ b/ext/openssl/ossl_ssl.c
@@ -2080,14 +2080,13 @@ ossl_ssl_write_internal_safe(VALUE _args)
 static VALUE
 ossl_ssl_write_internal(VALUE self, VALUE str, VALUE opts)
 {
-    VALUE args[3] = {self, str, opts};
-    int state;
-    str = StringValue(str);
-
+    StringValue(str);
     int frozen = RB_OBJ_FROZEN(str);
     if (!frozen) {
-        str = rb_str_locktmp(str);
+        rb_str_locktmp(str);
     }
+    int state;
+    VALUE args[3] = {self, str, opts};
     VALUE result = rb_protect(ossl_ssl_write_internal_safe, (VALUE)args, &state);
     if (!frozen) {
         rb_str_unlocktmp(str);

--- a/test/openssl/test_ssl.rb
+++ b/test/openssl/test_ssl.rb
@@ -270,6 +270,11 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
         ssl.syswrite(str)
         assert_same buf, ssl.sysread(str.size, buf)
         assert_equal(str, buf)
+
+        obj = Object.new
+        obj.define_singleton_method(:to_str) { str }
+        ssl.syswrite(obj)
+        assert_equal(str, ssl.sysread(str.bytesize))
       }
     }
   end


### PR DESCRIPTION
Correctly pass the new object assigned by StringValue() to ossl_ssl_write_internal_safe().

This is a follow-up to commit 0d8c17aa855d (#831).