### PR TITLE
AWS-LC has support for parsing ber constructed strings now

### DIFF
--- a/test/openssl/test_pkcs7.rb
+++ b/test/openssl/test_pkcs7.rb
@@ -355,8 +355,6 @@ END
   end
 
   def test_decode_ber_constructed_string
-    pend "AWS-LC ASN.1 parsers has no current support for parsing indefinite BER constructed strings" if aws_lc?
-
     p7 = OpenSSL::PKCS7.encrypt([@ee1_cert], "content", "aes-128-cbc")
 
     # Make an equivalent BER to p7.to_der. Here we convert the encryptedContent


### PR DESCRIPTION
During the collaboration we did on https://github.com/ruby/openssl/pull/855, we promised that we'd be fixing our support for parsing indefinite BER and BER constructed strings in AWS-LC soon. As of [AWS-LC v1.50.0](https://github.com/aws/aws-lc/releases/tag/v1.50.0), we've added support for both issues.

This PR is to remove the pending test case regarding the missing feature. We appreciate the help with pinpointing this gap!

