### PR TITLE
.github/workflows/test.yml: update test-openssls

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,25 +63,21 @@ jobs:
         openssl:
           # https://openssl-library.org/source/
           - openssl-1.1.1w # EOL 2023-09-11, still used by RHEL 8 and Ubuntu 20.04
-          - openssl-3.0.16 # Supported until 2026-09-07
+          - openssl-3.0.16 # Supported until 2026-09-07 (LTS)
           - openssl-3.1.8 # EOL 2025-03-14
           - openssl-3.2.4 # Supported until 2025-11-23
           - openssl-3.3.3 # Supported until 2026-04-09
           - openssl-3.4.1 # Supported until 2026-10-22
+          - openssl-3.5.0 # Supported until 2030 (LTS)
           - openssl-master
           # http://www.libressl.org/releases.html
-          - libressl-3.9.2 # Supported until 2025-04-05
+          - libressl-3.9.2 # EOL 2025-04-05
           - libressl-4.0.0 # Supported until 2025-10-08
+          - libressl-4.1.0 # Supported until 2026-04-28
           # https://github.com/aws/aws-lc/tags
           - aws-lc-latest
         include:
-          - { name-extra: 'with fips provider', openssl: openssl-3.0.16, fips-enabled: true }
-          - { name-extra: 'with fips provider', openssl: openssl-3.1.8, fips-enabled: true }
-          - { name-extra: 'with fips provider', openssl: openssl-3.2.4, fips-enabled: true }
-          - { name-extra: 'with fips provider', openssl: openssl-3.3.3, fips-enabled: true }
-          - { name-extra: 'with fips provider', openssl: openssl-3.4.1, fips-enabled: true }
-          - { name-extra: 'with fips provider', openssl: openssl-master, fips-enabled: true }
-          - { name-extra: 'without legacy provider', openssl: openssl-3.4.1, append-configure: 'no-legacy' }
+          - { name-extra: 'without legacy provider', openssl: openssl-3.5.0, append-configure: 'no-legacy' }
           - { openssl: aws-lc-latest, skip-warnings: true }
     steps:
       - name: repo checkout
@@ -113,7 +109,7 @@ jobs:
             OPENSSL_COMMIT=${{ matrix.openssl == 'openssl-master' && 'master' || matrix.openssl }}
             git clone -b $OPENSSL_COMMIT --depth 1 https://github.com/openssl/openssl.git .
             echo "Git commit: $(git rev-parse HEAD)"
-            ./Configure --prefix=$HOME/openssl --libdir=lib enable-fips ${{ matrix.append-configure }}
+            ./Configure --prefix=$HOME/openssl --libdir=lib enable-fips no-tests ${{ matrix.append-configure }}
             make -j4 && make install_sw && make install_fips
             ;;
           libressl-*)
@@ -150,20 +146,16 @@ jobs:
       - name: rake compile
         run:  bundle exec rake compile -- --with-openssl-dir=$HOME/openssl
 
-      - name: setup OpenSSL config file for fips
-        run: |
-          sed -e "s|OPENSSL_DIR|$HOME/openssl|" tool/openssl_fips.cnf.tmpl > tmp/openssl_fips.cnf
-          echo "OPENSSL_CONF=$(pwd)/tmp/openssl_fips.cnf" >> $GITHUB_ENV
-        if: matrix.fips-enabled
-
       - name: rake test
         run:  bundle exec rake test TESTOPTS="-v --no-show-detail-immediately"
         timeout-minutes: 5
-        if: ${{ !matrix.fips-enabled }}
 
       # Run only the passing tests on the FIPS module as a temporary workaround.
       # TODO Fix other tests, and run all the tests on FIPS module.
       - name: rake test_fips
-        run:  bundle exec rake test_fips TESTOPTS="-v --no-show-detail-immediately"
+        run: |
+          sed -e "s|OPENSSL_DIR|$HOME/openssl|" tool/openssl_fips.cnf.tmpl > tmp/openssl_fips.cnf
+          export OPENSSL_CONF=$(pwd)/tmp/openssl_fips.cnf
+          bundle exec rake test_fips TESTOPTS="-v --no-show-detail-immediately"
         timeout-minutes: 5
-        if: matrix.fips-enabled
+        if: ${{ startsWith(matrix.openssl, 'openssl-3') || matrix.openssl == 'openssl-master' }}


### PR DESCRIPTION
Changes include:

 - Test against OpenSSL 3.5.0 and LibreSSL 4.1.0.

 - Run "rake test" and "rake test_fips" in the same job so that we can
   avoid compiling the same OpenSSL version twice.

 - Use the "no-tests" option when compiling OpenSSL 3.0 or later. This
   disables compiling OpenSSL's test suite which we do not run.