### PR TITLE
Cleanup ossl_*_new() functions

### DIFF
--- a/ext/openssl/ossl_bn.c
+++ b/ext/openssl/ossl_bn.c
@@ -61,10 +61,9 @@ ossl_bn_new(const BIGNUM *bn)
     VALUE obj;
 
     obj = NewBN(cBN);
-    newbn = bn ? BN_dup(bn) : BN_new();
-    if (!newbn) {
-	ossl_raise(eBNError, NULL);
-    }
+    newbn = BN_dup(bn);
+    if (!newbn)
+        ossl_raise(eBNError, "BN_dup");
     SetBN(obj, newbn);
 
     return obj;

--- a/ext/openssl/ossl_engine.c
+++ b/ext/openssl/ossl_engine.c
@@ -320,7 +320,7 @@ ossl_engine_load_privkey(int argc, VALUE *argv, VALUE self)
     GetEngine(self, e);
     pkey = ENGINE_load_private_key(e, sid, NULL, sdata);
     if (!pkey) ossl_raise(eEngineError, NULL);
-    obj = ossl_pkey_new(pkey);
+    obj = ossl_pkey_wrap(pkey);
     OSSL_PKEY_SET_PRIVATE(obj);
 
     return obj;
@@ -350,7 +350,7 @@ ossl_engine_load_pubkey(int argc, VALUE *argv, VALUE self)
     pkey = ENGINE_load_public_key(e, sid, NULL, sdata);
     if (!pkey) ossl_raise(eEngineError, NULL);
 
