### PR TITLE
lib/openssl.rb: require files in alphabetical order

### DIFF
--- a/lib/openssl.rb
+++ b/lib/openssl.rb
@@ -12,16 +12,16 @@
 
 require 'openssl.so'
 
-require_relative 'openssl/bn'
 require_relative 'openssl/asn1'
-require_relative 'openssl/pkey'
+require_relative 'openssl/bn'
 require_relative 'openssl/cipher'
 require_relative 'openssl/digest'
 require_relative 'openssl/hmac'
-require_relative 'openssl/x509'
-require_relative 'openssl/ssl'
 require_relative 'openssl/pkcs5'
+require_relative 'openssl/pkey'
+require_relative 'openssl/ssl'
 require_relative 'openssl/version'
+require_relative 'openssl/x509'
 
 module OpenSSL
   # call-seq:


### PR DESCRIPTION
This list was originally in alphabetical order. Sort it again.

This change should be safe since the .rb sources should only depend on the extension and not each other.