### PR TITLE
ssl: fix test_pqc_sigalg on RHEL 9.7

### DIFF
--- a/test/openssl/test_ssl.rb
+++ b/test/openssl/test_ssl.rb
@@ -2084,6 +2084,7 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
     ctx_proc = -> ctx {
       # Unset values set by start_server
       ctx.cert = ctx.key = ctx.extra_chain_cert = nil
+      ctx.sigalgs = "rsa_pss_rsae_sha256:mldsa65"
       ctx.add_certificate(mldsa_cert, mldsa)
       ctx.add_certificate(rsa_cert, rsa)
     }


### PR DESCRIPTION
RHEL 9.7 ships OpenSSL 3.5.1 with ML-DSA support, but it is disabled for TLS by default, according to the system configuration file: /etc/crypto-policies/back-ends/opensslcnf.config

Specify SSLContext#sigalgs to override the default list.

Fixes #964 