### PR TITLE
pkey: unify error classes into PKeyError

### DIFF
--- a/ext/openssl/ossl_pkey.c
+++ b/ext/openssl/ossl_pkey.c
@@ -1717,7 +1717,16 @@ Init_ossl_pkey(void)
 
     /* Document-class: OpenSSL::PKey::PKeyError
      *
-     *Raised when errors occur during PKey#sign or PKey#verify.
+     * Raised when errors occur during PKey#sign or PKey#verify.
+     *
+     * Before version 4.0.0, OpenSSL::PKey::PKeyError had the following
+     * subclasses. These subclasses have been removed and the constants are
+     * now defined as aliases of OpenSSL::PKey::PKeyError.
+     *
+     * * OpenSSL::PKey::DHError
+     * * OpenSSL::PKey::DSAError
+     * * OpenSSL::PKey::ECError
+     * * OpenSSL::PKey::RSAError
      */
     ePKeyError = rb_define_class_under(mPKey, "PKeyError", eOSSLError);
 

--- a/ext/openssl/ossl_pkey_dh.c
+++ b/ext/openssl/ossl_pkey_dh.c
@@ -27,7 +27,6 @@
  * Classes
  */
 VALUE cDH;
-static VALUE eDHError;
 
 /*
  * Private
@@ -86,7 +85,7 @@ ossl_dh_initialize(int argc, VALUE *argv, VALUE self)
     if (rb_scan_args(argc, argv, "01", &arg) == 0) {
         dh = DH_new();
         if (!dh)
-            ossl_raise(eDHError, "DH_new");
+            ossl_raise(ePKeyError, "DH_new");
         goto legacy;
     }
 
@@ -105,12 +104,12 @@ ossl_dh_initialize(int argc, VALUE *argv, VALUE self)
     pkey = ossl_pkey_read_generic(in, Qnil);
     BIO_free(in);
     if (!pkey)
-        ossl_raise(eDHError, "could not parse pkey");
+        ossl_raise(ePKeyError, "could not parse pkey");
 
     type = EVP_PKEY_base_id(pkey);
     if (type != EVP_PKEY_DH) {
         EVP_PKEY_free(pkey);
-        rb_raise(eDHError, "incorrect pkey type: %s", OBJ_nid2sn(type));
+        rb_raise(ePKeyError, "incorrect pkey type: %s", OBJ_nid2sn(type));
     }
     RTYPEDDATA_DATA(self) = pkey;
     return self;
@@ -121,7 +120,7 @@ ossl_dh_initialize(int argc, VALUE *argv, VALUE self)
     if (!pkey || EVP_PKEY_assign_DH(pkey, dh) != 1) {
         EVP_PKEY_free(pkey);
         DH_free(dh);
-        ossl_raise(eDHError, "EVP_PKEY_assign_DH");
+        ossl_raise(ePKeyError, "EVP_PKEY_assign_DH");
     }
     RTYPEDDATA_DATA(self) = pkey;
     return self;
@@ -143,7 +142,7 @@ ossl_dh_initialize_copy(VALUE self, VALUE other)
 
     dh = DHparams_dup(dh_other);
     if (!dh)
-	ossl_raise(eDHError, "DHparams_dup");
+	ossl_raise(ePKeyError, "DHparams_dup");
 
     DH_get0_key(dh_other, &pub, &priv);
     if (pub) {
@@ -153,7 +152,7 @@ ossl_dh_initialize_copy(VALUE self, VALUE other)
         if (!pub2 || (priv && !priv2)) {
 	    BN_clear_free(pub2);
 	    BN_clear_free(priv2);
-	    ossl_raise(eDHError, "BN_dup");
+	    ossl_raise(ePKeyError, "BN_dup");
 	}
 	DH_set0_key(dh, pub2, priv2);
     }
@@ -162,7 +161,7 @@ ossl_dh_initialize_copy(VALUE self, VALUE other)
     if (!pkey || EVP_PKEY_assign_DH(pkey, dh) != 1) {
         EVP_PKEY_free(pkey);
         DH_free(dh);
-        ossl_raise(eDHError, "EVP_PKEY_assign_DH");
+        ossl_raise(ePKeyError, "EVP_PKEY_assign_DH");
     }
     RTYPEDDATA_DATA(self) = pkey;
     return self;
@@ -241,11 +240,11 @@ ossl_dh_export(VALUE self)
 
     GetDH(self, dh);
     if (!(out = BIO_new(BIO_s_mem()))) {
-	ossl_raise(eDHError, NULL);
+	ossl_raise(ePKeyError, NULL);
     }
     if (!PEM_write_bio_DHparams(out, dh)) {
 	BIO_free(out);
-	ossl_raise(eDHError, NULL);
+	ossl_raise(ePKeyError, NULL);
     }
     str = ossl_membio2str(out);
 
@@ -275,11 +274,11 @@ ossl_dh_to_der(VALUE self)
 
     GetDH(self, dh);
     if((len = i2d_DHparams(dh, NULL)) <= 0)
-	ossl_raise(eDHError, NULL);
+	ossl_raise(ePKeyError, NULL);
     str = rb_str_new(0, len);
     p = (unsigned char *)RSTRING_PTR(str);
     if(i2d_DHparams(dh, &p) < 0)
-	ossl_raise(eDHError, NULL);
+	ossl_raise(ePKeyError, NULL);
     ossl_str_adjust(str, p);
 
     return str;
@@ -306,7 +305,7 @@ ossl_dh_check_params(VALUE self)
     GetPKey(self, pkey);
     pctx = EVP_PKEY_CTX_new(pkey, /* engine */NULL);
     if (!pctx)
