### PR TITLE
pkcs7: clean up tests

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -34,7 +34,6 @@ Rake::TestTask.new(:test_fips_internal) do |t|
     'test/openssl/test_ns_spki.rb',
     'test/openssl/test_ocsp.rb',
     'test/openssl/test_pkcs12.rb',
-    'test/openssl/test_pkcs7.rb',
     'test/openssl/test_ssl.rb',
     'test/openssl/test_ts.rb',
     'test/openssl/test_x509cert.rb',


### PR DESCRIPTION
This includes:

 - Update test keys and add omissions for enveloped-data tests so that the rest can be tested in the FIPS mode.
 - Add tests for PKCS7#error_string and #data.
 - Check more error paths.
 - Various style fixes.