### PR TITLE
CI: Upgrade OpenSSL and LibreSSL versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,21 +101,22 @@ jobs:
         openssl:
           # https://openssl-library.org/source/
           - openssl-1.1.1w # EOL 2023-09-11, still used by RHEL 8 and Ubuntu 20.04
-          - openssl-3.0.16 # Supported until 2026-09-07 (LTS)
+          - openssl-3.0.18 # Supported until 2026-09-07 (LTS)
           - openssl-3.1.8 # EOL 2025-03-14
-          - openssl-3.2.4 # Supported until 2025-11-23
-          - openssl-3.3.3 # Supported until 2026-04-09
-          - openssl-3.4.1 # Supported until 2026-10-22
-          - openssl-3.5.0 # Supported until 2030 (LTS)
+          - openssl-3.2.6 # Supported until 2025-11-23
+          - openssl-3.3.5 # Supported until 2026-04-09
+          - openssl-3.4.3 # Supported until 2026-10-22
+          - openssl-3.5.4 # Supported until 2030 (LTS)
+          - openssl-3.6.0 # EOL TBD
           - openssl-master
           # http://www.libressl.org/releases.html
           - libressl-3.9.2 # EOL 2025-04-05
-          - libressl-4.0.0 # Supported until 2025-10-08
-          - libressl-4.1.0 # Supported until 2026-04-28
+          - libressl-4.0.1 # Supported until 2025-10-08
+          - libressl-4.1.1 # Supported until 2026-04-28
           # https://github.com/aws/aws-lc/tags
           - aws-lc-latest
         include:
-          - { name-extra: 'without legacy provider', openssl: openssl-3.5.0, append-configure: 'no-legacy' }
+          - { name-extra: 'without legacy provider', openssl: openssl-3.5.4, append-configure: 'no-legacy' }
           - { openssl: aws-lc-latest, skip-warnings: true }
     steps:
       - name: repo checkout


### PR DESCRIPTION
This PR is to upgrade OpenSSL and LibreSSL versions. The PR adds OpenSSL 3.6.0.

I checked the following pages to check the latest versions, and also checked the openssl/openssl's tags to confirm the OpenSSL 3.1.8 was the latest version of the OpenSSL 3.1 series.

* https://openssl-library.org/source/
* http://www.libressl.org/releases.html