-        ossl_raise(eDHError, "EVP_PKEY_CTX_new");
+        ossl_raise(ePKeyError, "EVP_PKEY_CTX_new");
     ret = EVP_PKEY_param_check(pctx);
     EVP_PKEY_CTX_free(pctx);
 #else
@@ -355,13 +354,6 @@ Init_ossl_dh(void)
     ePKeyError = rb_define_class_under(mPKey, "PKeyError", eOSSLError);
 #endif
 
-    /* Document-class: OpenSSL::PKey::DHError
-     *
-     * Generic exception that is raised if an operation on a DH PKey
-     * fails unexpectedly or in case an instantiation of an instance of DH
-     * fails due to non-conformant input data.
-     */
-    eDHError = rb_define_class_under(mPKey, "DHError", ePKeyError);
     /* Document-class: OpenSSL::PKey::DH
      *
      * An implementation of the Diffie-Hellman key exchange protocol based on

--- a/ext/openssl/ossl_pkey_dsa.c
+++ b/ext/openssl/ossl_pkey_dsa.c
@@ -41,7 +41,6 @@ DSA_PRIVATE(VALUE obj, OSSL_3_const DSA *dsa)
  * Classes
  */
 VALUE cDSA;
-static VALUE eDSAError;
 
 /*
  * Private
@@ -98,7 +97,7 @@ ossl_dsa_initialize(int argc, VALUE *argv, VALUE self)
     if (argc == 0) {
         dsa = DSA_new();
         if (!dsa)
-            ossl_raise(eDSAError, "DSA_new");
+            ossl_raise(ePKeyError, "DSA_new");
         goto legacy;
     }
 
@@ -117,12 +116,12 @@ ossl_dsa_initialize(int argc, VALUE *argv, VALUE self)
     pkey = ossl_pkey_read_generic(in, pass);
     BIO_free(in);
     if (!pkey)
-        ossl_raise(eDSAError, "Neither PUB key nor PRIV key");
+        ossl_raise(ePKeyError, "Neither PUB key nor PRIV key");
 
     type = EVP_PKEY_base_id(pkey);
     if (type != EVP_PKEY_DSA) {
         EVP_PKEY_free(pkey);
-        rb_raise(eDSAError, "incorrect pkey type: %s", OBJ_nid2sn(type));
+        rb_raise(ePKeyError, "incorrect pkey type: %s", OBJ_nid2sn(type));
     }
     RTYPEDDATA_DATA(self) = pkey;
     return self;
@@ -133,7 +132,7 @@ ossl_dsa_initialize(int argc, VALUE *argv, VALUE self)
     if (!pkey || EVP_PKEY_assign_DSA(pkey, dsa) != 1) {
         EVP_PKEY_free(pkey);
         DSA_free(dsa);
-        ossl_raise(eDSAError, "EVP_PKEY_assign_DSA");
+        ossl_raise(ePKeyError, "EVP_PKEY_assign_DSA");
     }
     RTYPEDDATA_DATA(self) = pkey;
     return self;
@@ -156,13 +155,13 @@ ossl_dsa_initialize_copy(VALUE self, VALUE other)
                               (d2i_of_void *)d2i_DSAPrivateKey,
                               (char *)dsa);
     if (!dsa_new)
-	ossl_raise(eDSAError, "ASN1_dup");
+	ossl_raise(ePKeyError, "ASN1_dup");
 
     pkey = EVP_PKEY_new();
     if (!pkey || EVP_PKEY_assign_DSA(pkey, dsa_new) != 1) {
         EVP_PKEY_free(pkey);
         DSA_free(dsa_new);
-        ossl_raise(eDSAError, "EVP_PKEY_assign_DSA");
+        ossl_raise(ePKeyError, "EVP_PKEY_assign_DSA");
     }
     RTYPEDDATA_DATA(self) = pkey;
 
@@ -332,14 +331,6 @@ Init_ossl_dsa(void)
     cPKey = rb_define_class_under(mPKey, "PKey", rb_cObject);
     ePKeyError = rb_define_class_under(mPKey, "PKeyError", eOSSLError);
 #endif
-
-    /* Document-class: OpenSSL::PKey::DSAError
-     *
-     * Generic exception that is raised if an operation on a DSA PKey
-     * fails unexpectedly or in case an instantiation of an instance of DSA
-     * fails due to non-conformant input data.
-     */
-    eDSAError = rb_define_class_under(mPKey, "DSAError", ePKeyError);
 
     /* Document-class: OpenSSL::PKey::DSA
      *

--- a/ext/openssl/ossl_pkey_ec.c
+++ b/ext/openssl/ossl_pkey_ec.c
@@ -41,7 +41,6 @@ static const rb_data_type_t ossl_ec_point_type;
 } while (0)
 
 VALUE cEC;
-static VALUE eECError;
 static VALUE cEC_GROUP;
 static VALUE eEC_GROUP;
 static VALUE cEC_POINT;
@@ -69,20 +68,20 @@ ec_key_new_from_group(VALUE arg)
 
 	GetECGroup(arg, group);
 	if (!(ec = EC_KEY_new()))
-	    ossl_raise(eECError, NULL);
+	    ossl_raise(ePKeyError, NULL);
 
 	if (!EC_KEY_set_group(ec, group)) {
 	    EC_KEY_free(ec);
-	    ossl_raise(eECError, NULL);
+	    ossl_raise(ePKeyError, NULL);
 	}
     } else {
 	int nid = OBJ_sn2nid(StringValueCStr(arg));
 
 	if (nid == NID_undef)
-	    ossl_raise(eECError, "invalid curve name");
+	    ossl_raise(ePKeyError, "invalid curve name");
 
 	if (!(ec = EC_KEY_new_by_curve_name(nid)))
-	    ossl_raise(eECError, NULL);
+	    ossl_raise(ePKeyError, NULL);
 
 	EC_KEY_set_asn1_flag(ec, OPENSSL_EC_NAMED_CURVE);
 	EC_KEY_set_conv_form(ec, POINT_CONVERSION_UNCOMPRESSED);
@@ -112,12 +111,12 @@ ossl_ec_key_s_generate(VALUE klass, VALUE arg)
     if (!pkey || EVP_PKEY_assign_EC_KEY(pkey, ec) != 1) {
         EVP_PKEY_free(pkey);
         EC_KEY_free(ec);
-        ossl_raise(eECError, "EVP_PKEY_assign_EC_KEY");
+        ossl_raise(ePKeyError, "EVP_PKEY_assign_EC_KEY");
     }
     RTYPEDDATA_DATA(obj) = pkey;
 
     if (!EC_KEY_generate_key(ec))
-	ossl_raise(eECError, "EC_KEY_generate_key");
+	ossl_raise(ePKeyError, "EC_KEY_generate_key");
 
     return obj;
 }
@@ -148,7 +147,7 @@ static VALUE ossl_ec_key_initialize(int argc, VALUE *argv, VALUE self)
     rb_scan_args(argc, argv, "02", &arg, &pass);
     if (NIL_P(arg)) {
         if (!(ec = EC_KEY_new()))
-            ossl_raise(eECError, "EC_KEY_new");
+            ossl_raise(ePKeyError, "EC_KEY_new");
         goto legacy;
     }
     else if (rb_obj_is_kind_of(arg, cEC_GROUP)) {
@@ -171,7 +170,7 @@ static VALUE ossl_ec_key_initialize(int argc, VALUE *argv, VALUE self)
     type = EVP_PKEY_base_id(pkey);
     if (type != EVP_PKEY_EC) {
         EVP_PKEY_free(pkey);
-        rb_raise(eECError, "incorrect pkey type: %s", OBJ_nid2sn(type));
+        rb_raise(ePKeyError, "incorrect pkey type: %s", OBJ_nid2sn(type));
     }
     RTYPEDDATA_DATA(self) = pkey;
     return self;
@@ -181,7 +180,7 @@ static VALUE ossl_ec_key_initialize(int argc, VALUE *argv, VALUE self)
     if (!pkey || EVP_PKEY_assign_EC_KEY(pkey, ec) != 1) {
         EVP_PKEY_free(pkey);
         EC_KEY_free(ec);
-        ossl_raise(eECError, "EVP_PKEY_assign_EC_KEY");
+        ossl_raise(ePKeyError, "EVP_PKEY_assign_EC_KEY");
     }
     RTYPEDDATA_DATA(self) = pkey;
     return self;
@@ -202,12 +201,12 @@ ossl_ec_key_initialize_copy(VALUE self, VALUE other)
 
     ec_new = EC_KEY_dup(ec);
     if (!ec_new)
-	ossl_raise(eECError, "EC_KEY_dup");
+	ossl_raise(ePKeyError, "EC_KEY_dup");
 
     pkey = EVP_PKEY_new();
     if (!pkey || EVP_PKEY_assign_EC_KEY(pkey, ec_new) != 1) {
         EC_KEY_free(ec_new);
-        ossl_raise(eECError, "EVP_PKEY_assign_EC_KEY");
+        ossl_raise(ePKeyError, "EVP_PKEY_assign_EC_KEY");
     }
     RTYPEDDATA_DATA(self) = pkey;
 
@@ -256,7 +255,7 @@ ossl_ec_key_set_group(VALUE self, VALUE group_v)
     GetECGroup(group_v, group);
 
     if (EC_KEY_set_group(ec, group) != 1)
-        ossl_raise(eECError, "EC_KEY_set_group");
+        ossl_raise(ePKeyError, "EC_KEY_set_group");
 
     return group_v;
 #endif
@@ -306,7 +305,7 @@ static VALUE ossl_ec_key_set_private_key(VALUE self, VALUE private_key)
             break;
 	/* fallthrough */
     default:
