### PR TITLE
Improve Argument Error Message in EC:Group.new

### DIFF
--- a/ext/openssl/ossl_pkey_ec.c
+++ b/ext/openssl/ossl_pkey_ec.c
@@ -702,7 +702,7 @@ static VALUE ossl_ec_group_initialize(int argc, VALUE *argv, VALUE self)
 
         break;
       default:
-        ossl_raise(rb_eArgError, "wrong number of arguments");
+        ossl_raise(rb_eArgError, "wrong number of arguments (given %d, expected 1 or 4)", argc);
     }
 
     ASSUME(group);

--- a/test/openssl/test_pkey_ec.rb
+++ b/test/openssl/test_pkey_ec.rb
@@ -345,6 +345,15 @@ class OpenSSL::TestEC < OpenSSL::PKeyTestCase
     assert_equal group1.degree, group4.degree
   end
 
+  def test_ec_group_initialize_error_message
+    # Test that passing 2 arguments raises the helpful error
+    e = assert_raise(ArgumentError) do
+      OpenSSL::PKey::EC::Group.new(:GFp, 123)
+    end
+
+    assert_equal("wrong number of arguments (given 2, expected 1 or 4)", e.message)
+  end
+
   def test_ec_point
     group = OpenSSL::PKey::EC::Group.new("prime256v1")
     key = OpenSSL::PKey::EC.generate(group)


### PR DESCRIPTION
Before, passing the wrong number of arguments (e.g., 2) to OpenSSL::PKey::EC::Group.new raised a generic "wrong number of arguments"
error.

This change updates it to show the actual argument count and the expected
options (1 or 4), making debugging easier for the user.

Example:
ArgumentError: wrong number of arguments (given 2, expected 1 or 4)

I hope it helps!