### PR TITLE
pkey: fix memory leak when derived key is too large

### DIFF
--- a/ext/openssl/ossl_pkey.c
+++ b/ext/openssl/ossl_pkey.c
@@ -1496,8 +1496,10 @@ ossl_pkey_derive(int argc, VALUE *argv, VALUE self)
         EVP_PKEY_CTX_free(ctx);
         ossl_raise(ePKeyError, "EVP_PKEY_derive");
     }
-    if (keylen > LONG_MAX)
+    if (keylen > LONG_MAX) {
+        EVP_PKEY_CTX_free(ctx);
         rb_raise(ePKeyError, "derived key would be too large");
+    }
     str = ossl_str_new(NULL, (long)keylen, &state);
     if (state) {
         EVP_PKEY_CTX_free(ctx);


### PR DESCRIPTION
Unlikely to happen in practice, but mirrors other similar checks that also free the context.