### PR TITLE
pkcs7: fix error check of PKCS7_SIGNER_INFO_set()

### DIFF
--- a/ext/openssl/ossl_pkcs7.c
+++ b/ext/openssl/ossl_pkcs7.c
@@ -979,7 +979,7 @@ ossl_pkcs7si_initialize(VALUE self, VALUE cert, VALUE key, VALUE digest)
     x509 = GetX509CertPtr(cert); /* NO NEED TO DUP */
     md = ossl_evp_md_fetch(digest, &md_holder);
     GetPKCS7si(self, p7si);
-    if (!(PKCS7_SIGNER_INFO_set(p7si, x509, pkey, md)))
+    if (PKCS7_SIGNER_INFO_set(p7si, x509, pkey, md) <= 0)
         ossl_raise(ePKCS7Error, "PKCS7_SIGNER_INFO_set");
     rb_ivar_set(self, id_md_holder, md_holder);
 


### PR DESCRIPTION
This function returns <=0 on error, not only 0.
This is evident by looking at the implementation where it can return a negative error here [1]. Use in OpenSSL itself also uses the <=0 check [2].

[1] https://github.com/openssl/openssl/blob/087bddcda9973671d52f94e63db32bfd6001fd1b/crypto/pkcs7/pk7_lib.c#L378-L381
[2] https://github.com/openssl/openssl/blob/087bddcda9973671d52f94e63db32bfd6001fd1b/crypto/pkcs7/pk7_lib.c#L414

This was found by a hybrid static-dynamic analyser that looks for inconsistent handling of error checks in bindings.