### PR TITLE
Bump minimum jruby-openssl to 0.15.4 for CVE-2025-46551

### DIFF
--- a/openssl.gemspec
+++ b/openssl.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   if Gem::Platform === spec.platform and spec.platform =~ 'java' or RUBY_ENGINE == 'jruby'
     spec.platform    = "java"
     spec.files       = []
-    spec.add_runtime_dependency('jruby-openssl', '~> 0.14')
+    spec.add_runtime_dependency('jruby-openssl')
   else
     spec.files         = Dir.glob(["lib/**/*.rb", "ext/**/*.{c,h,rb}", "*.md"], base: File.expand_path("..", __FILE__)) +
                          ["BSDL", "COPYING"]


### PR DESCRIPTION
I recieved the dependabot alert for `GHSA-72qj-48g4-5xgx` at ruby/ruby repository. We should bump up to `jruby-openssl` dependency with fixed version.

/cc @headius 