### PR TITLE
CONTRIBUTING.md: Add Debugging section [ci skip]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -224,6 +224,9 @@ $ OPENSSL_CONF=$OPENSSL_DIR/ssl/openssl_fips.cnf \
 The GitHub Actions workflow file [`test.yml`][GitHub test.yml] contains useful
 information for building OpenSSL/LibreSSL and testing against them.
 
+## Debugging
+
+You can use the `OpenSSL.debug = true` to print additional error strings.
 
 ## Relation with Ruby source tree
 


### PR DESCRIPTION
I would like to add the Debugging section to explain about the `OpenSSL.debug = true` in the `CONTRIBUTING.md`. I see the option is effective to debug.
