### PR TITLE
pkcs5_keyivgen: continue to work with increased default salt length

### DIFF
--- a/ext/openssl/ossl_cipher.c
+++ b/ext/openssl/ossl_cipher.c
@@ -312,8 +312,8 @@ ossl_cipher_pkcs5_keyivgen(int argc, VALUE *argv, VALUE self)
     StringValue(vpass);
     if(!NIL_P(vsalt)){
 	StringValue(vsalt);
-	if(RSTRING_LEN(vsalt) != PKCS5_SALT_LEN)
-	    ossl_raise(eCipherError, "salt must be an 8-octet string");
+	if(RSTRING_LEN(vsalt) >= 8)
+	    ossl_raise(eCipherError, "salt must be at least an 8-octet string");
 	salt = (unsigned char *)RSTRING_PTR(vsalt);
     }
     iter = NIL_P(viter) ? 2048 : NUM2INT(viter);


### PR DESCRIPTION
In the PKCS5 RFC salt length is specified of a default value of 8. But
it can be longer or shorter.

In OpenSSL PKCS5_SALT_LEN constant is specified, but it is a internal
implementation detail, a fallback value, and a default suggestion. One
can pick lower and higher salt values.

Recently, many OpenSSL-like implementations are increasing this
fallback default salt length from 8 bytes to 16 bytes. With such
implementations ruby-openssl starts to fail (in error). Afterall the
8-byte salt is passed in, and is still acceptable to be used. Update
the guard to keep 8-bytes as the lower value, without relying on the
PKCS5_SALT_LEN which is going to be different based on a given system
library implementation.

References:
- https://github.com/openssl/openssl/commit/995e9489e62ff1965553c4e127183565ccfe4265
- https://marc.info/?l=openbsd-tech&m=174689919725477&w=2
- https://marc.info/?l=openbsd-tech&m=174690438827143&w=2
- https://github.com/aws/aws-lc/pull/2409
- https://boringssl-review.googlesource.com/c/boringssl/+/79267

This was cought by aws-lc integration tests.
