### PR TITLE
pkey/ec: fix OpenSSL::PKey::EC::Group#curve_name for unknown curves

### DIFF
--- a/ext/openssl/ossl_pkey_ec.c
+++ b/ext/openssl/ossl_pkey_ec.c
@@ -849,25 +849,23 @@ static VALUE ossl_ec_group_get_cofactor(VALUE self)
 
 /*
  * call-seq:
- *   group.curve_name  => String
+ *    group.curve_name -> string or nil
  *
- * Returns the curve name (sn).
+ * Returns the curve name (short name) corresponding to this group, or +nil+
+ * if \OpenSSL does not have an OID associated with the group.
  *
  * See the OpenSSL documentation for EC_GROUP_get_curve_name()
  */
 static VALUE ossl_ec_group_get_curve_name(VALUE self)
 {
-    EC_GROUP *group = NULL;
+    EC_GROUP *group;
     int nid;
 
     GetECGroup(self, group);
-    if (group == NULL)
-        return Qnil;
-
     nid = EC_GROUP_get_curve_name(group);
-
-/* BUG: an nid or asn1 object should be returned, maybe. */
-    return rb_str_new2(OBJ_nid2sn(nid));
+    if (nid == NID_undef)
+        return Qnil;
+    return rb_str_new_cstr(OBJ_nid2sn(nid));
 }
 
 /*

--- a/test/openssl/test_pkey_ec.rb
+++ b/test/openssl/test_pkey_ec.rb
@@ -369,18 +369,26 @@ class OpenSSL::TestEC < OpenSSL::PKeyTestCase
       point2.to_octet_string(:uncompressed)
     assert_equal point2.to_octet_string(:uncompressed),
       point3.to_octet_string(:uncompressed)
+  end
 
+  def test_small_curve
     begin
       group = OpenSSL::PKey::EC::Group.new(:GFp, 17, 2, 2)
       group.point_conversion_form = :uncompressed
       generator = OpenSSL::PKey::EC::Point.new(group, B(%w{ 04 05 01 }))
       group.set_generator(generator, 19, 1)
-      point = OpenSSL::PKey::EC::Point.new(group, B(%w{ 04 06 03 }))
     rescue OpenSSL::PKey::EC::Group::Error
       pend "Patched OpenSSL rejected curve" if /unsupported field/ =~ $!.message
       raise
     end
+    assert_equal 17.to_bn.num_bits, group.degree
+    assert_equal B(%w{ 04 05 01 }),
+      group.generator.to_octet_string(:uncompressed)
+    assert_equal 19.to_bn, group.order
+    assert_equal 1.to_bn, group.cofactor
+    assert_nil group.curve_name
 
+    point = OpenSSL::PKey::EC::Point.new(group, B(%w{ 04 06 03 }))
     assert_equal 0x040603.to_bn, point.to_bn
     assert_equal 0x040603.to_bn, point.to_bn(:uncompressed)
     assert_equal 0x0306.to_bn, point.to_bn(:compressed)


### PR DESCRIPTION
`EC_GROUP_get_curve_name()` returns `NID_undef` when OpenSSL does not recognize the curve and there is no associated OID.

Handle this case explicitly and return `nil` instead of the string "UNDEF", which should not be exposed outside the extension.