### PR TITLE
Fix test_cipher.rb in FIPS.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -26,7 +26,6 @@ Rake::TestTask.new(:test_fips_internal) do |t|
   # Exclude failing test files in FIPS for this task to pass.
   # TODO: Fix failing test files.
   t.test_files = FileList['test/**/test_*.rb'] - FileList[
-    'test/openssl/test_cipher.rb',
     'test/openssl/test_digest.rb',
     'test/openssl/test_hmac.rb',
     'test/openssl/test_kdf.rb',


### PR DESCRIPTION
This PR is to fix test_cipher.rb in FIPS.

I used the FIPS-approved algorithm AES-256-CBC instead of FIPS-not-approved algorithm DES-EDE3-CBC, also used the FIPS-approved algorithm SHA256 instead of FIPS-not-approved algorithm MD5 in some tests to pass the tests.

I confirmed the CI passed on my fork repository.
https://github.com/junaruga/ruby-openssl/actions/runs/20862608486
