### PR TITLE
x509store: check for error of X509_STORE_set_ex_data()

### DIFF
--- a/ext/openssl/ossl_ssl.c
+++ b/ext/openssl/ossl_ssl.c
@@ -91,7 +91,8 @@ ossl_sslctx_s_alloc(VALUE klass)
     SSL_CTX_set_mode(ctx, mode);
     SSL_CTX_set_dh_auto(ctx, 1);
     RTYPEDDATA_DATA(obj) = ctx;
-    SSL_CTX_set_ex_data(ctx, ossl_sslctx_ex_ptr_idx, (void *)obj);
+    if (!SSL_CTX_set_ex_data(ctx, ossl_sslctx_ex_ptr_idx, (void *)obj))
+        ossl_raise(eSSLError, "SSL_CTX_set_ex_data");
 
     return obj;
 }
@@ -1672,7 +1673,8 @@ ossl_ssl_initialize(int argc, VALUE *argv, VALUE self)
         ossl_raise(eSSLError, NULL);
     RTYPEDDATA_DATA(self) = ssl;
 
-    SSL_set_ex_data(ssl, ossl_ssl_ex_ptr_idx, (void *)self);
+    if (!SSL_set_ex_data(ssl, ossl_ssl_ex_ptr_idx, (void *)self))
+        ossl_raise(eSSLError, "SSL_set_ex_data");
     SSL_set_info_callback(ssl, ssl_info_cb);
 
     rb_call_super(0, NULL);

--- a/ext/openssl/ossl_x509store.c
+++ b/ext/openssl/ossl_x509store.c
@@ -190,8 +190,9 @@ ossl_x509store_set_vfy_cb(VALUE self, VALUE cb)
     X509_STORE *store;
 
     GetX509Store(self, store);
+    if (!X509_STORE_set_ex_data(store, store_ex_verify_cb_idx, (void *)cb))
+        ossl_raise(eX509StoreError, "X509_STORE_set_ex_data");
     rb_iv_set(self, "@verify_callback", cb);
-    X509_STORE_set_ex_data(store, store_ex_verify_cb_idx, (void *)cb);
     RB_OBJ_WRITTEN(self, Qundef, cb);
 
     return cb;
@@ -608,7 +609,8 @@ ossl_x509stctx_verify(VALUE self)
 
     GetX509StCtx(self, ctx);
     VALUE cb = rb_iv_get(self, "@verify_callback");
-    X509_STORE_CTX_set_ex_data(ctx, stctx_ex_verify_cb_idx, (void *)cb);
+    if (!X509_STORE_CTX_set_ex_data(ctx, stctx_ex_verify_cb_idx, (void *)cb))
+        ossl_raise(eX509StoreError, "X509_STORE_CTX_set_ex_data");
     RB_OBJ_WRITTEN(self, Qundef, cb);
 
     switch (X509_verify_cert(ctx)) {


### PR DESCRIPTION
This can technically fail because it internally performs allocations. Also confirmed by the man page [1].

[1] (among other functions on this page) https://docs.openssl.org/3.5/man3/BIO_get_ex_new_index

This was found by a hybrid static-dynamic analyser that looks for inconsistent handling of error checks in bindings.