### PR TITLE
ossl.c: implement OpenSSL::OpenSSLError#detailed_message

### DIFF
--- a/ext/openssl/extconf.rb
+++ b/ext/openssl/extconf.rb
@@ -38,8 +38,12 @@ Logging::message "=== OpenSSL for Ruby configurator ===\n"
 
 $defs.push("-D""OPENSSL_SUPPRESS_DEPRECATED")
 
+# Missing in TruffleRuby
+have_func("rb_call_super_kw(0, NULL, 0)", "ruby.h")
+# Ruby 3.1
 have_func("rb_io_descriptor", "ruby/io.h")
-have_func("rb_io_maybe_wait(0, Qnil, Qnil, Qnil)", "ruby/io.h") # Ruby 3.1
+have_func("rb_io_maybe_wait(0, Qnil, Qnil, Qnil)", "ruby/io.h")
+# Ruby 3.2
 have_func("rb_io_timeout", "ruby/io.h")
 
 Logging::message "=== Checking for system dependent stuff... ===\n"


### PR DESCRIPTION
An OpenSSL function sometimes puts more than one error entry into the thread-local error queue. We currently use the last, the highest level entry for generating the exception message. The rest is silently dropped unless `OpenSSL.debug` is set to `true`, which makes it print to `rb_warn()`.

Capture all current OpenSSL error queue contents into `OpenSSL::OpenSSLError#errors` in `ossl_make_error()`, and extend `OpenSSL::OpenSSLError#detailed_message` to include the information.

An example:

```console
$ ruby -Ilib -ropenssl -e'OpenSSL::X509::ExtensionFactory.new.create_ext("a", "b")'
-e:1:in 'OpenSSL::X509::ExtensionFactory#create_ext': a = b: error in extension (name=a, value=b) (OpenSSL::X509::ExtensionError)
OpenSSL error queue reported 2 errors:
error:11000082:X509 V3 routines:do_ext_nconf:unknown extension name
error:11000080:X509 V3 routines:X509V3_EXT_nconf_int:error in extension (name=a, value=b)
        from -e:1:in '<main>'
```

Closes https://github.com/ruby/openssl/issues/312.