### PR TITLE
WIP: Fix test_ssl.rb in FIPS.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -34,7 +34,6 @@ Rake::TestTask.new(:test_fips_internal) do |t|
     'test/openssl/test_ns_spki.rb',
     'test/openssl/test_ocsp.rb',
     'test/openssl/test_pkcs12.rb',
-    'test/openssl/test_ssl.rb',
     'test/openssl/test_ts.rb',
     'test/openssl/test_x509cert.rb',
     'test/openssl/test_x509crl.rb',


### PR DESCRIPTION
This PR is working in progress. Right now there are 4 test failures below on the OpenSSL FIPS cases.

https://github.com/junaruga/ruby-openssl/actions/runs/17331123966/job/49207153277#step:11:419

```
$ OPENSSL_CONF=$OPENSSL_DIR/ssl/openssl_fips.cnf \
  bundle exec rake debug test_fips TEST=test/openssl/test_ssl.rb
...
F
===============================================================================
Failure: test_get_ephemeral_key(OpenSSL::TestSSL):
  exceptions on 1 threads:
  #<Thread:0x00007fc06e32d6e8 /home/jaruga/var/git/ruby/openssl/test/openssl/utils.rb:251 dead>:
  /home/jaruga/var/git/ruby/openssl/test/openssl/test_ssl.rb:2321:in 'OpenSSL::SSL::SSLSocket#connect': SSL_connect returned=1 errno=0 peeraddr=127.0.0.1:45383 state=error: EVP lib (OpenSSL::SSL::SSLError)
  	from /home/jaruga/var/git/ruby/openssl/test/openssl/test_ssl.rb:2321:in 'OpenSSL::TestSSL#server_connect'
  	from /home/jaruga/var/git/ruby/openssl/test/openssl/test_ssl.rb:1760:in 'block in OpenSSL::TestSSL#test_get_ephemeral_key'
  	from /home/jaruga/var/git/ruby/openssl/test/openssl/utils.rb:255:in 'block (2 levels) in OpenSSL::SSLTestCase#start_server'
/home/jaruga/var/git/ruby/openssl/bundle/ruby/3.5.0+2/gems/test-unit-ruby-core-1.0.7/lib/core_assertions.rb:762:in 'Test::Unit::CoreAssertions#assert_join_threads'
/home/jaruga/var/git/ruby/openssl/test/openssl/utils.rb:277:in 'block in OpenSSL::SSLTestCase#start_server'
/home/jaruga/var/git/ruby/openssl/test/openssl/utils.rb:203:in 'IO.pipe'
/home/jaruga/var/git/ruby/openssl/test/openssl/utils.rb:203:in 'OpenSSL::SSLTestCase#start_server'
/home/jaruga/var/git/ruby/openssl/test/openssl/test_ssl.rb:1755:in 'OpenSSL::TestSSL#test_get_ephemeral_key'
     1752:       ctx.max_version = OpenSSL::SSL::TLS1_2_VERSION
     1753:       ctx.ciphers = "kRSA"
     1754:     }
  => 1755:     start_server(ctx_proc: ctx_proc1, ignore_listener_error: true) do |port|
     1756:       ctx = OpenSSL::SSL::SSLContext.new
     1757:       ctx.max_version = OpenSSL::SSL::TLS1_2_VERSION
     1758:       ctx.ciphers = "kRSA"
===============================================================================
F
===============================================================================
Failure: test_post_connect_check_with_anon_ciphers(OpenSSL::TestSSL):
  exceptions on 1 threads:
  #<Thread:0x00007fc06e246720 /home/jaruga/var/git/ruby/openssl/test/openssl/utils.rb:251 dead>:
  /home/jaruga/var/git/ruby/openssl/lib/openssl/ssl.rb:551:in 'OpenSSL::SSL::SSLSocket#accept': SSL_accept returned=1 errno=0 peeraddr=127.0.0.1:33730 state=error: internal error (OpenSSL::SSL::SSLError)
  	from /home/jaruga/var/git/ruby/openssl/lib/openssl/ssl.rb:551:in 'OpenSSL::SSL::SSLServer#accept'
  	from /home/jaruga/var/git/ruby/openssl/test/openssl/utils.rb:226:in 'block (3 levels) in OpenSSL::SSLTestCase#start_server'
  	from <internal:kernel>:168:in 'Kernel#loop'
  	from /home/jaruga/var/git/ruby/openssl/test/openssl/utils.rb:222:in 'block (2 levels) in OpenSSL::SSLTestCase#start_server'
  /home/jaruga/var/git/ruby/openssl/test/openssl/test_ssl.rb:2321:in 'OpenSSL::SSL::SSLSocket#connect': SSL_connect returned=1 errno=0 peeraddr=127.0.0.1:34315 state=error: tlsv1 alert internal error (SSL alert number 80) (OpenSSL::SSL::SSLError)
  	from /home/jaruga/var/git/ruby/openssl/test/openssl/test_ssl.rb:2321:in 'OpenSSL::TestSSL#server_connect'
  	from /home/jaruga/var/git/ruby/openssl/test/openssl/test_ssl.rb:702:in 'block in OpenSSL::TestSSL#test_post_connect_check_with_anon_ciphers'
  	from /home/jaruga/var/git/ruby/openssl/test/openssl/utils.rb:255:in 'block (2 levels) in OpenSSL::SSLTestCase#start_server'
/home/jaruga/var/git/ruby/openssl/bundle/ruby/3.5.0+2/gems/test-unit-ruby-core-1.0.7/lib/core_assertions.rb:762:in 'Test::Unit::CoreAssertions#assert_join_threads'
/home/jaruga/var/git/ruby/openssl/test/openssl/utils.rb:277:in 'block in OpenSSL::SSLTestCase#start_server'
/home/jaruga/var/git/ruby/openssl/test/openssl/utils.rb:203:in 'IO.pipe'
/home/jaruga/var/git/ruby/openssl/test/openssl/utils.rb:203:in 'OpenSSL::SSLTestCase#start_server'
/home/jaruga/var/git/ruby/openssl/test/openssl/test_ssl.rb:697:in 'OpenSSL::TestSSL#test_post_connect_check_with_anon_ciphers'
     694:       ctx.security_level = 0
     695:     }
     696:
  => 697:     start_server(ctx_proc: ctx_proc) { |port|
     698:       ctx = OpenSSL::SSL::SSLContext.new
     699:       ctx.max_version = OpenSSL::SSL::TLS1_2_VERSION
     700:       ctx.ciphers = "aNULL"
===============================================================================
F
===============================================================================
Failure: test_tmp_dh(OpenSSL::TestSSL):
  exceptions on 1 threads:
  #<Thread:0x00007fc06d3c2460 /home/jaruga/var/git/ruby/openssl/test/openssl/utils.rb:251 dead>:
  /home/jaruga/var/git/ruby/openssl/lib/openssl/ssl.rb:551:in 'OpenSSL::SSL::SSLSocket#accept': SSL_accept returned=1 errno=0 peeraddr=127.0.0.1:58706 state=error: internal error (OpenSSL::SSL::SSLError)
  	from /home/jaruga/var/git/ruby/openssl/lib/openssl/ssl.rb:551:in 'OpenSSL::SSL::SSLServer#accept'
  	from /home/jaruga/var/git/ruby/openssl/test/openssl/utils.rb:226:in 'block (3 levels) in OpenSSL::SSLTestCase#start_server'
  	from <internal:kernel>:168:in 'Kernel#loop'
  	from /home/jaruga/var/git/ruby/openssl/test/openssl/utils.rb:222:in 'block (2 levels) in OpenSSL::SSLTestCase#start_server'
  /home/jaruga/var/git/ruby/openssl/test/openssl/test_ssl.rb:2321:in 'OpenSSL::SSL::SSLSocket#connect': SSL_connect returned=1 errno=0 peeraddr=127.0.0.1:33911 state=error: tlsv1 alert internal error (SSL alert number 80) (OpenSSL::SSL::SSLError)
  	from /home/jaruga/var/git/ruby/openssl/test/openssl/test_ssl.rb:2321:in 'OpenSSL::TestSSL#server_connect'
  	from /home/jaruga/var/git/ruby/openssl/test/openssl/test_ssl.rb:2143:in 'block in OpenSSL::TestSSL#test_tmp_dh'
  	from /home/jaruga/var/git/ruby/openssl/test/openssl/utils.rb:255:in 'block (2 levels) in OpenSSL::SSLTestCase#start_server'
/home/jaruga/var/git/ruby/openssl/bundle/ruby/3.5.0+2/gems/test-unit-ruby-core-1.0.7/lib/core_assertions.rb:762:in 'Test::Unit::CoreAssertions#assert_join_threads'
/home/jaruga/var/git/ruby/openssl/test/openssl/utils.rb:277:in 'block in OpenSSL::SSLTestCase#start_server'
/home/jaruga/var/git/ruby/openssl/test/openssl/utils.rb:203:in 'IO.pipe'
/home/jaruga/var/git/ruby/openssl/test/openssl/utils.rb:203:in 'OpenSSL::SSLTestCase#start_server'
/home/jaruga/var/git/ruby/openssl/test/openssl/test_ssl.rb:2142:in 'OpenSSL::TestSSL#test_tmp_dh'
     2139:       ctx.ciphers = "DH:!NULL" # use DH
     2140:       ctx.tmp_dh = dh
     2141:     }
  => 2142:     start_server(ctx_proc: ctx_proc) do |port|
     2143:       server_connect(port) { |ssl|
     2144:         assert_equal dh.to_der, ssl.tmp_key.to_der
     2145:       }
===============================================================================
F
===============================================================================
Failure: test_tmp_dh_callback(OpenSSL::TestSSL):
  exceptions on 1 threads:
  #<Thread:0x00007fc06d330740 /home/jaruga/var/git/ruby/openssl/test/openssl/utils.rb:251 dead>:
  /home/jaruga/var/git/ruby/openssl/lib/openssl/ssl.rb:551:in 'OpenSSL::SSL::SSLSocket#accept': SSL_accept returned=1 errno=0 peeraddr=127.0.0.1:55890 state=error: internal error (OpenSSL::SSL::SSLError)
  	from /home/jaruga/var/git/ruby/openssl/lib/openssl/ssl.rb:551:in 'OpenSSL::SSL::SSLServer#accept'
  	from /home/jaruga/var/git/ruby/openssl/test/openssl/utils.rb:226:in 'block (3 levels) in OpenSSL::SSLTestCase#start_server'
  	from <internal:kernel>:168:in 'Kernel#loop'
  	from /home/jaruga/var/git/ruby/openssl/test/openssl/utils.rb:222:in 'block (2 levels) in OpenSSL::SSLTestCase#start_server'
  /home/jaruga/var/git/ruby/openssl/test/openssl/test_ssl.rb:2321:in 'OpenSSL::SSL::SSLSocket#connect': SSL_connect returned=1 errno=0 peeraddr=127.0.0.1:45871 state=error: tlsv1 alert internal error (SSL alert number 80) (OpenSSL::SSL::SSLError)
  	from /home/jaruga/var/git/ruby/openssl/test/openssl/test_ssl.rb:2321:in 'OpenSSL::TestSSL#server_connect'
  	from /home/jaruga/var/git/ruby/openssl/test/openssl/test_ssl.rb:1879:in 'block in OpenSSL::TestSSL#test_tmp_dh_callback'
  	from /home/jaruga/var/git/ruby/openssl/test/openssl/utils.rb:255:in 'block (2 levels) in OpenSSL::SSLTestCase#start_server'
/home/jaruga/var/git/ruby/openssl/bundle/ruby/3.5.0+2/gems/test-unit-ruby-core-1.0.7/lib/core_assertions.rb:762:in 'Test::Unit::CoreAssertions#assert_join_threads'
/home/jaruga/var/git/ruby/openssl/test/openssl/utils.rb:277:in 'block in OpenSSL::SSLTestCase#start_server'
/home/jaruga/var/git/ruby/openssl/test/openssl/utils.rb:203:in 'IO.pipe'
/home/jaruga/var/git/ruby/openssl/test/openssl/utils.rb:203:in 'OpenSSL::SSLTestCase#start_server'
/home/jaruga/var/git/ruby/openssl/test/openssl/test_ssl.rb:1878:in 'OpenSSL::TestSSL#test_tmp_dh_callback'
     1875:         dh
     1876:       }
     1877:     }
  => 1878:     start_server(ctx_proc: ctx_proc) do |port|
     1879:       server_connect(port) { |ssl|
     1880:         assert called, "dh callback should be called"
     1881:         assert_equal dh.to_der, ssl.tmp_key.to_der
===============================================================================
Finished in 11.583246314 seconds.
-------------------------------------------------------------------------------
88 tests, 559 assertions, 4 failures, 0 errors, 0 pendings, 1 omissions, 0 notifications
95.4023% passed
-------------------------------------------------------------------------------
...
```

I am debugging ruby openssl's latest master branch on the OpenSSL relatively latest commit openssl/openssl@0b091c88d7d50c542ee393ed31ef5a1b92eea476.

The cause of the 4 test failures looks similar. For example, the failure of the `test_post_connect_check_with_anon_ciphers` happened at the https://github.com/ruby/openssl/blob/d377a3424c7a95ee00cbd459b90855d6f00a904d/test/openssl/test_ssl.rb#L2321 (`SSLSocket#connect`).

```
$ OPENSSL_CONF=$OPENSSL_DIR/ssl/openssl_fips.cnf \
  ruby -I ./lib test/openssl/test_ssl.rb \
  -v --name=test_post_connect_check_with_anon_ciphers
```

I debugged the issue on gdb like this.

```
$ gdb --args \
  ruby -I ./lib test/openssl/test_ssl.rb \
  -v --name=test_post_connect_check_with_anon_ciphers
(gdb) set environment OPENSSL_CONF=/home/jaruga/.local/openssl-3.6.0-dev-fips-debug-0b091c88d7/ssl/openssl_fips.cnf
(gdb) b ossl_ssl_connect
(gdb) b SSL_connect
```

Then I found the following line is a part of the happening error.

https://github.com/openssl/openssl/blob/0b091c88d7d50c542ee393ed31ef5a1b92eea476/ssl/statem/statem.c#L489

```
(gdb) f
#0  state_machine (s=0x7fffc000b640, server=0) at ssl/statem/statem.c:489
489>                goto end;
```

This is the backtrace.

```
(gdb) bt
#0  state_machine (s=0x7fffc000b640, server=0) at ssl/statem/statem.c:489
#1  0x00007fffce314187 in ossl_statem_connect (s=0x7fffc000b640) at ssl/statem/statem.c:301
#2  0x00007fffce277794 in SSL_do_handshake (s=0x7fffc000b640) at ssl/ssl_lib.c:5014
#3  0x00007fffce270e03 in SSL_connect (s=0x7fffc000b640) at ssl/ssl_lib.c:2250
#4  0x00007fffce3d9551 in ossl_start_ssl (self=140736638532320, func=0x7fffce270d49 <SSL_connect>, funcname=0x7fffce406f95 "SSL_connect", opts=0) at ../../../../ext/openssl/ossl_ssl.c:1790
#5  0x00007fffce3d97c8 in ossl_ssl_connect (self=140736638532320) at ../../../../ext/openssl/ossl_ssl.c:1864
#6  0x00007ffff7ae7c92 in ractor_safe_call_cfunc_0 (recv=140736638532320, argc=0, argv=0x7fffcc9ac0b0, func=0x7fffce3d978e <ossl_ssl_connect>) at vm_insnhelper.c:3587
#7  0x00007ffff7ae885b in vm_call_cfunc_with_frame_ (ec=0xd0b030, reg_cfp=0x7fffccaabf30, calling=0x7fffcc9a99e0, argc=0, argv=0x7fffcc9ac0b0, stack_bottom=0x7fffcc9ac0a8) at vm_insnhelper.c:3771
#8  0x00007ffff7ae8ac4 in vm_call_cfunc_with_frame (ec=0xd0b030, reg_cfp=0x7fffccaabf30, calling=0x7fffcc9a99e0) at vm_insnhelper.c:3817
#9  0x00007ffff7ae8bed in vm_call_cfunc_other (ec=0xd0b030, reg_cfp=0x7fffccaabf30, calling=0x7fffcc9a99e0) at vm_insnhelper.c:3843
#10 0x00007ffff7ae9028 in vm_call_cfunc (ec=0xd0b030, reg_cfp=0x7fffccaabf30, calling=0x7fffcc9a99e0) at vm_insnhelper.c:3925
#11 0x00007ffff7aebc13 in vm_call_method_each_type (ec=0xd0b030, cfp=0x7fffccaabf30, calling=0x7fffcc9a99e0) at vm_insnhelper.c:4750
#12 0x00007ffff7aec6c7 in vm_call_method (ec=0xd0b030, cfp=0x7fffccaabf30, calling=0x7fffcc9a99e0) at vm_insnhelper.c:4876
#13 0x00007ffff7aec8c5 in vm_call_general (ec=0xd0b030, reg_cfp=0x7fffccaabf30, calling=0x7fffcc9a99e0) at vm_insnhelper.c:4920
#14 0x00007ffff7aef00b in vm_sendish (ec=0xd0b030, reg_cfp=0x7fffccaabf30, cd=0x812770, block_handler=0, method_explorer=mexp_search_method) at vm_insnhelper.c:5969
#15 0x00007ffff7af6b6e in vm_exec_core (ec=0xd0b030) at insns.def:899
#16 0x00007ffff7b0ef92 in rb_vm_exec (ec=0xd0b030) at vm.c:2625
#17 0x00007ffff7b0c2c9 in invoke_iseq_block_from_c (ec=0xd0b030, captured=0xd05c10, self=140736651740080, argc=0, argv=0x7fffcc9aaa20, kw_splat=0, passed_block_handler=0, cref=0x0, is_lambda=0, me=0x0) at vm.c:1655
#18 invoke_block_from_c_proc (ec=0xd0b030, proc=0xd05c10, self=140736651740080, argc=0, argv=0x7fffcc9aaa20, kw_splat=0, passed_block_handler=0, is_lambda=0, me=0x0) at vm.c:1749
#19 vm_invoke_proc (ec=0xd0b030, proc=0xd05c10, self=140736651740080, argc=0, argv=0x7fffcc9aaa20, kw_splat=0, passed_block_handler=0) at vm.c:1779
#20 0x00007ffff7b0ca37 in rb_vm_invoke_proc (ec=0xd0b030, proc=0xd05c10, argc=0, argv=0x7fffcc9aaa20, kw_splat=0, passed_block_handler=0) at vm.c:1800
#21 0x00007ffff7a9d62f in thread_do_start_proc (th=0x72fc10) at thread.c:604
#22 0x00007ffff7a9d6a0 in thread_do_start (th=0x72fc10) at thread.c:621
#23 0x00007ffff7a9d98d in thread_start_func_2 (th=0x72fc10, stack_start=0x7fffcc9aabe8) at thread.c:676
#24 0x00007ffff7a96eb5 in call_thread_start_func_2 (th=0x72fc10) at thread_pthread.c:2218
#25 0x00007ffff7a96fd5 in nt_start (ptr=0xd069c0) at thread_pthread.c:2263
#26 0x00007ffff767f1d4 in start_thread (arg=<optimized out>) at pthread_create.c:448
#27 0x00007ffff7701cec in __GI___clone3 () at ../sysdeps/unix/sysv/linux/x86_64/clone3.S:78
```

I need to debug more. But I assume the error in the connection process just is happening in the FIPS specific part, of course. What do you think about how to fix this failure?

