### PR TITLE
CI test.yml - add workflow_dispatch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   ruby-versions:


### PR DESCRIPTION
'workflow_dispatch' is very helpful for forcing a CI run when either a dependency, Ruby, or the 'GHA Ruby system' (setup-ruby, etc)
have changed.

I created this commit in Nov-23, but forgot to create a PR...