### PR TITLE
Rename the `SSLContext#ecdh_curves=` to `#groups=`.

### DIFF
--- a/ext/openssl/ossl_ssl.c
+++ b/ext/openssl/ossl_ssl.c
@@ -1123,22 +1123,24 @@ ossl_sslctx_set_tmp_dh(VALUE self, VALUE arg)
 #if !defined(OPENSSL_NO_EC)
 /*
  * call-seq:
- *    ctx.ecdh_curves = curve_list -> curve_list
+ *    ctx.groups = groups_list -> groups_list
  *
- * Sets the list of "supported elliptic curves" for this context.
+ * Sets the list of "supported groups" or "supported elliptic curves" for this
+ * context.
  *
- * For a TLS client, the list is directly used in the Supported Elliptic Curves
- * Extension. For a server, the list is used by OpenSSL to determine the set of
- * shared curves. OpenSSL will pick the most appropriate one from it.
+ * For a TLS client, the list is directly used in the "supported_groups"
+ * extension or Supported Elliptic Curves Extension. For a server, the list is
+ * used by OpenSSL to determine the set of shared groups or curves. OpenSSL
+ * will pick the most appropriate one from it.
  *
  * === Example
  *   ctx1 = OpenSSL::SSL::SSLContext.new
- *   ctx1.ecdh_curves = "X25519:P-256:P-224"
+ *   ctx1.groups = "X25519:P-256:P-224"
  *   svr = OpenSSL::SSL::SSLServer.new(tcp_svr, ctx1)
  *   Thread.new { svr.accept }
  *
  *   ctx2 = OpenSSL::SSL::SSLContext.new
- *   ctx2.ecdh_curves = "P-256"
+ *   ctx2.groups = "P-256"
  *   cli = OpenSSL::SSL::SSLSocket.new(tcp_sock, ctx2)
  *   cli.connect
  *
@@ -1146,7 +1148,7 @@ ossl_sslctx_set_tmp_dh(VALUE self, VALUE arg)
  *   # => "prime256v1" (is an alias for NIST P-256)
  */
 static VALUE
-ossl_sslctx_set_ecdh_curves(VALUE self, VALUE arg)
+ossl_sslctx_set_groups(VALUE self, VALUE arg)
 {
     SSL_CTX *ctx;
 
@@ -1154,12 +1156,12 @@ ossl_sslctx_set_ecdh_curves(VALUE self, VALUE arg)
     GetSSLCTX(self, ctx);
     StringValueCStr(arg);
 
-    if (!SSL_CTX_set1_curves_list(ctx, RSTRING_PTR(arg)))
+    if (!SSL_CTX_set1_groups_list(ctx, RSTRING_PTR(arg)))
 	ossl_raise(eSSLError, NULL);
     return arg;
 }
 #else
