### PR TITLE
ocsp: fix uninitialized variables in BasicResponse#status

### DIFF
--- a/ext/openssl/ossl_ocsp.c
+++ b/ext/openssl/ossl_ocsp.c
@@ -905,8 +905,8 @@ ossl_ocspbres_get_status(VALUE self)
     int count = OCSP_resp_count(bs);
     for (int i = 0; i < count; i++) {
         OCSP_SINGLERESP *single = OCSP_resp_get0(bs, i);
-        ASN1_TIME *revtime, *thisupd, *nextupd;
-        int reason;
+        ASN1_TIME *revtime = NULL, *thisupd = NULL, *nextupd = NULL;
+        int reason = -1;
 
         int status = OCSP_single_get0_status(single, &reason, &revtime, &thisupd, &nextupd);
         if (status < 0)

--- a/ext/openssl/ossl_pkcs7.c
+++ b/ext/openssl/ossl_pkcs7.c
@@ -1010,7 +1010,7 @@ static VALUE
 ossl_pkcs7si_get_signed_time(VALUE self)
 {
     PKCS7_SIGNER_INFO *p7si;
-    ASN1_TYPE *asn1obj;
+    const ASN1_TYPE *asn1obj;
 
     GetPKCS7si(self, p7si);
 


### PR DESCRIPTION
`BasicResponse#status` raises `OpenSSL::ASN1::ASN1Error: ASN1_TIME_to_tm` for any OCSP response with a `GOOD` or `UNKNOWN` certificate status. `REVOKED` works fine.

I hit this while checking OCSP status for `google.com`.

Minimal reproduction:

```ruby
require "openssl"
# Ruby 4.0.1, openssl gem 4.0.0, OpenSSL 3.6.1

key = OpenSSL::PKey::RSA.generate(2048)
ca = OpenSSL::X509::Certificate.new.tap { |c|
  c.subject = c.issuer = OpenSSL::X509::Name.parse("/CN=CA")
  c.serial, c.version, c.public_key = 1, 2, key
  c.not_before, c.not_after = Time.now, Time.now + 86400
  c.sign(key, "SHA256")
}

cid = OpenSSL::OCSP::CertificateId.new(ca, ca)
bres = OpenSSL::OCSP::BasicResponse.new
bres.add_status(cid, OpenSSL::OCSP::V_CERTSTATUS_GOOD, 0, nil, -300, 500, nil)
bres.sign(ca, key)

bres.status # => OpenSSL::ASN1::ASN1Error: ASN1_TIME_to_tm
```

Querying Google's OCSP responder:

```ruby
require "openssl"
require "net/http"

sock = TCPSocket.new("google.com", 443)
ctx = OpenSSL::SSL::SSLContext.new
ctx.verify_mode = OpenSSL::SSL::VERIFY_PEER
ctx.cert_store = OpenSSL::X509::Store.new.tap(&:set_default_paths)
ssl = OpenSSL::SSL::SSLSocket.new(sock, ctx)
ssl.hostname = "google.com"
ssl.connect
cert, issuer = ssl.peer_cert_chain[0..1]
ssl.close; sock.close

cid = OpenSSL::OCSP::CertificateId.new(cert, issuer, OpenSSL::Digest.new("SHA1"))
req = OpenSSL::OCSP::Request.new
req.add_certid(cid)

uri = URI("http://o.pki.goog/we2")
resp = Net::HTTP.new(uri.host, uri.port).post(uri.path, req.to_der, "Content-Type" => "application/ocsp-request")
basic = OpenSSL::OCSP::Response.new(resp.body).basic

basic.verify([issuer], ctx.cert_store) # => true (response is valid)
basic.status                           # => OpenSSL::ASN1::ASN1Error: ASN1_TIME_to_tm
```

Cause / fix - In `ossl_ocspbres_get_status()`, `revtime` is declared but not initialized before being passed to `OCSP_single_get0_status()`:

```c
ASN1_TIME *revtime, *thisupd, *nextupd;
int reason;

int status = OCSP_single_get0_status(single, &reason, &revtime, &thisupd, &nextupd);
// ...
rb_ary_push(ary, revtime ? asn1time_to_time(revtime) : Qnil);
```

For `GOOD` and `UNKNOWN`, OpenSSL's `OCSP_single_get0_status` doesn't write to `revtime` (only `REVOKED` does). So `revtime` holds whatever was on the stack, the nil guard passes, and `asn1time_to_time` dereferences a garbage pointer.

The fix initializes all four variables before the call. Also adds test coverage for `BasicResponse#status` with `GOOD` and `REVOKED` status. Previously, no tests exercised this method (existing tests use `BasicResponse#responses` instead).