-    return ossl_pkey_new(pkey);
+    return ossl_pkey_wrap(pkey);
 }
 
 /*

--- a/ext/openssl/ossl_ns_spki.c
+++ b/ext/openssl/ossl_ns_spki.c
@@ -190,7 +190,7 @@ ossl_spki_get_public_key(VALUE self)
 	ossl_raise(eSPKIError, NULL);
     }
 
-    return ossl_pkey_new(pkey); /* NO DUP - OK */
+    return ossl_pkey_wrap(pkey);
 }
 
 /*

--- a/ext/openssl/ossl_pkcs12.c
+++ b/ext/openssl/ossl_pkcs12.c
@@ -161,9 +161,9 @@ ossl_pkcs12_s_create(int argc, VALUE *argv, VALUE self)
 }
 
 static VALUE
-ossl_pkey_new_i(VALUE arg)
+ossl_pkey_wrap_i(VALUE arg)
 {
-    return ossl_pkey_new((EVP_PKEY *)arg);
+    return ossl_pkey_wrap((EVP_PKEY *)arg);
 }
 
 static VALUE
@@ -211,7 +211,7 @@ ossl_pkcs12_initialize(int argc, VALUE *argv, VALUE self)
     if(!PKCS12_parse(pkcs, passphrase, &key, &x509, &x509s))
 	ossl_raise(ePKCS12Error, "PKCS12_parse");
     if (key) {
-	pkey = rb_protect(ossl_pkey_new_i, (VALUE)key, &st);
+	pkey = rb_protect(ossl_pkey_wrap_i, (VALUE)key, &st);
 	if (st) goto err;
     }
     if (x509) {

--- a/ext/openssl/ossl_pkcs7.c
+++ b/ext/openssl/ossl_pkcs7.c
@@ -153,13 +153,14 @@ ossl_PKCS7_RECIP_INFO_dup(PKCS7_RECIP_INFO *si)
 static VALUE
 ossl_pkcs7si_new(PKCS7_SIGNER_INFO *p7si)
 {
-    PKCS7_SIGNER_INFO *pkcs7;
+    PKCS7_SIGNER_INFO *p7si_new;
     VALUE obj;
 
     obj = NewPKCS7si(cPKCS7Signer);
-    pkcs7 = p7si ? ossl_PKCS7_SIGNER_INFO_dup(p7si) : PKCS7_SIGNER_INFO_new();
-    if (!pkcs7) ossl_raise(ePKCS7Error, NULL);
-    SetPKCS7si(obj, pkcs7);
+    p7si_new = ossl_PKCS7_SIGNER_INFO_dup(p7si);
+    if (!p7si_new)
+        ossl_raise(ePKCS7Error, "ASN1_dup");
+    SetPKCS7si(obj, p7si_new);
 
     return obj;
 }
@@ -167,13 +168,14 @@ ossl_pkcs7si_new(PKCS7_SIGNER_INFO *p7si)
 static VALUE
 ossl_pkcs7ri_new(PKCS7_RECIP_INFO *p7ri)
 {
-    PKCS7_RECIP_INFO *pkcs7;
+    PKCS7_RECIP_INFO *p7ri_new;
     VALUE obj;
 
     obj = NewPKCS7ri(cPKCS7Recipient);
-    pkcs7 = p7ri ? ossl_PKCS7_RECIP_INFO_dup(p7ri) : PKCS7_RECIP_INFO_new();
-    if (!pkcs7) ossl_raise(ePKCS7Error, NULL);
-    SetPKCS7ri(obj, pkcs7);
+    p7ri_new = ossl_PKCS7_RECIP_INFO_dup(p7ri);
+    if (!p7ri_new)
+        ossl_raise(ePKCS7Error,"ASN1_dup");
+    SetPKCS7ri(obj, p7ri_new);
 
     return obj;
 }

--- a/ext/openssl/ossl_pkey.c
+++ b/ext/openssl/ossl_pkey.c
@@ -39,7 +39,7 @@ const rb_data_type_t ossl_evp_pkey_type = {
 };
 
 static VALUE
-pkey_new0(VALUE arg)
+pkey_wrap0(VALUE arg)
 {
     EVP_PKEY *pkey = (EVP_PKEY *)arg;
     VALUE klass, obj;
@@ -65,12 +65,12 @@ pkey_new0(VALUE arg)
 }
 
 VALUE
-ossl_pkey_new(EVP_PKEY *pkey)
+ossl_pkey_wrap(EVP_PKEY *pkey)
 {
     VALUE obj;
     int status;
 
-    obj = rb_protect(pkey_new0, (VALUE)pkey, &status);
+    obj = rb_protect(pkey_wrap0, (VALUE)pkey, &status);
     if (status) {
 	EVP_PKEY_free(pkey);
 	rb_jump_tag(status);
@@ -239,7 +239,7 @@ ossl_pkey_new_from_data(int argc, VALUE *argv, VALUE self)
     BIO_free(bio);
     if (!pkey)
 	ossl_raise(ePKeyError, "Could not parse PKey");
-    return ossl_pkey_new(pkey);
+    return ossl_pkey_wrap(pkey);
 }
 
 static VALUE
@@ -443,7 +443,7 @@ pkey_generate(int argc, VALUE *argv, VALUE self, int genparam)
         }
     }
 
-    return ossl_pkey_new(gen_arg.pkey);
+    return ossl_pkey_wrap(gen_arg.pkey);
 }
 
 /*
@@ -687,7 +687,7 @@ ossl_pkey_new_raw_private_key(VALUE self, VALUE type, VALUE key)
         ossl_raise(ePKeyError, "EVP_PKEY_new_raw_private_key");
 #endif
 
-    return ossl_pkey_new(pkey);
+    return ossl_pkey_wrap(pkey);
 }
 
 /*
@@ -719,7 +719,7 @@ ossl_pkey_new_raw_public_key(VALUE self, VALUE type, VALUE key)
         ossl_raise(ePKeyError, "EVP_PKEY_new_raw_public_key");
 #endif
 
-    return ossl_pkey_new(pkey);
+    return ossl_pkey_wrap(pkey);
 }
 
 /*

--- a/ext/openssl/ossl_pkey.h
+++ b/ext/openssl/ossl_pkey.h
@@ -27,7 +27,7 @@ extern const rb_data_type_t ossl_evp_pkey_type;
 } while (0)
 
 /* Takes ownership of the EVP_PKEY */
-VALUE ossl_pkey_new(EVP_PKEY *);
+VALUE ossl_pkey_wrap(EVP_PKEY *);
 void ossl_pkey_check_public_key(const EVP_PKEY *);
 EVP_PKEY *ossl_pkey_read_generic(BIO *, VALUE);
 EVP_PKEY *GetPKeyPtr(VALUE);

