### PR TITLE
pkcs7: fix error check of PKCS7_RECIP_INFO_set()

### DIFF
--- a/ext/openssl/ossl_pkcs7.c
+++ b/ext/openssl/ossl_pkcs7.c
@@ -1055,7 +1055,7 @@ ossl_pkcs7ri_initialize(VALUE self, VALUE cert)
 
     x509 = GetX509CertPtr(cert); /* NO NEED TO DUP */
     GetPKCS7ri(self, p7ri);
-    if (!PKCS7_RECIP_INFO_set(p7ri, x509)) {
+    if (PKCS7_RECIP_INFO_set(p7ri, x509) <= 0) {
         ossl_raise(ePKCS7Error, NULL);
     }
 


### PR DESCRIPTION
This function actually returns a value <=0 on error, but it is not documented as such.
Example from OpenSSL code [1] and implementation [2] indicate as such.

[1] https://github.com/openssl/openssl/blob/4b8ddae690d6449005e474bfdfe73106d4d6c5ea/crypto/pkcs7/pk7_lib.c#L578
[2] https://github.com/openssl/openssl/blob/4b8ddae690d6449005e474bfdfe73106d4d6c5ea/crypto/pkcs7/pk7_lib.c#L625

This was found by a hybrid static-dynamic analyser that looks for inconsistent handling of error checks in bindings.