### PR TITLE
asn1: use ASN1_TIME_to_tm() to decode UTCTime and GeneralizedTime

### DIFF
--- a/ext/openssl/ossl_asn1.c
+++ b/ext/openssl/ossl_asn1.c
@@ -55,57 +55,35 @@ static ID id_each;
 /*
  * DATE conversion
  */
+static VALUE
+time_utc_new(VALUE args)
+{
+    return rb_funcallv(rb_cTime, rb_intern("utc"), 6, (VALUE *)args);
+}
+
+static VALUE
+time_utc_new_rescue(VALUE args, VALUE exc)
+{
+    rb_raise(eASN1Error, "invalid time");
+}
+
 VALUE
 asn1time_to_time(const ASN1_TIME *time)
 {
     struct tm tm;
-    VALUE argv[6];
-    int count;
+    if (!ASN1_TIME_to_tm(time, &tm))
+        ossl_raise(eASN1Error, "ASN1_TIME_to_tm");
 
-    memset(&tm, 0, sizeof(struct tm));
-
-    switch (time->type) {
-      case V_ASN1_UTCTIME:
-        count = sscanf((const char *)time->data, "%2d%2d%2d%2d%2d%2dZ",
-                       &tm.tm_year, &tm.tm_mon, &tm.tm_mday, &tm.tm_hour, &tm.tm_min,
-                       &tm.tm_sec);
-
-        if (count == 5) {
-            tm.tm_sec = 0;
-        } else if (count != 6) {
-            ossl_raise(rb_eTypeError, "bad UTCTIME format: \"%s\"",
-                       time->data);
-        }
-        if (tm.tm_year < 50) {
-            tm.tm_year += 2000;
-        } else {
-            tm.tm_year += 1900;
-        }
-        break;
-      case V_ASN1_GENERALIZEDTIME:
-        count = sscanf((const char *)time->data, "%4d%2d%2d%2d%2d%2dZ",
-                       &tm.tm_year, &tm.tm_mon, &tm.tm_mday, &tm.tm_hour, &tm.tm_min,
-                       &tm.tm_sec);
-        if (count == 5) {
-            tm.tm_sec = 0;
-        }
-        else if (count != 6) {
-            ossl_raise(rb_eTypeError, "bad GENERALIZEDTIME format: \"%s\"",
-                       time->data);
-        }
-        break;
-      default:
-        rb_warning("unknown time format");
-        return Qnil;
-    }
-    argv[0] = INT2NUM(tm.tm_year);
-    argv[1] = INT2NUM(tm.tm_mon);
-    argv[2] = INT2NUM(tm.tm_mday);
-    argv[3] = INT2NUM(tm.tm_hour);
-    argv[4] = INT2NUM(tm.tm_min);
-    argv[5] = INT2NUM(tm.tm_sec);
-
-    return rb_funcall2(rb_cTime, rb_intern("utc"), 6, argv);
+    VALUE args[] = {
+        INT2NUM(tm.tm_year + 1900),
+        INT2NUM(tm.tm_mon + 1),
+        INT2NUM(tm.tm_mday),
+        INT2NUM(tm.tm_hour),
+        INT2NUM(tm.tm_min),
+        INT2NUM(tm.tm_sec),
+    };
+    return rb_rescue2(time_utc_new, (VALUE)args, time_utc_new_rescue, Qnil,
+                      rb_eArgError, 0);
 }
 
 static VALUE

--- a/test/openssl/test_asn1.rb
+++ b/test/openssl/test_asn1.rb
@@ -426,17 +426,28 @@ class  OpenSSL::TestASN1 < OpenSSL::TestCase
       OpenSSL::ASN1::UTCTime.new(Time.new(2049, 12, 31, 23, 0, 0, "-04:00")).to_der
     }
 
-    # not implemented
+    # UTC offset (BER): ASN1_TIME_to_tm() may or may not support it
     # decode_test B(%w{ 17 11 }) + "500908234339+0930".b,
     #   OpenSSL::ASN1::UTCTime.new(Time.new(1950, 9, 8, 23, 43, 39, "+09:30"))
     # decode_test B(%w{ 17 0F }) + "5009082343-0930".b,
     #   OpenSSL::ASN1::UTCTime.new(Time.new(1950, 9, 8, 23, 43, 0, "-09:30"))
-    # assert_raise(OpenSSL::ASN1::ASN1Error) {
-    #   OpenSSL::ASN1.decode(B(%w{ 17 0C }) + "500908234339".b)
-    # }
-    # assert_raise(OpenSSL::ASN1::ASN1Error) {
-    #   OpenSSL::ASN1.decode(B(%w{ 17 0D }) + "500908234339Y".b)
-    # }
+
+    # Seconds is omitted (BER)
+    # decode_test B(%w{ 18 0D }) + "201612081934Z".b,
+    #   OpenSSL::ASN1::GeneralizedTime.new(Time.utc(2016, 12, 8, 19, 34, 0))
+
+    # Fractional seconds is not allowed in UTCTime
+    assert_raise(OpenSSL::ASN1::ASN1Error) {
+      OpenSSL::ASN1.decode(B(%w{ 17 0F }) + "160908234339.5Z".b)
+    }
+
+    # Missing "Z"
+    assert_raise(OpenSSL::ASN1::ASN1Error) {
+      OpenSSL::ASN1.decode(B(%w{ 17 0C }) + "500908234339".b)
+    }
+    assert_raise(OpenSSL::ASN1::ASN1Error) {
+      OpenSSL::ASN1.decode(B(%w{ 17 0D }) + "500908234339Y".b)
+    }
   end
 
   def test_generalizedtime