--- a/ext/openssl/ossl_pkey_ec.c
+++ b/ext/openssl/ossl_pkey_ec.c
@@ -805,11 +805,10 @@ static VALUE ossl_ec_group_get_order(VALUE self)
 {
     VALUE bn_obj;
     BIGNUM *bn;
-    EC_GROUP *group = NULL;
+    EC_GROUP *group;
 
     GetECGroup(self, group);
-
-    bn_obj = ossl_bn_new(NULL);
+    bn_obj = ossl_bn_new(BN_value_one());
     bn = GetBNPtr(bn_obj);
 
     if (EC_GROUP_get_order(group, bn, ossl_bn_ctx) != 1)
@@ -830,11 +829,10 @@ static VALUE ossl_ec_group_get_cofactor(VALUE self)
 {
     VALUE bn_obj;
     BIGNUM *bn;
-    EC_GROUP *group = NULL;
+    EC_GROUP *group;
 
     GetECGroup(self, group);
-
-    bn_obj = ossl_bn_new(NULL);
+    bn_obj = ossl_bn_new(BN_value_one());
     bn = GetBNPtr(bn_obj);
 
     if (EC_GROUP_get_cofactor(group, bn, ossl_bn_ctx) != 1)

--- a/ext/openssl/ossl_ssl.c
+++ b/ext/openssl/ossl_ssl.c
@@ -2642,7 +2642,7 @@ ossl_ssl_tmp_key(VALUE self)
     GetSSL(self, ssl);
     if (!SSL_get_server_tmp_key(ssl, &key))
 	return Qnil;
-    return ossl_pkey_new(key);
+    return ossl_pkey_wrap(key);
 }
 #endif /* !defined(OPENSSL_NO_SOCK) */
 

--- a/ext/openssl/ossl_x509attr.c
+++ b/ext/openssl/ossl_x509attr.c
@@ -54,14 +54,9 @@ ossl_x509attr_new(X509_ATTRIBUTE *attr)
     VALUE obj;
 
     obj = NewX509Attr(cX509Attr);
-    if (!attr) {
-	new = X509_ATTRIBUTE_new();
-    } else {
-	new = X509_ATTRIBUTE_dup(attr);
-    }
-    if (!new) {
-	ossl_raise(eX509AttrError, NULL);
-    }
+    new = X509_ATTRIBUTE_dup(attr);
+    if (!new)
+        ossl_raise(eX509AttrError, "X509_ATTRIBUTE_dup");
     SetX509Attr(obj, new);
 
     return obj;

--- a/ext/openssl/ossl_x509cert.c
+++ b/ext/openssl/ossl_x509cert.c
@@ -54,14 +54,9 @@ ossl_x509_new(X509 *x509)
     VALUE obj;
 
     obj = NewX509(cX509Cert);
-    if (!x509) {
-	new = X509_new();
-    } else {
-	new = X509_dup(x509);
-    }
-    if (!new) {
-	ossl_raise(eX509CertError, NULL);
-    }
+    new = X509_dup(x509);
+    if (!new)
+        ossl_raise(eX509CertError, "X509_dup");
     SetX509(obj, new);
 
     return obj;

--- a/ext/openssl/ossl_x509cert.c
+++ b/ext/openssl/ossl_x509cert.c
@@ -504,7 +504,7 @@ ossl_x509_get_public_key(VALUE self)
 	ossl_raise(eX509CertError, NULL);
     }
 
