### PR TITLE
x509cert: check for error of X509_set_serialNumber()

### DIFF
--- a/ext/openssl/ossl_x509cert.c
+++ b/ext/openssl/ossl_x509cert.c
@@ -311,7 +311,9 @@ ossl_x509_set_serial(VALUE self, VALUE num)
     X509 *x509;
 
     GetX509(self, x509);
-    X509_set_serialNumber(x509, num_to_asn1integer(num, X509_get_serialNumber(x509)));
+    if (!X509_set_serialNumber(x509, num_to_asn1integer(num, X509_get_serialNumber(x509)))) {
+        ossl_raise(eX509CertError, NULL);
+    }
 
     return num;
 }


### PR DESCRIPTION
This function may return 0 on error [1].

[1] https://manpages.debian.org/stretch/libssl-doc/X509_set_serialNumber.3ssl.en.html

This was found by a hybrid static-dynamic analyser that looks for inconsistent handling of error checks in bindings.