### PR TITLE
pkcs7: raise OpenSSL::PKCS7::PKCS7Error in #initialize

### DIFF
--- a/ext/openssl/ossl_pkcs7.c
+++ b/ext/openssl/ossl_pkcs7.c
@@ -390,10 +390,10 @@ ossl_pkcs7_initialize(int argc, VALUE *argv, VALUE self)
     }
     BIO_free(in);
     if (!p7)
-        ossl_raise(rb_eArgError, "Could not parse the PKCS7");
+        ossl_raise(ePKCS7Error, "Could not parse the PKCS7");
     if (!p7->d.ptr) {
         PKCS7_free(p7);
-        ossl_raise(rb_eArgError, "No content in PKCS7");
+        ossl_raise(ePKCS7Error, "No content in PKCS7");
     }
 
     RTYPEDDATA_DATA(self) = p7;

--- a/test/openssl/test_pkcs7.rb
+++ b/test/openssl/test_pkcs7.rb
@@ -304,7 +304,7 @@ IQCJVpo1FTLZOHSc9UpjS+VKR4cg50Iz0HiPyo6hwjCrwA==
 
   def test_empty_signed_data_ruby_bug_19974
     data = "-----BEGIN PKCS7-----\nMAsGCSqGSIb3DQEHAg==\n-----END PKCS7-----\n"
-    assert_raise(ArgumentError) { OpenSSL::PKCS7.new(data) }
+    assert_raise(OpenSSL::PKCS7::PKCS7Error) { OpenSSL::PKCS7.new(data) }
 
     data = <<END
 MIME-Version: 1.0
@@ -319,7 +319,7 @@ END
 
   def test_graceful_parsing_failure #[ruby-core:43250]
     contents = "not a valid PKCS #7 PEM block"
-    assert_raise(ArgumentError) { OpenSSL::PKCS7.new(contents) }
+    assert_raise(OpenSSL::PKCS7::PKCS7Error) { OpenSSL::PKCS7.new(contents) }
   end
 
   def test_set_type_signed


### PR DESCRIPTION
When `d2i_PKCS7_bio()` and `PEM_read_bio_PKCS7()` fail to decode the input, `OpenSSL::PKCS7.new` currently raises `ArgumentError`. The usual practice in ruby/openssl where an error originates from the underlying OpenSSL library is to raise `OpenSSL::OpenSSLError`.

Raise `OpenSSL::PKCS7::PKCS7Error` instead for consistency with `OpenSSL::PKCS7.read_smime` and all other existing `#initialize` methods that handle DER/PEM-encoded inputs.

Related to https://github.com/ruby/openssl/pull/752