-    return ossl_pkey_new(pkey); /* NO DUP - OK */
+    return ossl_pkey_wrap(pkey);
 }
 
 /*

--- a/ext/openssl/ossl_x509crl.c
+++ b/ext/openssl/ossl_x509crl.c
@@ -64,8 +64,9 @@ ossl_x509crl_new(X509_CRL *crl)
     VALUE obj;
 
     obj = NewX509CRL(cX509CRL);
-    tmp = crl ? X509_CRL_dup(crl) : X509_CRL_new();
-    if(!tmp) ossl_raise(eX509CRLError, NULL);
+    tmp = X509_CRL_dup(crl);
+    if (!tmp)
+        ossl_raise(eX509CRLError, "X509_CRL_dup");
     SetX509CRL(obj, tmp);
 
     return obj;

--- a/ext/openssl/ossl_x509ext.c
+++ b/ext/openssl/ossl_x509ext.c
@@ -68,14 +68,9 @@ ossl_x509ext_new(X509_EXTENSION *ext)
     VALUE obj;
 
     obj = NewX509Ext(cX509Ext);
-    if (!ext) {
-	new = X509_EXTENSION_new();
-    } else {
-	new = X509_EXTENSION_dup(ext);
-    }
-    if (!new) {
-	ossl_raise(eX509ExtError, NULL);
-    }
+    new = X509_EXTENSION_dup(ext);
+    if (!new)
+        ossl_raise(eX509ExtError, "X509_EXTENSION_dup");
     SetX509Ext(obj, new);
 
     return obj;

--- a/ext/openssl/ossl_x509name.c
+++ b/ext/openssl/ossl_x509name.c
@@ -59,14 +59,9 @@ ossl_x509name_new(X509_NAME *name)
     VALUE obj;
 
     obj = NewX509Name(cX509Name);
-    if (!name) {
-	new = X509_NAME_new();
-    } else {
-	new = X509_NAME_dup(name);
-    }
-    if (!new) {
-	ossl_raise(eX509NameError, NULL);
-    }
+    new = X509_NAME_dup(name);
+    if (!new)
+        ossl_raise(eX509NameError, "X509_NAME_dup");
     SetX509Name(obj, new);
 
     return obj;

--- a/ext/openssl/ossl_x509req.c
+++ b/ext/openssl/ossl_x509req.c
@@ -289,7 +289,7 @@ ossl_x509req_get_public_key(VALUE self)
 	ossl_raise(eX509ReqError, NULL);
     }
 
-    return ossl_pkey_new(pkey); /* NO DUP - OK */
+    return ossl_pkey_wrap(pkey);
 }
 
 static VALUE

--- a/ext/openssl/ossl_x509revoked.c
+++ b/ext/openssl/ossl_x509revoked.c
@@ -54,14 +54,9 @@ ossl_x509revoked_new(X509_REVOKED *rev)
     VALUE obj;
 
     obj = NewX509Rev(cX509Rev);
-    if (!rev) {
-	new = X509_REVOKED_new();
-    } else {
-	new = X509_REVOKED_dup(rev);
-    }
-    if (!new) {
-	ossl_raise(eX509RevError, NULL);
-    }
+    new = X509_REVOKED_dup(rev);
+    if (!new)
+	ossl_raise(eX509RevError, "X509_REVOKED_dup");
     SetX509Rev(obj, new);
 
     return obj;


### PR DESCRIPTION
The `ossl_*_new()` functions are confusingly inconsistent in how they handle the lifetime of the passed OpenSSL object. This PR makes the behavior consistent, remove dead code, and fix potential memory leaks due to allocating Ruby objects after allocating OpenSSL objects.

---
**bn: avoid ossl_bn_new(NULL)**

Currently, calling ossl_bn_new() with a NULL argument allocates a new
OpenSSL::BN instance representing 0. This behavior is confusing. Raise
an exception if this is attempted, instead.

---
**x509: disallow ossl_x509{,attr,crl,ext,revoked,name}*_new(NULL)**

These functions are not actually called with NULL. It also doesn't make
sense to do so, so let's simplify the definitions.

---
**pkcs7: disallow ossl_pkcs7{si,ri}_new(NULL)**

These functions are not actually called with NULL.

---
**ocsp: refactor ossl_ocspsres_new()**

Similar to most of the other ossl_*_new() functions, let it take a const
pointer and make a copy of the object.

This also fixes a potential memory leak when the wrapper object
allocation fails.

---
**ocsp: refactor ossl_ocspcertid_new()**

Likewise, let it take a const pointer and not the ownership of the
OpenSSL object.

This fixes potential memory leak in OpenSSL::OCSP::BasicResponse#status.

---
**pkey: rename ossl_pkey_new() to ossl_pkey_wrap()**

Among functions named ossl_*_new(), ossl_pkey_new() is now the only one
that takes ownership of the passed OpenSSL object instead of making a
copy or incrementing its reference counter. Rename it to make this
behavior easier to understand.

