### PR TITLE
Check NULL values for deprecated EVP_PKEY_get0() functions

### DIFF
--- a/ext/openssl/ossl_pkey_dh.c
+++ b/ext/openssl/ossl_pkey_dh.c
@@ -21,6 +21,8 @@
     EVP_PKEY *_pkey; \
     GetPKeyDH((obj), _pkey); \
     (dh) = EVP_PKEY_get0_DH(_pkey); \
+    if ((dh) == NULL) \
+        ossl_raise(eDHError, "failed to get DH from EVP_PKEY"); \
 } while (0)
 
 /*

--- a/ext/openssl/ossl_pkey_dsa.c
+++ b/ext/openssl/ossl_pkey_dsa.c
@@ -21,6 +21,8 @@
     EVP_PKEY *_pkey; \
     GetPKeyDSA((obj), _pkey); \
     (dsa) = EVP_PKEY_get0_DSA(_pkey); \
+    if ((dsa) == NULL) \
+        ossl_raise(eDSAError, "failed to get DSA from EVP_PKEY"); \
 } while (0)
 
 static inline int

--- a/ext/openssl/ossl_pkey_ec.c
+++ b/ext/openssl/ossl_pkey_ec.c
@@ -22,6 +22,8 @@ static const rb_data_type_t ossl_ec_point_type;
     EVP_PKEY *_pkey; \
     GetPKeyEC(obj, _pkey); \
     (key) = EVP_PKEY_get0_EC_KEY(_pkey); \
+    if ((key) == NULL) \
+        ossl_raise(eECError, "failed to get EC_KEY from EVP_PKEY"); \
 } while (0)
 
 #define GetECGroup(obj, group) do { \

--- a/ext/openssl/ossl_pkey_rsa.c
+++ b/ext/openssl/ossl_pkey_rsa.c
@@ -21,6 +21,8 @@
     EVP_PKEY *_pkey; \
     GetPKeyRSA((obj), _pkey); \
     (rsa) = EVP_PKEY_get0_RSA(_pkey); \
+    if ((rsa) == NULL) \
+        ossl_raise(eRSAError, "failed to get RSA from EVP_PKEY"); \
 } while (0)
 
 static inline int


### PR DESCRIPTION
In OpenSSL <= 1.1.1, EVP_PKEY_get0() always returned a valid object, so a NULL check was not necessary. In OpenSSL 3.0, the function can return NULL (https://docs.openssl.org/3.0/man7/migration_guide/#deprecated-function-mappings), so guard against this issue.