### PR TITLE
pkey: fix error check of i2d_DHparams()

### DIFF
--- a/ext/openssl/ossl_pkey_dh.c
+++ b/ext/openssl/ossl_pkey_dh.c
@@ -286,7 +286,7 @@ ossl_dh_to_der(VALUE self)
         ossl_raise(ePKeyError, NULL);
     str = rb_str_new(0, len);
     p = (unsigned char *)RSTRING_PTR(str);
-    if(i2d_DHparams(dh, &p) < 0)
+    if(i2d_DHparams(dh, &p) <= 0)
         ossl_raise(ePKeyError, NULL);
     ossl_str_adjust(str, p);
 


### PR DESCRIPTION
The first call correctly checks for a value <=0, the second call does not.
According to LibreSSL docs [1] the error is <=0.
For OpenSSL, we refer to [2] which refers to [3] only states that a value <0 returns an error, but this appears to be a docs inconsistency that does not match reality.
Fix this inconsistency for LibreSSL by using the same check.

[1] https://man.openbsd.org/d2i_DHparams.3
[2] https://manpages.debian.org/stretch/libssl-doc/i2d_DHparams.3ssl.en.html
[3] https://manpages.debian.org/stretch/libssl-doc/d2i_X509.3ssl.en.html

This was found by a hybrid static-dynamic analyser that looks for inconsistent handling of error checks in bindings.