-        ossl_raise(eECError, "EC_KEY_set_private_key");
+        ossl_raise(ePKeyError, "EC_KEY_set_private_key");
     }
 
     return private_key;
@@ -357,7 +356,7 @@ static VALUE ossl_ec_key_set_public_key(VALUE self, VALUE public_key)
             break;
 	/* fallthrough */
     default:
-        ossl_raise(eECError, "EC_KEY_set_public_key");
+        ossl_raise(ePKeyError, "EC_KEY_set_public_key");
     }
 
     return public_key;
@@ -461,7 +460,7 @@ ossl_ec_key_export(int argc, VALUE *argv, VALUE self)
 
     GetEC(self, ec);
     if (EC_KEY_get0_public_key(ec) == NULL)
-        ossl_raise(eECError, "can't export - no public key set");
+        ossl_raise(ePKeyError, "can't export - no public key set");
     if (EC_KEY_get0_private_key(ec))
         return ossl_pkey_export_traditional(argc, argv, self, 0);
     else
@@ -489,7 +488,7 @@ ossl_ec_key_to_der(VALUE self)
 
     GetEC(self, ec);
     if (EC_KEY_get0_public_key(ec) == NULL)
-        ossl_raise(eECError, "can't export - no public key set");
+        ossl_raise(ePKeyError, "can't export - no public key set");
     if (EC_KEY_get0_private_key(ec))
         return ossl_pkey_export_traditional(0, NULL, self, 1);
     else
