### PR TITLE
asn1integer_to_num: don't cast away const

### DIFF
--- a/ext/openssl/ossl_asn1.c
+++ b/ext/openssl/ossl_asn1.c
@@ -131,8 +131,7 @@ asn1integer_to_num(const ASN1_INTEGER *ai)
         ossl_raise(rb_eTypeError, "ASN1_INTEGER is NULL!");
     }
     if (ASN1_STRING_type(ai) == V_ASN1_ENUMERATED)
-        /* const_cast: workaround for old OpenSSL */
-        bn = ASN1_ENUMERATED_to_BN((ASN1_ENUMERATED *)ai, NULL);
+        bn = ASN1_ENUMERATED_to_BN(ai, NULL);
     else
         bn = ASN1_INTEGER_to_BN(ai, NULL);
 


### PR DESCRIPTION
ASN1_ENUMERATED_to_BN() has been const-correct for a long time in all supported libraries, so we can remove this workaround.

Small follow-up to #978