### PR TITLE
Add `sync_close` kwarg to `SSLSocket.new`

### DIFF
--- a/test/openssl/test_ssl.rb
+++ b/test/openssl/test_ssl.rb
@@ -355,6 +355,22 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
     end
   end
 
+  def test_sync_close_initialize_opt
+    start_server do |port|
+      begin
+        sock = TCPSocket.new("127.0.0.1", port)
+        ssl = OpenSSL::SSL::SSLSocket.new(sock, sync_close: true)
+        assert_equal true, ssl.sync_close
+        ssl.connect
+        ssl.puts "abc"; assert_equal "abc\n", ssl.gets
+        ssl.close
+        assert_predicate sock, :closed?
+      ensure
+        sock&.close
+      end
+    end
+  end
+
   def test_copy_stream
     start_server do |port|
       server_connect(port) do |ssl|


### PR DESCRIPTION
Add a `sync_close` keyword argument to `SSLSocket.new`. This fixes #955. Example usage:

```ruby
SSLSocket.new(io, ctx, sync_close: true)
```
