### PR TITLE
ssl: add SSLSocket#sigalg, #peer_sigalg, #group

### DIFF
--- a/ext/openssl/extconf.rb
+++ b/ext/openssl/extconf.rb
@@ -156,8 +156,14 @@ have_func("EVP_MD_CTX_get_pkey_ctx(NULL)", evp_h)
 have_func("EVP_PKEY_eq(NULL, NULL)", evp_h)
 have_func("EVP_PKEY_dup(NULL)", evp_h)
 
+# added in 3.2.0
+have_func("SSL_get0_group_name(NULL)", ssl_h)
+
 # added in 3.4.0
 have_func("TS_VERIFY_CTX_set0_certs(NULL, NULL)", ts_h)
+
+# added in 3.5.0
+have_func("SSL_get0_peer_signature_name(NULL, NULL)", ssl_h)
 
 Logging::message "=== Checking done. ===\n"
 

--- a/ext/openssl/ossl_ssl.c
+++ b/ext/openssl/ossl_ssl.c
@@ -2644,6 +2644,68 @@ ossl_ssl_tmp_key(VALUE self)
 	return Qnil;
     return ossl_pkey_new(key);
 }
+
+#ifdef HAVE_SSL_GET0_PEER_SIGNATURE_NAME
+/*
+ * call-seq:
+ *    ssl.sigalg => String or nil
+ *
+ * Returns the signature algorithm name, the IANA name of the signature scheme
+ * used by the local to sign the TLS handshake.
+ */
+static VALUE
+ossl_ssl_get_sigalg(VALUE self)
+{
+    SSL *ssl;
+    const char *name;
+
+    GetSSL(self, ssl);
+    if (!SSL_get0_signature_name(ssl, &name))
+        return Qnil;
+    return rb_str_new_cstr(name);
+}
+
+/*
+ * call-seq:
+ *    ssl.peer_sigalg => String or nil
+ *
+ * Returns the signature algorithm name, the IANA name of the signature scheme
+ * used by the peer to sign the TLS handshake.
+ */
+static VALUE
+ossl_ssl_get_peer_sigalg(VALUE self)
+{
+    SSL *ssl;
+    const char *name;
+
+    GetSSL(self, ssl);
+    if (!SSL_get0_peer_signature_name(ssl, &name))
+        return Qnil;
+    return rb_str_new_cstr(name);
+}
+#endif
+
+#ifdef HAVE_SSL_GET0_GROUP_NAME
+/*
+ * call-seq:
+ *    ssl.group => String or nil
+ *
+ * Returns the name of the group that was used for the key agreement of the
+ * current TLS session establishment.
+ */
+static VALUE
+ossl_ssl_get_group(VALUE self)
+{
+    SSL *ssl;
+    const char *name;
+
+    GetSSL(self, ssl);
+    if (!(name = SSL_get0_group_name(ssl)))
+        return Qnil;
+    return rb_str_new_cstr(name);
+}
+#endif
+
 #endif /* !defined(OPENSSL_NO_SOCK) */
 
 void
@@ -3067,6 +3129,13 @@ Init_ossl_ssl(void)
 # ifdef OSSL_USE_NEXTPROTONEG
     rb_define_method(cSSLSocket, "npn_protocol", ossl_ssl_npn_protocol, 0);
 # endif
+#ifdef HAVE_SSL_GET0_PEER_SIGNATURE_NAME
+    rb_define_method(cSSLSocket, "sigalg", ossl_ssl_get_sigalg, 0);
+    rb_define_method(cSSLSocket, "peer_sigalg", ossl_ssl_get_peer_sigalg, 0);
+#endif
+#ifdef HAVE_SSL_GET0_GROUP_NAME
+    rb_define_method(cSSLSocket, "group", ossl_ssl_get_group, 0);
+#endif
 
     rb_define_const(mSSL, "VERIFY_NONE", INT2NUM(SSL_VERIFY_NONE));
     rb_define_const(mSSL, "VERIFY_PEER", INT2NUM(SSL_VERIFY_PEER));


### PR DESCRIPTION
@rhenium This PR is related to https://github.com/ruby/openssl/issues/894 - Add features to get the following data from a TLS client.

* Peer signing digest
* Peer signature type
* Negotiated TLS1.3 group

Note I added the `#include <openssl/obj_mac.h>` for `NID_undef` and `#include <openssl/objects.h>` for the `OBJ_nid2sn()`.

I am not sure about the best location where I should put these new logic, the functions and unit tests in the files. I would appreciate if you tell me the best location.

You can also just cherry-pick this PR or refer to this PR or create your new PR.

Could you review the PR? Thank you!