@@ -518,7 +517,7 @@ static VALUE ossl_ec_key_generate_key(VALUE self)
 
     GetEC(self, ec);
     if (EC_KEY_generate_key(ec) != 1)
-	ossl_raise(eECError, "EC_KEY_generate_key");
+	ossl_raise(ePKeyError, "EC_KEY_generate_key");
 
     return self;
 #endif
@@ -543,18 +542,18 @@ static VALUE ossl_ec_key_check_key(VALUE self)
     GetEC(self, ec);
     pctx = EVP_PKEY_CTX_new(pkey, /* engine */NULL);
     if (!pctx)
-        ossl_raise(eECError, "EVP_PKEY_CTX_new");
+        ossl_raise(ePKeyError, "EVP_PKEY_CTX_new");
 
     if (EC_KEY_get0_private_key(ec) != NULL) {
         if (EVP_PKEY_check(pctx) != 1) {
             EVP_PKEY_CTX_free(pctx);
-            ossl_raise(eECError, "EVP_PKEY_check");
+            ossl_raise(ePKeyError, "EVP_PKEY_check");
         }
     }
     else {
         if (EVP_PKEY_public_check(pctx) != 1) {
             EVP_PKEY_CTX_free(pctx);
-            ossl_raise(eECError, "EVP_PKEY_public_check");
+            ossl_raise(ePKeyError, "EVP_PKEY_public_check");
         }
     }
 
@@ -564,7 +563,7 @@ static VALUE ossl_ec_key_check_key(VALUE self)
 
     GetEC(self, ec);
     if (EC_KEY_check_key(ec) != 1)
-	ossl_raise(eECError, "EC_KEY_check_key");
+	ossl_raise(ePKeyError, "EC_KEY_check_key");
 #endif
 
     return Qtrue;
@@ -1101,7 +1100,7 @@ static VALUE ossl_ec_group_to_string(VALUE self, int format)
 
     if (i != 1) {
         BIO_free(out);
-        ossl_raise(eECError, NULL);
+        ossl_raise(ePKeyError, NULL);
     }
 
     str = ossl_membio2str(out);
@@ -1528,8 +1527,6 @@ void Init_ossl_ec(void)
     eOSSLError = rb_define_class_under(mOSSL, "OpenSSLError", rb_eStandardError);
     ePKeyError = rb_define_class_under(mPKey, "PKeyError", eOSSLError);
 #endif
-
-    eECError = rb_define_class_under(mPKey, "ECError", ePKeyError);
 
     /*
      * Document-class: OpenSSL::PKey::EC

--- a/ext/openssl/ossl_pkey_rsa.c
+++ b/ext/openssl/ossl_pkey_rsa.c
@@ -42,7 +42,6 @@ RSA_PRIVATE(VALUE obj, OSSL_3_const RSA *rsa)
  * Classes
  */
 VALUE cRSA;
