### PR TITLE
asn1: align UTCTime year range with RFC 5280

### DIFF
--- a/ext/openssl/ossl_asn1.c
+++ b/ext/openssl/ossl_asn1.c
@@ -36,7 +36,7 @@ asn1time_to_time(const ASN1_TIME *time)
 	    ossl_raise(rb_eTypeError, "bad UTCTIME format: \"%s\"",
 		    time->data);
 	}
-	if (tm.tm_year < 69) {
+	if (tm.tm_year < 50) {
 	    tm.tm_year += 2000;
 	} else {
 	    tm.tm_year += 1900;

--- a/test/openssl/test_asn1.rb
+++ b/test/openssl/test_asn1.rb
@@ -411,13 +411,16 @@ class  OpenSSL::TestASN1 < OpenSSL::TestCase
   def test_utctime
     encode_decode_test B(%w{ 17 0D }) + "160908234339Z".b,
       OpenSSL::ASN1::UTCTime.new(Time.utc(2016, 9, 8, 23, 43, 39))
-    begin
-      # possible range of UTCTime is 1969-2068 currently
-      encode_decode_test B(%w{ 17 0D }) + "690908234339Z".b,
-        OpenSSL::ASN1::UTCTime.new(Time.utc(1969, 9, 8, 23, 43, 39))
-    rescue OpenSSL::ASN1::ASN1Error
-      pend "No negative time_t support?"
-    end
+
+    # 1950-2049 range is assumed to match RFC 5280's expectation
+    encode_decode_test B(%w{ 17 0D }) + "490908234339Z".b,
+      OpenSSL::ASN1::UTCTime.new(Time.utc(2049, 9, 8, 23, 43, 39))
+    encode_decode_test B(%w{ 17 0D }) + "500908234339Z".b,
+      OpenSSL::ASN1::UTCTime.new(Time.utc(1950, 9, 8, 23, 43, 39))
+    assert_raise(OpenSSL::ASN1::ASN1Error) {
+      OpenSSL::ASN1::UTCTime.new(Time.new(2049, 12, 31, 23, 0, 0, "-04:00")).to_der
+    }
+
     # not implemented
     # decode_test B(%w{ 17 11 }) + "500908234339+0930".b,
     #   OpenSSL::ASN1::UTCTime.new(Time.new(1950, 9, 8, 23, 43, 39, "+09:30"))


### PR DESCRIPTION
ASN.1 UTCTime uses two-digit years. While X.680 does not specify how to map them as far as I can tell, X.509/PKIX uses this type to represent dates between year 1950-2049.

OpenSSL::ASN1.decode has used 1969-2068 since the initial implementation. Given that ASN1::UTCTime#to_der relies on OpenSSL ASN1_UTCTIME type, which assumes the 1950-2049 range, this was likely unintentional.

Use the range 1950-2049 consistently, and fix decoding of X.509 certificates with dates in 1950-1968.