### PR TITLE
ssl: update tests for SSLContext#servername_cb callback

### DIFF
--- a/test/openssl/test_ssl.rb
+++ b/test/openssl/test_ssl.rb
@@ -1080,36 +1080,46 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
     end
   end
 
-  def test_servername_cb_raises_an_exception_on_unknown_objects
-    hostname = 'example.org'
-
-    ctx2 = OpenSSL::SSL::SSLContext.new
-    ctx2.cert = @svr_cert
-    ctx2.key = @svr_key
-    ctx2.servername_cb = lambda { |args| Object.new }
-
+  def test_servername_cb_exception
     sock1, sock2 = socketpair
 
-    s2 = OpenSSL::SSL::SSLSocket.new(sock2, ctx2)
-
-    ctx1 = OpenSSL::SSL::SSLContext.new
-
-    s1 = OpenSSL::SSL::SSLSocket.new(sock1, ctx1)
-    s1.hostname = hostname
     t = Thread.new {
-      assert_raise(OpenSSL::SSL::SSLError) do
+      s1 = OpenSSL::SSL::SSLSocket.new(sock1)
+      s1.hostname = "localhost"
+      assert_raise_with_message(OpenSSL::SSL::SSLError, /unrecognized.name/i) {
         s1.connect
-      end
+      }
     }
 
-    assert_raise(ArgumentError) do
-      s2.accept
-    end
-
+    ctx2 = OpenSSL::SSL::SSLContext.new
+    ctx2.servername_cb = lambda { |args| raise RuntimeError, "foo" }
+    s2 = OpenSSL::SSL::SSLSocket.new(sock2, ctx2)
+    assert_raise_with_message(RuntimeError, "foo") { s2.accept }
     assert t.join
   ensure
-    sock1.close if sock1
-    sock2.close if sock2
+    sock1.close
+    sock2.close
+    t.kill.join
+  end
+
+  def test_servername_cb_raises_an_exception_on_unknown_objects
+    sock1, sock2 = socketpair
+
+    t = Thread.new {
+      s1 = OpenSSL::SSL::SSLSocket.new(sock1)
+      s1.hostname = "localhost"
+      assert_raise(OpenSSL::SSL::SSLError) { s1.connect }
+    }
+
+    ctx2 = OpenSSL::SSL::SSLContext.new
+    ctx2.servername_cb = lambda { |args| Object.new }
+    s2 = OpenSSL::SSL::SSLSocket.new(sock2, ctx2)
+    assert_raise(ArgumentError) { s2.accept }
+    assert t.join
+  ensure
+    sock1.close
+    sock2.close
+    t.kill.join
   end
 
   def test_accept_errors_include_peeraddr


### PR DESCRIPTION
If an exception is raised by the `SSLContext#servername_cb` proc, the handshake should be canceled by sending an `unrecognized_name` alert to the client, and the exception should be re-raised from `SSLSocket#accept`.

Add more direct assertions to confirm these behaviors.