-static VALUE eRSAError;
 
 /*
  * Private
@@ -91,7 +90,7 @@ ossl_rsa_initialize(int argc, VALUE *argv, VALUE self)
     if (argc == 0) {
 	rsa = RSA_new();
         if (!rsa)
-            ossl_raise(eRSAError, "RSA_new");
+            ossl_raise(ePKeyError, "RSA_new");
         goto legacy;
     }
 
@@ -113,12 +112,12 @@ ossl_rsa_initialize(int argc, VALUE *argv, VALUE self)
     pkey = ossl_pkey_read_generic(in, pass);
     BIO_free(in);
     if (!pkey)
-        ossl_raise(eRSAError, "Neither PUB key nor PRIV key");
+        ossl_raise(ePKeyError, "Neither PUB key nor PRIV key");
 
     type = EVP_PKEY_base_id(pkey);
     if (type != EVP_PKEY_RSA) {
         EVP_PKEY_free(pkey);
-        rb_raise(eRSAError, "incorrect pkey type: %s", OBJ_nid2sn(type));
+        rb_raise(ePKeyError, "incorrect pkey type: %s", OBJ_nid2sn(type));
     }
     RTYPEDDATA_DATA(self) = pkey;
     return self;
@@ -129,7 +128,7 @@ ossl_rsa_initialize(int argc, VALUE *argv, VALUE self)
     if (!pkey || EVP_PKEY_assign_RSA(pkey, rsa) != 1) {
         EVP_PKEY_free(pkey);
         RSA_free(rsa);
-        ossl_raise(eRSAError, "EVP_PKEY_assign_RSA");
+        ossl_raise(ePKeyError, "EVP_PKEY_assign_RSA");
     }
     RTYPEDDATA_DATA(self) = pkey;
     return self;
@@ -152,12 +151,12 @@ ossl_rsa_initialize_copy(VALUE self, VALUE other)
                               (d2i_of_void *)d2i_RSAPrivateKey,
                               (char *)rsa);
     if (!rsa_new)
-	ossl_raise(eRSAError, "ASN1_dup");
+	ossl_raise(ePKeyError, "ASN1_dup");
 
     pkey = EVP_PKEY_new();
     if (!pkey || EVP_PKEY_assign_RSA(pkey, rsa_new) != 1) {
         RSA_free(rsa_new);
-        ossl_raise(eRSAError, "EVP_PKEY_assign_RSA");
+        ossl_raise(ePKeyError, "EVP_PKEY_assign_RSA");
     }
     RTYPEDDATA_DATA(self) = pkey;
 
@@ -312,7 +311,7 @@ ossl_rsa_to_der(VALUE self)
  * Signs _data_ using the Probabilistic Signature Scheme (RSA-PSS) and returns
  * the calculated signature.
  *
- * RSAError will be raised if an error occurs.
+ * PKeyError will be raised if an error occurs.
  *
  * See #verify_pss for the verification operation.
  *
@@ -399,7 +398,7 @@ ossl_rsa_sign_pss(int argc, VALUE *argv, VALUE self)
 
   err:
     EVP_MD_CTX_free(md_ctx);
-    ossl_raise(eRSAError, NULL);
+    ossl_raise(ePKeyError, NULL);
 }
 
 /*
@@ -409,7 +408,7 @@ ossl_rsa_sign_pss(int argc, VALUE *argv, VALUE self)
  * Verifies _data_ using the Probabilistic Signature Scheme (RSA-PSS).
  *
  * The return value is +true+ if the signature is valid, +false+ otherwise.
- * RSAError will be raised if an error occurs.
+ * PKeyError will be raised if an error occurs.
  *
  * See #sign_pss for the signing operation and an example code.
  *
@@ -492,7 +491,7 @@ ossl_rsa_verify_pss(int argc, VALUE *argv, VALUE self)
 
   err:
     EVP_MD_CTX_free(md_ctx);
-    ossl_raise(eRSAError, NULL);
+    ossl_raise(ePKeyError, NULL);
 }
 
 /*
@@ -535,14 +534,6 @@ Init_ossl_rsa(void)
     cPKey = rb_define_class_under(mPKey, "PKey", rb_cObject);
     ePKeyError = rb_define_class_under(mPKey, "PKeyError", eOSSLError);
 #endif
-
-    /* Document-class: OpenSSL::PKey::RSAError
-     *
-     * Generic exception that is raised if an operation on an RSA PKey
-     * fails unexpectedly or in case an instantiation of an instance of RSA
-     * fails due to non-conformant input data.
-     */
-    eRSAError = rb_define_class_under(mPKey, "RSAError", ePKeyError);
 
     /* Document-class: OpenSSL::PKey::RSA
      *

--- a/lib/openssl/pkey.rb
+++ b/lib/openssl/pkey.rb
@@ -7,6 +7,9 @@
 require_relative 'marshal'
 
 module OpenSSL::PKey
+  # Alias of PKeyError. Before version 4.0.0, this was a subclass of PKeyError.
+  DHError = PKeyError
+
   class DH
     include OpenSSL::Marshal
 
@@ -102,7 +105,7 @@ module OpenSSL::PKey
     #   puts dh0.pub_key == dh.pub_key #=> false
     def generate_key!
       if OpenSSL::OPENSSL_VERSION_NUMBER >= 0x30000000
-        raise DHError, "OpenSSL::PKey::DH is immutable on OpenSSL 3.0; " \
+        raise PKeyError, "OpenSSL::PKey::DH is immutable on OpenSSL 3.0; " \
         "use OpenSSL::PKey.generate_key instead"
       end
 
@@ -146,6 +149,9 @@ module OpenSSL::PKey
       end
     end
   end
+
+  # Alias of PKeyError. Before version 4.0.0, this was a subclass of PKeyError.
+  DSAError = PKeyError
 
   class DSA
     include OpenSSL::Marshal
@@ -242,13 +248,9 @@ module OpenSSL::PKey
     #   sig = dsa.sign_raw(nil, digest)
     #   p dsa.verify_raw(nil, sig, digest) #=> true
     def syssign(string)
-      q or raise OpenSSL::PKey::DSAError, "incomplete DSA"
-      private? or raise OpenSSL::PKey::DSAError, "Private DSA key needed!"
-      begin
-        sign_raw(nil, string)
-      rescue OpenSSL::PKey::PKeyError
-        raise OpenSSL::PKey::DSAError, $!.message
-      end
+      q or raise PKeyError, "incomplete DSA"
+      private? or raise PKeyError, "Private DSA key needed!"
+      sign_raw(nil, string)
     end
 
     # :call-seq:
@@ -266,12 +268,13 @@ module OpenSSL::PKey
     #   A \DSA signature value.
     def sysverify(digest, sig)
       verify_raw(nil, sig, digest)
-    rescue OpenSSL::PKey::PKeyError
-      raise OpenSSL::PKey::DSAError, $!.message
     end
   end
 
   if defined?(EC)
+  # Alias of PKeyError. Before version 4.0.0, this was a subclass of PKeyError.
+  ECError = PKeyError
+
   class EC
     include OpenSSL::Marshal
 
@@ -282,8 +285,6 @@ module OpenSSL::PKey
     # Consider using PKey::PKey#sign_raw and PKey::PKey#verify_raw instead.
     def dsa_sign_asn1(data)
       sign_raw(nil, data)
-    rescue OpenSSL::PKey::PKeyError
-      raise OpenSSL::PKey::ECError, $!.message
     end
 
     # :call-seq:
@@ -293,8 +294,6 @@ module OpenSSL::PKey
     # Consider using PKey::PKey#sign_raw and PKey::PKey#verify_raw instead.
     def dsa_verify_asn1(data, sig)
       verify_raw(nil, sig, data)
-    rescue OpenSSL::PKey::PKeyError
-      raise OpenSSL::PKey::ECError, $!.message
     end
 
     # :call-seq:
@@ -333,6 +332,9 @@ module OpenSSL::PKey
     end
   end
   end
+
+  # Alias of PKeyError. Before version 4.0.0, this was a subclass of PKeyError.
+  RSAError = PKeyError
 
   class RSA
     include OpenSSL::Marshal
@@ -407,15 +409,11 @@ module OpenSSL::PKey
     # Consider using PKey::PKey#sign_raw and PKey::PKey#verify_raw, and
     # PKey::PKey#verify_recover instead.
     def private_encrypt(string, padding = PKCS1_PADDING)
-      n or raise OpenSSL::PKey::RSAError, "incomplete RSA"
-      private? or raise OpenSSL::PKey::RSAError, "private key needed."
-      begin
-        sign_raw(nil, string, {
-          "rsa_padding_mode" => translate_padding_mode(padding),
-        })
-      rescue OpenSSL::PKey::PKeyError
-        raise OpenSSL::PKey::RSAError, $!.message
-      end
+      n or raise PKeyError, "incomplete RSA"
+      private? or raise PKeyError, "private key needed."
+      sign_raw(nil, string, {
+        "rsa_padding_mode" => translate_padding_mode(padding),
+      })
     end
 
     # :call-seq:
@@ -430,14 +428,10 @@ module OpenSSL::PKey
     # Consider using PKey::PKey#sign_raw and PKey::PKey#verify_raw, and
     # PKey::PKey#verify_recover instead.
     def public_decrypt(string, padding = PKCS1_PADDING)
-      n or raise OpenSSL::PKey::RSAError, "incomplete RSA"
-      begin
-        verify_recover(nil, string, {
-          "rsa_padding_mode" => translate_padding_mode(padding),
-        })
-      rescue OpenSSL::PKey::PKeyError
-        raise OpenSSL::PKey::RSAError, $!.message
-      end
+      n or raise PKeyError, "incomplete RSA"
+      verify_recover(nil, string, {
+        "rsa_padding_mode" => translate_padding_mode(padding),
+      })
     end
 
     # :call-seq:
@@ -452,14 +446,10 @@ module OpenSSL::PKey
     # <b>Deprecated in version 3.0</b>.
     # Consider using PKey::PKey#encrypt and PKey::PKey#decrypt instead.
     def public_encrypt(data, padding = PKCS1_PADDING)
-      n or raise OpenSSL::PKey::RSAError, "incomplete RSA"
-      begin
-        encrypt(data, {
-          "rsa_padding_mode" => translate_padding_mode(padding),
-        })
-      rescue OpenSSL::PKey::PKeyError
-        raise OpenSSL::PKey::RSAError, $!.message
-      end
+      n or raise PKeyError, "incomplete RSA"
+      encrypt(data, {
+        "rsa_padding_mode" => translate_padding_mode(padding),
+      })
     end
 
     # :call-seq:
@@ -473,15 +463,11 @@ module OpenSSL::PKey
     # <b>Deprecated in version 3.0</b>.
     # Consider using PKey::PKey#encrypt and PKey::PKey#decrypt instead.
     def private_decrypt(data, padding = PKCS1_PADDING)
-      n or raise OpenSSL::PKey::RSAError, "incomplete RSA"
-      private? or raise OpenSSL::PKey::RSAError, "private key needed."
-      begin
-        decrypt(data, {
-          "rsa_padding_mode" => translate_padding_mode(padding),
-        })
-      rescue OpenSSL::PKey::PKeyError
-        raise OpenSSL::PKey::RSAError, $!.message
-      end
+      n or raise PKeyError, "incomplete RSA"
+      private? or raise PKeyError, "private key needed."
+      decrypt(data, {
+        "rsa_padding_mode" => translate_padding_mode(padding),
+      })
     end
 
     PKCS1_PADDING = 1
@@ -500,7 +486,7 @@ module OpenSSL::PKey
       when PKCS1_OAEP_PADDING
         "oaep"
       else
-        raise OpenSSL::PKey::PKeyError, "unsupported padding mode"
+        raise PKeyError, "unsupported padding mode"
       end
     end
   end

--- a/test/openssl/test_pkey.rb
+++ b/test/openssl/test_pkey.rb
@@ -209,4 +209,11 @@ class OpenSSL::TestPKey < OpenSSL::PKeyTestCase
     rsa = Fixtures.pkey("rsa1024")
     assert_include rsa.to_text, "publicExponent"
   end
+
+  def test_legacy_error_classes
+    assert_same(OpenSSL::PKey::PKeyError, OpenSSL::PKey::DSAError)
+    assert_same(OpenSSL::PKey::PKeyError, OpenSSL::PKey::DHError)
+    assert_same(OpenSSL::PKey::PKeyError, OpenSSL::PKey::ECError)
+    assert_same(OpenSSL::PKey::PKeyError, OpenSSL::PKey::RSAError)
+  end
 end

--- a/test/openssl/test_pkey_dh.rb
+++ b/test/openssl/test_pkey_dh.rb
@@ -121,7 +121,7 @@ class OpenSSL::TestPKeyDH < OpenSSL::PKeyTestCase
 
     # AWS-LC automatically does parameter checks on the parsed params.
     if aws_lc?
-      assert_raise(OpenSSL::PKey::DHError) {
+      assert_raise(OpenSSL::PKey::PKeyError) {
         OpenSSL::PKey::DH.new(OpenSSL::ASN1::Sequence([
           OpenSSL::ASN1::Integer(dh0.p + 1),
           OpenSSL::ASN1::Integer(dh0.g)

--- a/test/openssl/test_pkey_dsa.rb
+++ b/test/openssl/test_pkey_dsa.rb
@@ -92,7 +92,7 @@ class OpenSSL::TestPKeyDSA < OpenSSL::PKeyTestCase
     sig = key.syssign(digest)
     assert_equal true, key.sysverify(digest, sig)
     assert_equal false, key.sysverify(digest, invalid_sig)
-    assert_sign_verify_false_or_error{ key.sysverify(digest, malformed_sig) }
+    assert_sign_verify_false_or_error { key.sysverify(digest, malformed_sig) }
     assert_equal true, key.verify_raw(nil, sig, digest)
     assert_equal false, key.verify_raw(nil, invalid_sig, digest)
     assert_sign_verify_false_or_error { key.verify_raw(nil, malformed_sig, digest) }
@@ -163,7 +163,7 @@ class OpenSSL::TestPKeyDSA < OpenSSL::PKeyTestCase
     cipher = OpenSSL::Cipher.new("aes-128-cbc")
     exported = dsa512.to_pem(cipher, "abcdef\0\1")
     assert_same_dsa dsa512, OpenSSL::PKey::DSA.new(exported, "abcdef\0\1")
-    assert_raise(OpenSSL::PKey::DSAError) {
+    assert_raise(OpenSSL::PKey::PKeyError) {
       OpenSSL::PKey::DSA.new(exported, "abcdef")
     }
   end

--- a/test/openssl/test_pkey_ec.rb
+++ b/test/openssl/test_pkey_ec.rb
@@ -47,7 +47,9 @@ class OpenSSL::TestEC < OpenSSL::PKeyTestCase
   end
 
   def test_generate
-    assert_raise(OpenSSL::PKey::ECError) { OpenSSL::PKey::EC.generate("non-existent") }
+    assert_raise(OpenSSL::PKey::PKeyError) {
+      OpenSSL::PKey::EC.generate("non-existent")
+    }
     g = OpenSSL::PKey::EC::Group.new("prime256v1")
     ec = OpenSSL::PKey::EC.generate(g)
     assert_equal(true, ec.private?)
@@ -58,7 +60,7 @@ class OpenSSL::TestEC < OpenSSL::PKeyTestCase
   def test_generate_key
     ec = OpenSSL::PKey::EC.new("prime256v1")
     assert_equal false, ec.private?
-    assert_raise(OpenSSL::PKey::ECError) { ec.to_der }
+    assert_raise(OpenSSL::PKey::PKeyError) { ec.to_der }
     ec.generate_key!
     assert_equal true, ec.private?
     assert_nothing_raised { ec.to_der }
@@ -100,13 +102,13 @@ class OpenSSL::TestEC < OpenSSL::PKeyTestCase
       assert_raise(OpenSSL::PKey::PKeyError) { OpenSSL::PKey.read(ec_key_data) }
     else
       key4 = OpenSSL::PKey.read(ec_key_data)
-      assert_raise(OpenSSL::PKey::ECError) { key4.check_key }
+      assert_raise(OpenSSL::PKey::PKeyError) { key4.check_key }
     end
 
     # EC#private_key= is deprecated in 3.0 and won't work on OpenSSL 3.0
     if !openssl?(3, 0, 0)
       key2.private_key += 1
-      assert_raise(OpenSSL::PKey::ECError) { key2.check_key }
+      assert_raise(OpenSSL::PKey::PKeyError) { key2.check_key }
     end
   end
 
@@ -260,7 +262,7 @@ class OpenSSL::TestEC < OpenSSL::PKeyTestCase
     cipher = OpenSSL::Cipher.new("aes-128-cbc")
     exported = p256.to_pem(cipher, "abcdef\0\1")
     assert_same_ec p256, OpenSSL::PKey::EC.new(exported, "abcdef\0\1")
-    assert_raise(OpenSSL::PKey::ECError) {
+    assert_raise(OpenSSL::PKey::PKeyError) {
       OpenSSL::PKey::EC.new(exported, "abcdef")
     }
   end

--- a/test/openssl/test_pkey_rsa.rb
+++ b/test/openssl/test_pkey_rsa.rb
@@ -9,8 +9,8 @@ class OpenSSL::TestPKeyRSA < OpenSSL::PKeyTestCase
     rsa = Fixtures.pkey("rsa2048")
     key.set_key(rsa.n, rsa.e, nil)
     key.set_factors(rsa.p, rsa.q)
-    assert_raise(OpenSSL::PKey::RSAError){ key.private_encrypt("foo") }
-    assert_raise(OpenSSL::PKey::RSAError){ key.private_decrypt("foo") }
+    assert_raise(OpenSSL::PKey::PKeyError){ key.private_encrypt("foo") }
+    assert_raise(OpenSSL::PKey::PKeyError){ key.private_decrypt("foo") }
   end if !openssl?(3, 0, 0) # Impossible state in OpenSSL 3.0
 
   def test_private
@@ -172,7 +172,7 @@ class OpenSSL::TestPKeyRSA < OpenSSL::PKeyTestCase
     # Failure cases
     assert_raise(ArgumentError){ key.private_encrypt() }
     assert_raise(ArgumentError){ key.private_encrypt("hi", 1, nil) }
-    assert_raise(OpenSSL::PKey::RSAError){ key.private_encrypt(plain0, 666) }
+    assert_raise(OpenSSL::PKey::PKeyError){ key.private_encrypt(plain0, 666) }
   end
 
 
@@ -223,7 +223,7 @@ class OpenSSL::TestPKeyRSA < OpenSSL::PKeyTestCase
         key.verify_pss("SHA256", signature, data, salt_length: :auto, mgf1_hash: "SHA256")
     end
 
-    assert_raise(OpenSSL::PKey::RSAError) {
+    assert_raise(OpenSSL::PKey::PKeyError) {
       key.sign_pss("SHA256", data, salt_length: 223, mgf1_hash: "SHA256")
     }
   end
@@ -411,7 +411,7 @@ class OpenSSL::TestPKeyRSA < OpenSSL::PKeyTestCase
     cipher = OpenSSL::Cipher.new("aes-128-cbc")
     exported = rsa1024.to_pem(cipher, "abcdef\0\1")
     assert_same_rsa rsa1024, OpenSSL::PKey::RSA.new(exported, "abcdef\0\1")
-    assert_raise(OpenSSL::PKey::RSAError) {
+    assert_raise(OpenSSL::PKey::PKeyError) {
       OpenSSL::PKey::RSA.new(exported, "abcdef")
     }
   end


### PR DESCRIPTION
Remove the following subclasses of `OpenSSL::PKey::PKeyError` and make them aliases of it.

 - `OpenSSL::PKey::DHError`
 - `OpenSSL::PKey::DSAError`
 - `OpenSSL::PKey::ECError`
 - `OpenSSL::PKey::RSAError`

Historically, methods defined on `OpenSSL::PKey` and `OpenSSL::PKey::PKey` raise `OpenSSL::PKey::PKeyError`, while methods on the subclasses raise their respective exception classes. However, this distinction is not particularly useful since all those exception classes represent the same kind of errors from the underlying `EVP_PKEY` API.

I think this convention comes from the fact that `OpenSSL::PKey::{DH, DSA,RSA}` originally wrapped the corresponding OpenSSL structs `DH`, `DSA`, and `RSA`, before they were unified to wrap `EVP_PKEY`, way back in 2002.

`OpenSSL::PKey::EC::Group::Error` and `OpenSSL::PKey::EC::Point::Error` are out of scope of this change, as they are not subclasses of `OpenSSL::PKey::PKeyError` and do not represent errors from the `EVP_PKEY` API.