### PR TITLE
Add missing write barriers in X509

### DIFF
--- a/ext/openssl/ossl_x509store.c
+++ b/ext/openssl/ossl_x509store.c
@@ -191,8 +191,8 @@ ossl_x509store_set_vfy_cb(VALUE self, VALUE cb)
 
     GetX509Store(self, store);
     rb_iv_set(self, "@verify_callback", cb);
-    // We don't need to trigger a write barrier because `rb_iv_set` did it.
     X509_STORE_set_ex_data(store, store_ex_verify_cb_idx, (void *)cb);
+    RB_OBJ_WRITTEN(self, Qundef, cb);
 
     return cb;
 }
@@ -611,6 +611,7 @@ ossl_x509stctx_verify(VALUE self)
     GetX509StCtx(self, ctx);
     VALUE cb = rb_iv_get(self, "@verify_callback");
     X509_STORE_CTX_set_ex_data(ctx, stctx_ex_verify_cb_idx, (void *)cb);
+    RB_OBJ_WRITTEN(self, Qundef, cb);
 
     switch (X509_verify_cert(ctx)) {
       case 1:


### PR DESCRIPTION
Both the X509 store and X509 store context were missing write barriers. To the callback object being stored in the ex data.

These values were also being stored as an IV, however in Ruby HEAD we're now storing the IVs for T_DATA (generic IVs) on a separate object. So we need an additional write barrier if we're marking it from this object.

I believe this was always necessary, because we could have done incremental marking ahead of compaction, and without the write barrier the mark function could have been run before @verify_callback was assigned.

This was detected by [wbcheck](https://github.com/ruby/ruby/pull/13557)