### PR TITLE
x509cert: handle invalid validity periods in Certificate#inspect

### DIFF
--- a/ext/openssl/ossl_x509cert.c
+++ b/ext/openssl/ossl_x509cert.c
@@ -665,20 +665,6 @@ ossl_x509_add_extension(VALUE self, VALUE extension)
     return extension;
 }
 
-static VALUE
-ossl_x509_inspect(VALUE self)
-{
-    return rb_sprintf("#<%"PRIsVALUE": subject=%+"PRIsVALUE", "
-                      "issuer=%+"PRIsVALUE", serial=%+"PRIsVALUE", "
-                      "not_before=%+"PRIsVALUE", not_after=%+"PRIsVALUE">",
-                      rb_obj_class(self),
-                      ossl_x509_get_subject(self),
-                      ossl_x509_get_issuer(self),
-                      ossl_x509_get_serial(self),
-                      ossl_x509_get_not_before(self),
-                      ossl_x509_get_not_after(self));
-}
-
 /*
  * call-seq:
  *    cert1 == cert2 -> true | false
@@ -1013,7 +999,6 @@ Init_ossl_x509cert(void)
     rb_define_method(cX509Cert, "extensions", ossl_x509_get_extensions, 0);
     rb_define_method(cX509Cert, "extensions=", ossl_x509_set_extensions, 1);
     rb_define_method(cX509Cert, "add_extension", ossl_x509_add_extension, 1);
-    rb_define_method(cX509Cert, "inspect", ossl_x509_inspect, 0);
     rb_define_method(cX509Cert, "==", ossl_x509_eq, 1);
     rb_define_method(cX509Cert, "tbs_bytes", ossl_x509_tbs_bytes, 0);
 }

--- a/lib/openssl/x509.rb
+++ b/lib/openssl/x509.rb
@@ -346,6 +346,15 @@ module OpenSSL
       include Extension::CRLDistributionPoints
       include Extension::AuthorityInfoAccess
 
+      def inspect
+        "#<#{self.class}: " \
+          "subject=#{subject.inspect}, " \
+          "issuer=#{issuer.inspect}, " \
+          "serial=#{serial.inspect}, " \
+          "not_before=#{not_before.inspect rescue "(error)"}, " \
+          "not_after=#{not_after.inspect rescue "(error)"}>"
+      end
+
       def pretty_print(q)
         q.object_group(self) {
           q.breakable

--- a/test/openssl/test_x509cert.rb
+++ b/test/openssl/test_x509cert.rb
@@ -298,6 +298,14 @@ class OpenSSL::TestX509Certificate < OpenSSL::TestCase
     assert_equal false, cert3 == cert4
   end
 
+  def test_inspect
+    cacert = issue_cert(@ca, @rsa1, 1, [], nil, nil)
+    assert_include(cacert.inspect, "subject=#{@ca.inspect}")
+
+    # Do not raise an exception for an invalid certificate
+    assert_instance_of(String, OpenSSL::X509::Certificate.new.inspect)
+  end
+
   def test_marshal
     now = Time.now
     cacert = issue_cert(@ca, @rsa1, 1, [], nil, nil,


### PR DESCRIPTION
In a newly allocated OpenSSL `X509` object, the `notBefore` and `notAfter` fields contain an `ASN1_STRING` object with type `V_ASN1_UNDEF` rather than an `ASN1_TIME`.

Commit 73484f67949a made `asn1time_to_time()` stricter and it now raises an exception if the argument is not an `ASN1_TIME`. Previously, it would print a verbose-mode warning and return nil.

`OpenSSL::X509::Certificate#inspect` should work even when the certificate is invalid. Let's handle this.