### PR TITLE
x509attr: check for errors of sk_ASN1_TYPE_push() & use reserve call

### DIFF
--- a/ext/openssl/extconf.rb
+++ b/ext/openssl/extconf.rb
@@ -135,6 +135,7 @@ Logging::message "=== Checking for OpenSSL features... ===\n"
 evp_h = "openssl/evp.h".freeze
 ts_h = "openssl/ts.h".freeze
 ssl_h = "openssl/ssl.h".freeze
+stack_h = "openssl/stack.h".freeze
 
 # compile options
 have_func("RAND_egd()", "openssl/rand.h")
@@ -149,6 +150,9 @@ have_func("EVP_PBE_scrypt(\"\", 0, (unsigned char *)\"\", 0, 0, 0, 0, 0, NULL, 0
 
 # added in OpenSSL 1.1.1 and LibreSSL 3.5.0, then removed in LibreSSL 4.0.0
 have_func("EVP_PKEY_check(NULL)", evp_h)
+
+# added in OpenSSL 1.1.1, currently not in LibreSSL
+have_func("OPENSSL_sk_new_reserve(NULL, 0)", stack_h)
 
 # added in 3.0.0
 have_func("SSL_CTX_set0_tmp_dh_pkey(NULL, NULL)", ssl_h)

--- a/ext/openssl/ossl_x509attr.c
+++ b/ext/openssl/ossl_x509attr.c
@@ -235,9 +235,15 @@ ossl_x509attr_get_value(VALUE self)
     unsigned char *p;
 
     GetX509Attr(self, attr);
+    count = X509_ATTRIBUTE_count(attr);
     /* there is no X509_ATTRIBUTE_get0_set() :( */
+#ifdef HAVE_OPENSSL_SK_NEW_RESERVE
+    if (!(sk = sk_ASN1_TYPE_new_reserve(NULL, count)))
+        ossl_raise(eX509AttrError, "sk_new_reserve");
+#else
     if (!(sk = sk_ASN1_TYPE_new_null()))
         ossl_raise(eX509AttrError, "sk_new");
+#endif
 
     for (i = 0; i < count; i++) {
         if (!sk_ASN1_TYPE_push(sk, (ASN1_TYPE *)X509_ATTRIBUTE_get0_type(attr, i))) {

--- a/ext/openssl/ossl_x509attr.c
+++ b/ext/openssl/ossl_x509attr.c
@@ -239,9 +239,12 @@ ossl_x509attr_get_value(VALUE self)
     if (!(sk = sk_ASN1_TYPE_new_null()))
         ossl_raise(eX509AttrError, "sk_new");
 
-    count = X509_ATTRIBUTE_count(attr);
-    for (i = 0; i < count; i++)
-        sk_ASN1_TYPE_push(sk, (ASN1_TYPE *)X509_ATTRIBUTE_get0_type(attr, i));
+    for (i = 0; i < count; i++) {
+        if (!sk_ASN1_TYPE_push(sk, (ASN1_TYPE *)X509_ATTRIBUTE_get0_type(attr, i))) {
+            sk_ASN1_TYPE_free(sk);
+            ossl_raise(eX509AttrError, NULL);
+        }
+    }
 
     if ((len = i2d_ASN1_SET_ANY(sk, NULL)) <= 0) {
         sk_ASN1_TYPE_free(sk);


### PR DESCRIPTION
See individual commits.

This function returns 0 on error. The main error condition is reallocation, so use a reserve call to avoid reallocations as well.

This was found by a hybrid static-dynamic analyser that looks for inconsistent handling of error checks in bindings.