### PR TITLE
pkey: skip tests using invalid keys in the FIPS mode

### DIFF
--- a/test/openssl/test_pkey_dh.rb
+++ b/test/openssl/test_pkey_dh.rb
@@ -103,6 +103,8 @@ class OpenSSL::TestPKeyDH < OpenSSL::PKeyTestCase
   end if !openssl?(3, 0, 0)
 
   def test_params_ok?
+    omit_on_fips
+
     # Skip the tests in old OpenSSL version 1.1.1c or early versions before
     # applying the following commits in OpenSSL 1.1.1d to make `DH_check`
     # function pass the RFC 7919 FFDHE group texts.

--- a/test/openssl/test_pkey_ec.rb
+++ b/test/openssl/test_pkey_ec.rb
@@ -72,6 +72,8 @@ class OpenSSL::TestEC < OpenSSL::PKeyTestCase
   end
 
   def test_check_key
+    omit_on_fips
+
     key0 = Fixtures.pkey("p256")
     assert_equal(true, key0.check_key)
     assert_equal(true, key0.private?)


### PR DESCRIPTION
In OpenSSL's master branch, importing/loading a key in the FIPS mode automatically performs a pair-wise consistency check. This breaks tests for `OpenSSL::PKey::EC#check_key` and `DH#params_ok?` as they use deliberately invalid keys. These methods would not be useful in the FIPS mode anyway.

Fixes: https://github.com/ruby/openssl/issues/926