### PR TITLE
x509store: fix StoreContext#current_cert

### DIFF
--- a/ext/openssl/ossl_x509store.c
+++ b/ext/openssl/ossl_x509store.c
@@ -735,10 +735,14 @@ static VALUE
 ossl_x509stctx_get_curr_cert(VALUE self)
 {
     X509_STORE_CTX *ctx;
+    X509 *x509;
 
     GetX509StCtx(self, ctx);
+    x509 = X509_STORE_CTX_get_current_cert(ctx);
+    if (!x509)
+        return Qnil;
 
-    return ossl_x509_new(X509_STORE_CTX_get_current_cert(ctx));
+    return ossl_x509_new(x509);
 }
 
 /*

--- a/test/openssl/test_x509store.rb
+++ b/test/openssl/test_x509store.rb
@@ -91,6 +91,18 @@ class OpenSSL::TestX509Store < OpenSSL::TestCase
     assert_match(/ok/i, store.error_string)
     assert_equal(OpenSSL::X509::V_OK, store.error)
     assert_equal([ee1_cert, ca2_cert, ca1_cert], store.chain)
+
+    # Manually instantiated StoreContext
+    # Nothing trusted
+    store = OpenSSL::X509::Store.new
+    ctx = OpenSSL::X509::StoreContext.new(store, ee1_cert)
+    assert_nil(ctx.current_cert)
+    assert_nil(ctx.current_crl)
+    assert_equal(false, ctx.verify)
+    assert_equal(OpenSSL::X509::V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY, ctx.error)
+    assert_equal(0, ctx.error_depth)
+    assert_equal([ee1_cert], ctx.chain)
+    assert_equal(ee1_cert, ctx.current_cert)
   end
 
   def test_verify_callback


### PR DESCRIPTION
Commit ef277083ba76 overlooked a caller of ossl_x509_new() with NULL argument. OpenSSL::X509::StoreContext#current_cert may not have a certificate to return if StoreContext#verify has not been called.