### PR TITLE
Escape plain text "call-seq:"

### DIFF
--- a/ext/openssl/ossl_ts.c
+++ b/ext/openssl/ossl_ts.c
@@ -1521,7 +1521,7 @@ Init_ossl_ts(void)
      * If none of both is present, a TimestampError will be raised when trying
      * to create a Response.
      *
-     * call-seq:
+     * \call-seq:
      *       factory.default_policy_id = "string" -> string
      *       factory.default_policy_id            -> string or nil
      *
@@ -1530,7 +1530,7 @@ Init_ossl_ts(void)
      * Sets or retrieves the serial number to be used for timestamp creation.
      * Must be present for timestamp creation.
      *
-     * call-seq:
+     * \call-seq:
      *       factory.serial_number = number -> number
      *       factory.serial_number          -> number or nil
      *
@@ -1539,7 +1539,7 @@ Init_ossl_ts(void)
      * Sets or retrieves the Time value to be used in the Response. Must be
      * present for timestamp creation.
      *
-     * call-seq:
+     * \call-seq:
      *       factory.gen_time = Time -> Time
      *       factory.gen_time        -> Time or nil
      *
@@ -1549,7 +1549,7 @@ Init_ossl_ts(void)
      * certificate (e.g. intermediate certificates) to be added to the Response.
      * Must be an Array of OpenSSL::X509::Certificate.
      *
-     * call-seq:
+     * \call-seq:
      *       factory.additional_certs = [cert1, cert2] -> [ cert1, cert2 ]
      *       factory.additional_certs                  -> array or nil
      *
@@ -1560,7 +1560,7 @@ Init_ossl_ts(void)
      * allowed where possible.
      * Must be an Array of String or OpenSSL::Digest subclass instances.
      *
-     * call-seq:
+     * \call-seq:
      *       factory.allowed_digests = ["sha1", OpenSSL::Digest.new('SHA256').new] -> [ "sha1", OpenSSL::Digest) ]
      *       factory.allowed_digests                                               -> array or nil
      *


### PR DESCRIPTION
These "call-seq:" are just plain text, not handled as a call-seq directive.
See https://ruby.github.io/openssl/OpenSSL/Timestamp/Factory.html#class-OpenSSL::Timestamp::Factory-label-gen_time
`call-seq:` is surrounded by `<p></p>` tag just like other plain text/paragraph.

A plain text that matches RDoc's directive format will be removed from the document in rdoc-6.16.0.
