### PR TITLE
pkey: add support for OpenSSL 3 provider-only pkeys

### DIFF
--- a/ext/openssl/ossl.h
+++ b/ext/openssl/ossl.h
@@ -71,6 +71,7 @@
 
 #if OSSL_OPENSSL_PREREQ(3, 0, 0)
 # define OSSL_USE_PROVIDER
+# include <openssl/provider.h>
 #endif
 
 /*

--- a/ext/openssl/ossl_pkey.c
+++ b/ext/openssl/ossl_pkey.c
@@ -635,6 +635,29 @@ ossl_pkey_initialize_copy(VALUE self, VALUE other)
 }
 #endif
 
+#ifndef OSSL_USE_PROVIDER
+static int
+lookup_pkey_type(VALUE type)
+{
+    const EVP_PKEY_ASN1_METHOD *ameth;
+    int pkey_id;
+
+    StringValue(type);
+    /*
+     * XXX: EVP_PKEY_asn1_find_str() looks up a PEM type string. Should we use
+     * OBJ_txt2nid() instead (and then somehow check if the NID is an acceptable
+     * EVP_PKEY type)?
+     * It is probably fine, though, since it can handle all algorithms that
+     * support raw keys in 1.1.1: { X25519, X448, ED25519, ED448, HMAC }.
+     */
+    ameth = EVP_PKEY_asn1_find_str(NULL, RSTRING_PTR(type), RSTRING_LENINT(type));
+    if (!ameth)
+        ossl_raise(ePKeyError, "algorithm %"PRIsVALUE" not found", type);
+    EVP_PKEY_asn1_get0_info(&pkey_id, NULL, NULL, NULL, NULL, ameth);
+    return pkey_id;
+}
+#endif
+
 /*
  *  call-seq:
  *      OpenSSL::PKey.new_raw_private_key(algo, string) -> PKey
@@ -646,22 +669,23 @@ static VALUE
 ossl_pkey_new_raw_private_key(VALUE self, VALUE type, VALUE key)
 {
     EVP_PKEY *pkey;
-    const EVP_PKEY_ASN1_METHOD *ameth;
-    int pkey_id;
     size_t keylen;
 
-    StringValue(type);
     StringValue(key);
-    ameth = EVP_PKEY_asn1_find_str(NULL, RSTRING_PTR(type), RSTRING_LENINT(type));
-    if (!ameth)
-        ossl_raise(ePKeyError, "algorithm %"PRIsVALUE" not found", type);
-    EVP_PKEY_asn1_get0_info(&pkey_id, NULL, NULL, NULL, NULL, ameth);
-
     keylen = RSTRING_LEN(key);
 
+#ifdef OSSL_USE_PROVIDER
+    pkey = EVP_PKEY_new_raw_private_key_ex(NULL, StringValueCStr(type), NULL,
+                                           (unsigned char *)RSTRING_PTR(key),
+                                           keylen);
+    if (!pkey)
+        ossl_raise(ePKeyError, "EVP_PKEY_new_raw_private_key_ex");
+#else
+    int pkey_id = lookup_pkey_type(type);
     pkey = EVP_PKEY_new_raw_private_key(pkey_id, NULL, (unsigned char *)RSTRING_PTR(key), keylen);
     if (!pkey)
         ossl_raise(ePKeyError, "EVP_PKEY_new_raw_private_key");
+#endif
 
     return ossl_pkey_new(pkey);
 }
@@ -677,22 +701,23 @@ static VALUE
 ossl_pkey_new_raw_public_key(VALUE self, VALUE type, VALUE key)
 {
     EVP_PKEY *pkey;
-    const EVP_PKEY_ASN1_METHOD *ameth;
-    int pkey_id;
     size_t keylen;
 
-    StringValue(type);
     StringValue(key);
-    ameth = EVP_PKEY_asn1_find_str(NULL, RSTRING_PTR(type), RSTRING_LENINT(type));
-    if (!ameth)
-        ossl_raise(ePKeyError, "algorithm %"PRIsVALUE" not found", type);
-    EVP_PKEY_asn1_get0_info(&pkey_id, NULL, NULL, NULL, NULL, ameth);
-
     keylen = RSTRING_LEN(key);
 
+#ifdef OSSL_USE_PROVIDER
+    pkey = EVP_PKEY_new_raw_public_key_ex(NULL, StringValueCStr(type), NULL,
+                                          (unsigned char *)RSTRING_PTR(key),
+                                          keylen);
+    if (!pkey)
+        ossl_raise(ePKeyError, "EVP_PKEY_new_raw_public_key_ex");
+#else
+    int pkey_id = lookup_pkey_type(type);
     pkey = EVP_PKEY_new_raw_public_key(pkey_id, NULL, (unsigned char *)RSTRING_PTR(key), keylen);
     if (!pkey)
         ossl_raise(ePKeyError, "EVP_PKEY_new_raw_public_key");
+#endif
 
     return ossl_pkey_new(pkey);
 }

--- a/ext/openssl/ossl_provider.c
+++ b/ext/openssl/ossl_provider.c
@@ -5,8 +5,6 @@
 #include "ossl.h"
 
 #ifdef OSSL_USE_PROVIDER
-# include <openssl/provider.h>
-
 #define NewProvider(klass) \
     TypedData_Wrap_Struct((klass), &ossl_provider_type, 0)
 #define SetProvider(obj, provider) do { \

--- a/test/openssl/test_pkey.rb
+++ b/test/openssl/test_pkey.rb
@@ -8,16 +8,7 @@ class OpenSSL::TestPKey < OpenSSL::PKeyTestCase
     assert_instance_of OpenSSL::PKey::RSA, rsa
     assert_equal "rsaEncryption", rsa.oid
     assert_match %r{oid=rsaEncryption}, rsa.inspect
-  end
-
-  def test_generic_oid_inspect_x25519
-    omit_on_fips
-
-    # X25519 private key
-    x25519 = OpenSSL::PKey.generate_key("X25519")
-    assert_instance_of OpenSSL::PKey::PKey, x25519
-    assert_equal "X25519", x25519.oid
-    assert_match %r{oid=X25519}, x25519.inspect
+    assert_match %r{type_name=RSA}, rsa.inspect if openssl?(3, 0, 0)
   end
 
   def test_s_generate_parameters
@@ -152,6 +143,8 @@ class OpenSSL::TestPKey < OpenSSL::PKeyTestCase
     alice = OpenSSL::PKey.read(alice_pem)
     bob = OpenSSL::PKey.read(bob_pem)
     assert_instance_of OpenSSL::PKey::PKey, alice
+    assert_equal "X25519", alice.oid
+    assert_match %r{oid=X25519}, alice.inspect
     assert_equal alice_pem, alice.private_to_pem
     assert_equal bob_pem, bob.public_to_pem
     assert_equal [shared_secret].pack("H*"), alice.derive(bob)


### PR DESCRIPTION
This includes two changes:

---
**pkey: handle EVP_PKEY_KEYMGMT return by EVP_PKEY_id()**

For algorithms implemented solely in an OpenSSL 3 provider, without an associated `EVP_PKEY_METHOD`, `EVP_PKEY_id()` returns a special value `EVP_PKEY_KEYMGMT`.

Let `OpenSSL::PKey::PKey#oid` raise an exception as necessary. Update `PKey#inspect` to include the string returned by `EVP_PKEY_get0_type_name()`, if available.

---
**pkey: use EVP_PKEY_new_raw_{private,public}_key_ex() if available**

Algorithms implemented only in OpenSSL 3 providers may not have a corresponding NID. The `*_ex()` variants have been added in OpenSSL 3.0 to handle such algorithms, by taking algorithm names as a string.
