### PR TITLE
Update link to OpenSSL configuration file docs

### DIFF
--- a/ext/openssl/ossl_config.c
+++ b/ext/openssl/ossl_config.c
@@ -426,7 +426,7 @@ Init_ossl_config(void)
      * configuration. See the value of OpenSSL::Config::DEFAULT_CONFIG_FILE for
      * the location of the file for your host.
      *
-     * See also http://www.openssl.org/docs/apps/config.html
+     * See also https://docs.openssl.org/master/man5/config/
      */
     cConfig = rb_define_class_under(mOSSL, "Config", rb_cObject);
 


### PR DESCRIPTION
The link to the OpenSSL configuration file documentation just redirects to https://docs.openssl.org/master/

This PR updates the link to the new location: https://docs.openssl.org/master/man5/config/