@@ -444,24 +455,46 @@ class  OpenSSL::TestASN1 < OpenSSL::TestCase
       OpenSSL::ASN1::GeneralizedTime.new(Time.utc(2016, 12, 8, 19, 34, 29))
     encode_decode_test B(%w{ 18 0F }) + "99990908234339Z".b,
       OpenSSL::ASN1::GeneralizedTime.new(Time.utc(9999, 9, 8, 23, 43, 39))
-    # not implemented
+
+    # Fractional seconds (DER). Not supported by ASN1_TIME_to_tm()
+    # because struct tm cannot store it.
+    # encode_decode_test B(%w{ 18 11 }) + "20161208193439.5Z".b,
+    #   OpenSSL::ASN1::GeneralizedTime.new(Time.utc(2016, 12, 8, 19, 34, 39.5))
+
+    # UTC offset (BER): ASN1_TIME_to_tm() may or may not support it
     # decode_test B(%w{ 18 13 }) + "20161208193439+0930".b,
     #   OpenSSL::ASN1::GeneralizedTime.new(Time.new(2016, 12, 8, 19, 34, 39, "+09:30"))
     # decode_test B(%w{ 18 11 }) + "201612081934-0930".b,
     #   OpenSSL::ASN1::GeneralizedTime.new(Time.new(2016, 12, 8, 19, 34, 0, "-09:30"))
     # decode_test B(%w{ 18 11 }) + "201612081934-09".b,
     #   OpenSSL::ASN1::GeneralizedTime.new(Time.new(2016, 12, 8, 19, 34, 0, "-09:00"))
+
+    # Minutes and seconds are omitted (BER)
+    # decode_test B(%w{ 18 0B }) + "2016120819Z".b,
+    #   OpenSSL::ASN1::GeneralizedTime.new(Time.utc(2016, 12, 8, 19, 0, 0))
+    # Fractional hours (BER)
     # decode_test B(%w{ 18 0D }) + "2016120819.5Z".b,
     #   OpenSSL::ASN1::GeneralizedTime.new(Time.utc(2016, 12, 8, 19, 30, 0))
+    # Fractional hours with "," as the decimal separator (BER)
     # decode_test B(%w{ 18 0D }) + "2016120819,5Z".b,
     #   OpenSSL::ASN1::GeneralizedTime.new(Time.utc(2016, 12, 8, 19, 30, 0))
+
+    # Seconds is omitted (BER)
+    # decode_test B(%w{ 18 0D }) + "201612081934Z".b,
+    #   OpenSSL::ASN1::GeneralizedTime.new(Time.utc(2016, 12, 8, 19, 34, 0))
+    # Fractional minutes (BER)
     # decode_test B(%w{ 18 0F }) + "201612081934.5Z".b,
     #   OpenSSL::ASN1::GeneralizedTime.new(Time.utc(2016, 12, 8, 19, 34, 30))
-    # decode_test B(%w{ 18 11 }) + "20161208193439.5Z".b,
-    #   OpenSSL::ASN1::GeneralizedTime.new(Time.utc(2016, 12, 8, 19, 34, 39.5))
-    # assert_raise(OpenSSL::ASN1::ASN1Error) {
-    #   OpenSSL::ASN1.decode(B(%w{ 18 0D }) + "201612081934Y".b)
-    # }
+
+    # Missing "Z"
+    assert_raise(OpenSSL::ASN1::ASN1Error) {
+      OpenSSL::ASN1.decode(B(%w{ 18 0F }) + "20161208193429Y".b)
+    }
+
+    # Encoding year out of range
+    assert_raise(OpenSSL::ASN1::ASN1Error) {
+      OpenSSL::ASN1::GeneralizedTime.new(Time.utc(10000, 9, 8, 23, 43, 39)).to_der
+    }
   end
 
   def test_basic_asn1data


### PR DESCRIPTION
The current logic relies on `sscanf()` and error checks are almost entirely missing. It also assumes that `ASN1_STRING` contents are NUL-terminated, which is undocumented and not guaranteed for all valid `ASN1_TIME` objects.

Switch to using `ASN1_TIME_to_tm()` added in OpenSSL 1.1.1. It is also supported by LibreSSL and AWS-LC.

In the long term, we may want to replace `ASN1_TIME_to_tm()` with a hand-rolled decoder, since the function is intended for a specific use-case. It is too permissive for strict DER, yet still does not support all valid DER inputs and silently drops information such as fractional seconds. However, it handles everything that the current `sscanf()` code could handle.

Partially resolves https://github.com/ruby/openssl/issues/725.