### PR TITLE
Add support for RUBY_FREE_AT_EXIT

### DIFF
--- a/ext/openssl/ossl.h
+++ b/ext/openssl/ossl.h
@@ -22,6 +22,7 @@
 #else
 #define RUBY_TYPED_FROZEN_SHAREABLE 0
 #endif
+#include <ruby/vm.h>
 
 #include <openssl/opensslv.h>
 

--- a/ext/openssl/ossl_provider.c
+++ b/ext/openssl/ossl_provider.c
@@ -182,6 +182,20 @@ ossl_provider_inspect(VALUE self)
                       rb_obj_class(self), OSSL_PROVIDER_get0_name(prov));
 }
 
+static int
+ossl_provider_at_exit_i(OSSL_PROVIDER *provider, void *cbdata)
+{
+    OSSL_PROVIDER_unload(provider);
+
+    return 1;
+}
+
+static void
+ossl_provider_at_exit(ruby_vm_t *vm)
+{
+    OSSL_PROVIDER_do_all(NULL, ossl_provider_at_exit_i, NULL);
+}
+
 void
 Init_ossl_provider(void)
 {
@@ -200,6 +214,8 @@ Init_ossl_provider(void)
     rb_define_method(cProvider, "unload", ossl_provider_unload, 0);
     rb_define_method(cProvider, "name", ossl_provider_get_name, 0);
     rb_define_method(cProvider, "inspect", ossl_provider_inspect, 0);
+
+    ruby_vm_at_exit(ossl_provider_at_exit);
 }
 #else
 void


### PR DESCRIPTION
OpenSSL::Provider does not automatically unload at shutdown, causing it to be reported as a memory leak by memory leak checkers when using RUBY_FREE_AT_EXIT. For example, LSAN reports many memory leaks that looks like this:

    #15 0x78dd17e2dfb4  (/lib/x86_64-linux-gnu/libcrypto.so.3+0x22dfb4)
    #16 0x78dd17e2b195 in OSSL_PROVIDER_try_load (/lib/x86_64-linux-gnu/libcrypto.so.3+0x22b195)
    #17 0x78dd35ba8751 in ossl_provider_s_load ext/openssl/ossl_provider.c:60:16

This commit adds a hook at shutdown to unload all the OpenSSL providers.