### PR TITLE
cipher: remove incorrect assertion in Cipher#update

### DIFF
--- a/ext/openssl/ossl_cipher.c
+++ b/ext/openssl/ossl_cipher.c
@@ -401,9 +401,9 @@ ossl_cipher_update(int argc, VALUE *argv, VALUE self)
     }
     out_len = in_len + EVP_MAX_BLOCK_LENGTH;
 
-    if (NIL_P(str)) {
-        str = rb_str_new(0, out_len);
-    } else {
+    if (NIL_P(str))
+        str = rb_str_buf_new(out_len);
+    else {
         StringValue(str);
         if ((long)rb_str_capacity(str) >= out_len)
             rb_str_modify(str);
@@ -411,9 +411,9 @@ ossl_cipher_update(int argc, VALUE *argv, VALUE self)
             rb_str_modify_expand(str, out_len - RSTRING_LEN(str));
     }
 
-    if (!ossl_cipher_update_long(ctx, (unsigned char *)RSTRING_PTR(str), &out_len, in, in_len))
-        ossl_raise(eCipherError, NULL);
-    assert(out_len <= RSTRING_LEN(str));
+    if (!ossl_cipher_update_long(ctx, (unsigned char *)RSTRING_PTR(str),
+                                 &out_len, in, in_len))
+        ossl_raise(eCipherError, "EVP_CipherUpdate");
     rb_str_set_len(str, out_len);
 
     return str;
@@ -456,7 +456,6 @@ ossl_cipher_final(VALUE self)
             ossl_raise(eCipherError, "cipher final failed");
         }
     }
-    assert(out_len <= RSTRING_LEN(str));
     rb_str_set_len(str, out_len);
 
     return str;

--- a/test/openssl/test_cipher.rb
+++ b/test/openssl/test_cipher.rb
@@ -134,13 +134,14 @@ class OpenSSL::TestCipher < OpenSSL::TestCase
   def test_update_with_buffer
     cipher = OpenSSL::Cipher.new("aes-128-ecb").encrypt
     cipher.random_key
-    expected = cipher.update("data") << cipher.final
-    assert_equal 16, expected.bytesize
+    expected = cipher.update("data" * 10) << cipher.final
+    assert_equal 48, expected.bytesize
 
     # Buffer is supplied
     cipher.reset
     buf = String.new
-    assert_same buf, cipher.update("data", buf)
+    assert_same buf, cipher.update("data" * 10, buf)
+    assert_equal 32, buf.bytesize
     assert_equal expected, buf + cipher.final
 
     # Buffer is frozen
@@ -149,9 +150,9 @@ class OpenSSL::TestCipher < OpenSSL::TestCase
 
     # Buffer is a shared string [ruby-core:120141] [Bug #20937]
     cipher.reset
-    buf = "x" * 1024
-    shared = buf[-("data".bytesize + 32)..-1]
-    assert_same shared, cipher.update("data", shared)
+    buf = "x".b * 1024
+    shared = buf[-("data".bytesize * 10 + 32)..-1]
+    assert_same shared, cipher.update("data" * 10, shared)
     assert_equal expected, shared + cipher.final
   end
 


### PR DESCRIPTION
Commit 1de3b80a46c2 (cipher: make output buffer String independent, 2024-12-10, https://github.com/ruby/openssl/pull/824) ensures the output buffer String has sufficient capacity, bu the length can be shorter. The `assert()` is simply incorrect and should be removed.

Also remove a similar `assert()` in `Cipher#final`. While not incorrect, it is not useful either.