### PR TITLE
Replace Ruby 3.5 with Ruby 4.0

### DIFF
--- a/test/openssl/test_ssl.rb
+++ b/test/openssl/test_ssl.rb
@@ -2325,12 +2325,12 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
     end
   end
 
-  # OpenSSL::Buffering requires $/ accessible from non-main Ractors (Ruby 3.5)
+  # OpenSSL::Buffering requires $/ accessible from non-main Ractors (Ruby 4.0)
   # https://bugs.ruby-lang.org/issues/21109
   #
   # Hangs on Windows
   # https://bugs.ruby-lang.org/issues/21537
-  if respond_to?(:ractor) && RUBY_VERSION >= "3.5" && RUBY_PLATFORM !~ /mswin|mingw/
+  if respond_to?(:ractor) && RUBY_VERSION >= "4.0" && RUBY_PLATFORM !~ /mswin|mingw/
     ractor
     def test_ractor_client
       start_server { |port|


### PR DESCRIPTION
This commit updates the Ruby version in the error message to follow the commit in Ruby master branch. 

https://github.com/ruby/ruby/commit/6d81969b475262aba251e99b518181bdf7c5a523