### PR TITLE
CI: Upgrade OpenSSL versions and LibreSSL comments

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,23 +101,24 @@ jobs:
         openssl:
           # https://openssl-library.org/source/
           - openssl-1.1.1w # EOL 2023-09-11, still used by RHEL 8 and Ubuntu 20.04
-          - openssl-3.0.18 # Supported until 2026-09-07 (LTS)
+          - openssl-3.0.20 # Supported until 2026-09-07 (LTS)
           - openssl-3.1.8 # EOL 2025-03-14
-          - openssl-3.2.6 # Supported until 2025-11-23
-          - openssl-3.3.5 # Supported until 2026-04-09
-          - openssl-3.4.3 # Supported until 2026-10-22
-          - openssl-3.5.4 # Supported until 2030 (LTS)
-          - openssl-3.6.0 # EOL TBD
+          - openssl-3.2.6 # EOL 2025-11-23
+          - openssl-3.3.7 # EOL 2026-04-09
+          - openssl-3.4.5 # Supported until 2026-10-22
+          - openssl-3.5.6 # Supported until 2030-04-08 (LTS)
+          - openssl-3.6.2 # Supported until 2026-11-01
+          - openssl-4.0.0 # Supported until 2027-05-14
           - openssl-master
           # http://www.libressl.org/releases.html
           - libressl-3.9.2 # EOL 2025-04-05
-          - libressl-4.0.1 # Supported until 2025-10-08
+          - libressl-4.0.1 # EOL 2025-10-08
           - libressl-4.1.2 # Supported until 2026-04-28
-          - libressl-4.2.1
+          - libressl-4.2.1 # Supported until 2026-10-22
           # https://github.com/aws/aws-lc/tags
           - aws-lc-latest
         include:
-          - { name-extra: 'without legacy provider', openssl: openssl-3.5.4, append-configure: 'no-legacy' }
+          - { name-extra: 'without legacy provider', openssl: openssl-4.0.0, append-configure: 'no-legacy' }
           - { openssl: aws-lc-latest, skip-warnings: true }
     steps:
       - name: repo checkout


### PR DESCRIPTION
This PR is to upgrade OpenSSL versions and LibreSSL comments.

OpenSSL 4.0.0 final version was released yesterday.

https://openssl-library.org/post/2026-04-14-openssl-40-final-release/

---

Add OpenSSL version 4.0.0.

Add LibreSSL version 4.2 EOL as 2026-10-22, because the EOL is the LibreSSL version 4.2.0 released date (2025-10-22) + 1 year according to the following pages.

https://www.libressl.org/releases.html

> LibreSSL stable branches are updated for 1 year after their corresponding OpenBSD branch is tagged for release. See below for the current stable release branches.

https://www.openbsd.org/78.html

> OpenBSD 7.8
> ...
> Released Oct 22, 2025. (59th OpenBSD release)
> ...
> LibreSSL version 4.2.0: