### PR TITLE
c_rehash: fix hash_name output for small hashes

### DIFF
--- a/sample/c_rehash.rb
+++ b/sample/c_rehash.rb
@@ -156,7 +156,7 @@ private
   end
 
   def hash_name(name)
-    sprintf("%x", name.hash)
+    sprintf("%08x", name.hash)
   end
 
   def fingerprint(der)


### PR DESCRIPTION
The hash lookup is done by 8-character hash.