### PR TITLE
x509cert: update doc for OpenSSL::X509::Certificate#==

### DIFF
--- a/ext/openssl/ossl_x509cert.c
+++ b/ext/openssl/ossl_x509cert.c
@@ -671,6 +671,12 @@ ossl_x509_add_extension(VALUE self, VALUE extension)
  *
  * Compares the two certificates. Note that this takes into account all fields,
  * not just the issuer name and the serial number.
+ *
+ * This method uses X509_cmp() from OpenSSL, which compares certificates based
+ * on their cached DER encodings. The comparison can be unreliable if a
+ * certificate is incomplete.
+ *
+ * See also the man page X509_cmp(3).
  */
 static VALUE
 ossl_x509_eq(VALUE self, VALUE other)


### PR DESCRIPTION
Mention the underlying OpenSSL function. Add a note about the unreliable comparison when called on an incomplete object.

Fixes https://github.com/ruby/openssl/issues/844