-#define ossl_sslctx_set_ecdh_curves rb_f_notimplement
+#define ossl_sslctx_set_groups rb_f_notimplement
 #endif
 
 /*
@@ -2890,7 +2892,7 @@ Init_ossl_ssl(void)
 #ifndef OPENSSL_NO_DH
     rb_define_method(cSSLContext, "tmp_dh=", ossl_sslctx_set_tmp_dh, 1);
 #endif
-    rb_define_method(cSSLContext, "ecdh_curves=", ossl_sslctx_set_ecdh_curves, 1);
+    rb_define_method(cSSLContext, "groups=", ossl_sslctx_set_groups, 1);
     rb_define_method(cSSLContext, "security_level", ossl_sslctx_get_security_level, 0);
     rb_define_method(cSSLContext, "security_level=", ossl_sslctx_set_security_level, 1);
 #ifdef SSL_MODE_SEND_FALLBACK_SCSV

--- a/lib/openssl/ssl.rb
+++ b/lib/openssl/ssl.rb
@@ -113,6 +113,9 @@ ssbzSibBsu/6iGtCOGEoXJf//////////wIBAg==
       # callback must return an SSLContext for the server name or nil.
       attr_accessor :servername_cb
 
+      # An alias of the #groups=.
+      alias ecdh_curves= groups=
+
       # call-seq:
       #    SSLContext.new           -> ctx
       #    SSLContext.new(:TLSv1)   -> ctx

--- a/test/openssl/test_ssl.rb
+++ b/test/openssl/test_ssl.rb
@@ -1785,7 +1785,7 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
     # ECDHE
     ctx_proc3 = proc { |ctx|
       ctx.ciphers = "DEFAULT:!kRSA:!kEDH"
-      ctx.ecdh_curves = "P-256"
+      ctx.groups = "P-256"
     }
     start_server(ctx_proc: ctx_proc3) do |port|
       ctx = OpenSSL::SSL::SSLContext.new
@@ -2001,17 +2001,17 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
     end
   end
 
-  def test_ecdh_curves_tls12
+  def test_groups_tls12
     ctx_proc = -> ctx {
       # Enable both ECDHE (~ TLS 1.2) cipher suites and TLS 1.3
       ctx.max_version = OpenSSL::SSL::TLS1_2_VERSION
       ctx.ciphers = "kEECDH"
-      ctx.ecdh_curves = "P-384:P-521"
+      ctx.groups = "P-384:P-521"
     }
     start_server(ctx_proc: ctx_proc, ignore_listener_error: true) do |port|
       # Test 1: Client=P-256:P-384, Server=P-384:P-521 --> P-384
       ctx = OpenSSL::SSL::SSLContext.new
-      ctx.ecdh_curves = "P-256:P-384"
+      ctx.groups = "P-256:P-384"
       server_connect(port, ctx) { |ssl|
         cs = ssl.cipher[0]
         assert_match (/\AECDH/), cs
@@ -2021,14 +2021,14 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
 
       # Test 2: Client=P-256, Server=P-521:P-384 --> Fail
       ctx = OpenSSL::SSL::SSLContext.new
-      ctx.ecdh_curves = "P-256"
+      ctx.groups = "P-256"
       assert_raise(OpenSSL::SSL::SSLError) {
         server_connect(port, ctx) { }
       }
 
       # Test 3: Client=P-521:P-384, Server=P-521:P-384 --> P-521
       ctx = OpenSSL::SSL::SSLContext.new
-      ctx.ecdh_curves = "P-521:P-384"
+      ctx.groups = "P-521:P-384"
       server_connect(port, ctx) { |ssl|
         assert_equal "secp521r1", ssl.tmp_key.group.curve_name
         ssl.puts "abc"; assert_equal "abc\n", ssl.gets
@@ -2036,14 +2036,14 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
     end
   end
 
-  def test_ecdh_curves_tls13
+  def test_groups_tls13
     ctx_proc = -> ctx {
       # Assume TLS 1.3 is enabled and chosen by default
-      ctx.ecdh_curves = "P-384:P-521"
+      ctx.groups = "P-384:P-521"
     }
     start_server(ctx_proc: ctx_proc, ignore_listener_error: true) do |port|
       ctx = OpenSSL::SSL::SSLContext.new
-      ctx.ecdh_curves = "P-256:P-384" # disable P-521
+      ctx.groups = "P-256:P-384" # disable P-521
 
       server_connect(port, ctx) { |ssl|
         assert_equal "TLSv1.3", ssl.ssl_version


### PR DESCRIPTION
This PR is related to the https://github.com/ruby/openssl/issues/894#issuecomment-2954154376. I checked the generated rdoc document by this change. I am still keeping the `SSLContext#ecdh_curves=` without deprecation in this PR. If we want to mark the `SSLContext#ecdh_curves=` as the deprecated, we can add the comment `# <b>Deprecated in version 3.4.</b> Use #groups= instead.` in the future, maybe before releasing the Ruby OpenSSL version 3.4.

What do you think?

---

Rename the `SSLContext#ecdh_curves=` to `#groups=`, keeping the `#ecdh_curves=` as an alias of the `#groups=` for backward compatibility.

In OpenSSL version 1.1.1 `SSL_CTX_set1_curves_list` was renamed to `SSL_CTX_set1_groups_list`, keeping the `SSL_CTX_set1_curves_list` at the following commit. Because TLS 1.3 renamed the extension. https://github.com/openssl/openssl/commit/de4d764e3271ce09d28c0d6d7bce3dc9d8b85ab9

As we only support OpenSSL version 1.1.1 or later versions, it is no problem to use the `SSL_CTX_set1_groups_list`.

For the document of the `ossl_sslctx_set_groups`,
I referred to the following RFC 8446 TLS 1.3 Supported Groups section. https://datatracker.ietf.org/doc/html/rfc8446#section-4.2.7