### PR TITLE
Fix test_digest.rb in FIPS.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -26,7 +26,6 @@ Rake::TestTask.new(:test_fips_internal) do |t|
   # Exclude failing test files in FIPS for this task to pass.
   # TODO: Fix failing test files.
   t.test_files = FileList['test/**/test_*.rb'] - FileList[
-    'test/openssl/test_digest.rb',
     'test/openssl/test_hmac.rb',
     'test/openssl/test_kdf.rb',
     'test/openssl/test_pkcs12.rb',


### PR DESCRIPTION
This PR is to fix test_digest.rb in FIPS.

I confirmed the CI passed on my fork repository below.
https://github.com/junaruga/ruby-openssl/actions/runs/20960665444