### PR TITLE
CI: Upgrade LibreSSL versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,7 +112,8 @@ jobs:
           # http://www.libressl.org/releases.html
           - libressl-3.9.2 # EOL 2025-04-05
           - libressl-4.0.1 # Supported until 2025-10-08
-          - libressl-4.1.1 # Supported until 2026-04-28
+          - libressl-4.1.2 # Supported until 2026-04-28
+          - libressl-4.2.1
           # https://github.com/aws/aws-lc/tags
           - aws-lc-latest
         include:


### PR DESCRIPTION
This PR is to upgrade LibreSSL versions, adding LibreSSL 4.2.

I have a question. I couldn't find or determine the support ending date for LibreSSL 4.2.

There is the following statement about the supporting term. However, I couldn't find when the corresponding OpenBSD branch is tagged for release. Could you tell me how to check it?

https://www.libressl.org/releases.html

> LibreSSL stable branches are updated for 1 year after their corresponding OpenBSD branch is tagged for release.

In the case of the LibreSSL 4.1, the 4.1.0 version was released on 30th April 2025 according to the above LibreSSL release page. But the LibreSSL 4.1.2 support date commented in the `test.yml` is 20256-04-28, which is not exactly the date after 1 year from the 30th April 2025 (2025-04-30).

> LibreSSL 4.1.0 (Apr 30th, 2025) 
