### PR TITLE
x509attr: fix const-qualification for openssl-master

### DIFF
--- a/ext/openssl/ossl_x509attr.c
+++ b/ext/openssl/ossl_x509attr.c
@@ -196,7 +196,7 @@ ossl_x509attr_set_value(VALUE self, VALUE value)
         ossl_raise(eX509AttrError, "attribute value must be ASN1::Set");
 
     if (X509_ATTRIBUTE_count(attr)) { /* populated, reset first */
-        ASN1_OBJECT *obj = X509_ATTRIBUTE_get0_object(attr);
+        const ASN1_OBJECT *obj = X509_ATTRIBUTE_get0_object(attr);
         X509_ATTRIBUTE *new_attr = X509_ATTRIBUTE_create_by_OBJ(NULL, obj, 0, NULL, -1);
         if (!new_attr) {
             sk_ASN1_TYPE_pop_free(sk, ASN1_TYPE_free);
@@ -240,7 +240,7 @@ ossl_x509attr_get_value(VALUE self)
 
     count = X509_ATTRIBUTE_count(attr);
     for (i = 0; i < count; i++)
-        sk_ASN1_TYPE_push(sk, X509_ATTRIBUTE_get0_type(attr, i));
+        sk_ASN1_TYPE_push(sk, (ASN1_TYPE *)X509_ATTRIBUTE_get0_type(attr, i));
 
     if ((len = i2d_ASN1_SET_ANY(sk, NULL)) <= 0) {
         sk_ASN1_TYPE_free(sk);


### PR DESCRIPTION
`X509_ATTRIBUTE_get0_object()` and `X509_ATTRIBUTE_get0_type()` return `const` pointers in OpenSSL master, which breaks the build with `-Werror=discarded-qualifiers`.

Noticed this while working on #1004 — the `openssl-master` CI job was already failing before that PR, and it's still failing on master now.