### PR TITLE
ssl: remove OpenSSL::X509::V_FLAG_CRL_CHECK_ALL from the default store

### DIFF
--- a/lib/openssl/ssl.rb
+++ b/lib/openssl/ssl.rb
@@ -92,7 +92,6 @@ YoaOffgTf5qxiwkjnlVZQc3whgnEt9FpVMvQ9eknyeGB5KHfayAc3+hUAvI3/Cr3
 
       DEFAULT_CERT_STORE = OpenSSL::X509::Store.new # :nodoc:
       DEFAULT_CERT_STORE.set_default_paths
-      DEFAULT_CERT_STORE.flags = OpenSSL::X509::V_FLAG_CRL_CHECK_ALL
 
       # A callback invoked when DH parameters are required for ephemeral DH key
       # exchange.


### PR DESCRIPTION
With OpenSSL 3.6.0, it causes nearly every certificate verification to fail with the message `certificate verify failed (unable to get certificate CRL)` because the CRLs are typically unavailable in the default store used by `OpenSSL::SSL::SSLContext#set_params`.

`OpenSSL::X509::V_FLAG_CRL_CHECK_ALL` is a flag that extends the CRL checking to all certificates in the chain. In OpenSSL < 3.6.0, the flag alone has no effect, and `OpenSSL::X509::V_FLAG_CRL_CHECK` must also be set to enable CRL checking.

In OpenSSL 3.6.0, `OpenSSL::X509::V_FLAG_CRL_CHECK_ALL` now implies `OpenSSL::X509::V_FLAG_CRL_CHECK`. This is inconsistent with the man page and may be fixed in a future OpenSSL 3.6.x release, but this flag is not needed and should not be set by default.

Fixes https://github.com/ruby/openssl/issues/949