### PR TITLE
asn1: add error checks for ASN1_STRING_set() calls

### DIFF
--- a/ext/openssl/ossl_asn1.c
+++ b/ext/openssl/ossl_asn1.c
@@ -253,7 +253,10 @@ obj_to_asn1str(VALUE obj)
     StringValue(obj);
     if(!(str = ASN1_STRING_new()))
         ossl_raise(eASN1Error, NULL);
-    ASN1_STRING_set(str, RSTRING_PTR(obj), RSTRING_LENINT(obj));
+    if(!ASN1_STRING_set(str, RSTRING_PTR(obj), RSTRING_LENINT(obj))) {
+        ASN1_STRING_free(str);
+        ossl_raise(eASN1Error, NULL);
+    }
 
     return str;
 }
@@ -323,7 +326,10 @@ obj_to_asn1derstr(VALUE obj)
     str = ossl_to_der(obj);
     if(!(a1str = ASN1_STRING_new()))
         ossl_raise(eASN1Error, NULL);
-    ASN1_STRING_set(a1str, RSTRING_PTR(str), RSTRING_LENINT(str));
+    if(!ASN1_STRING_set(a1str, RSTRING_PTR(str), RSTRING_LENINT(str))) {
+        ASN1_STRING_free(a1str);
+        ossl_raise(eASN1Error, NULL);
+    }
 
     return a1str;
 }


### PR DESCRIPTION
Other calls in the project have such checks, add it consistently everywhere to raise an exception in case of an error.

This was found by a hybrid static-dynamic analyser that looks for inconsistent handling of error checks in bindings.