### PR TITLE
pkey: fix repeated passphrase prompts in OpenSSL::PKey.read

### DIFF
--- a/test/openssl/test_pkey.rb
+++ b/test/openssl/test_pkey.rb
@@ -124,6 +124,17 @@ class OpenSSL::TestPKey < OpenSSL::PKeyTestCase
       }
     }
     assert_equal(1, called)
+
+    # Incorrect passphrase returned by the block. The input contains two PEM
+    # blocks.
+    called = 0
+    assert_raise(OpenSSL::PKey::PKeyError) {
+      OpenSSL::PKey.read(encrypted_pem + encrypted_pem) {
+        called += 1
+        "incorrect_passphrase"
+      }
+    }
+    assert_equal(1, called)
   end
 
   def test_s_read_passphrase_tty


### PR DESCRIPTION
This PR fixes two issues shown in https://github.com/ruby/openssl/issues/927, which affects OpenSSL 3.0 or later.

---
**pkey: add more tests for OpenSSL::PKey.read**

Add tests covering edge cases in the current behavior to prevent accidental regressions. The next patches will update the OpenSSL 3.x path.

---
**pkey: pass pem_password_cb to OSSL_DECODER only when it is needed**

Specify `OSSL_DECODER_CTX_set_pem_password_cb()` only when we expect a passphrase-protected private key.

`OSSL_DECODER` appears to try to decrypt every PEM block in the input even when the PEM header does not match the requested selection. This can cause repeated prompts for a passphrase in a single `OpenSSL::PKey.read` call.

---
**pkey: stop retrying after non-retryable error from OSSL_DECODER**

Continue processing only when `OSSL_DECODER_from_bio()` returns the error code `ERR_R_UNSUPPORTED`. Otherwise, raise an exception without retrying decoding the input in another format.

This fixes another case where `OpenSSL::PKey.read` prompts for a passphrase multiple times when the input contains more than one passphrase-protected PEM blocks and the first one cannot be decoded.

I am not entirely sure if error code `ERR_R_UNSUPPORTED` is considered part of the public interface of OpenSSL, but this seems to be the only option available and is the approach used internally by the `PEM_read_bio_*()` functions.

---

Fixes https://github.com/ruby/openssl/issues/927

