### PR TITLE
hmac: enable tests in the FIPS mode

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -26,7 +26,6 @@ Rake::TestTask.new(:test_fips_internal) do |t|
   # Exclude failing test files in FIPS for this task to pass.
   # TODO: Fix failing test files.
   t.test_files = FileList['test/**/test_*.rb'] - FileList[
-    'test/openssl/test_hmac.rb',
     'test/openssl/test_kdf.rb',
     'test/openssl/test_ts.rb',
   ]

--- a/test/openssl/test_hmac.rb
+++ b/test/openssl/test_hmac.rb
@@ -4,14 +4,18 @@ require_relative 'utils'
 if defined?(OpenSSL)
 
 class OpenSSL::TestHMAC < OpenSSL::TestCase
-  def test_hmac
+  def test_hmac_md5
+    omit_on_fips # MD5
+
     # RFC 2202 2. Test Cases for HMAC-MD5
     hmac = OpenSSL::HMAC.new(["0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b"].pack("H*"), "MD5")
     hmac.update("Hi There")
     assert_equal ["9294727a3638bb1c13f48ef8158bfc9d"].pack("H*"), hmac.digest
     assert_equal "9294727a3638bb1c13f48ef8158bfc9d", hmac.hexdigest
     assert_equal "kpRyejY4uxwT9I74FYv8nQ==", hmac.base64digest
+  end
 
+  def test_hmac_sha224
     # RFC 4231 4.2. Test Case 1
     hmac = OpenSSL::HMAC.new(["0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b"].pack("H*"), "SHA224")
     hmac.update("Hi There")
@@ -21,7 +25,7 @@ class OpenSSL::TestHMAC < OpenSSL::TestCase
   end
 
   def test_dup
-    h1 = OpenSSL::HMAC.new("KEY", "MD5")
+    h1 = OpenSSL::HMAC.new("KEY"*32, "SHA256")
     h1.update("DATA")
     h = h1.dup
     assert_equal(h1.digest, h.digest, "dup digest")
@@ -35,7 +39,7 @@ class OpenSSL::TestHMAC < OpenSSL::TestCase
   end
 
   def test_reset_keep_key
-    h1 = OpenSSL::HMAC.new("KEY", "MD5")
+    h1 = OpenSSL::HMAC.new("KEY"*32, "SHA256")
     first = h1.update("test").hexdigest
     h1.reset
     second = h1.update("test").hexdigest
@@ -43,9 +47,9 @@ class OpenSSL::TestHMAC < OpenSSL::TestCase
   end
 
   def test_eq
-    h1 = OpenSSL::HMAC.new("KEY", "MD5")
-    h2 = OpenSSL::HMAC.new("KEY", OpenSSL::Digest.new("MD5"))
-    h3 = OpenSSL::HMAC.new("FOO", "MD5")
+    h1 = OpenSSL::HMAC.new("KEY"*32, "SHA256")
+    h2 = OpenSSL::HMAC.new("KEY"*32, OpenSSL::Digest.new("SHA256"))
+    h3 = OpenSSL::HMAC.new("FOO"*32, "SHA256")
 
     assert_equal h1, h2
     refute_equal h1, h2.digest
@@ -53,17 +57,19 @@ class OpenSSL::TestHMAC < OpenSSL::TestCase
   end
 
   def test_singleton_methods
-    # RFC 2202 2. Test Cases for HMAC-MD5
-    key = ["0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b"].pack("H*")
-    digest = OpenSSL::HMAC.digest("MD5", key, "Hi There")
-    assert_equal ["9294727a3638bb1c13f48ef8158bfc9d"].pack("H*"), digest
-    hexdigest = OpenSSL::HMAC.hexdigest("MD5", key, "Hi There")
-    assert_equal "9294727a3638bb1c13f48ef8158bfc9d", hexdigest
-    b64digest = OpenSSL::HMAC.base64digest("MD5", key, "Hi There")
-    assert_equal "kpRyejY4uxwT9I74FYv8nQ==", b64digest
+    # RFC 4231 4.2. Test Case 1
+    key = ["0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b"].pack("H*")
+    digest = OpenSSL::HMAC.digest("SHA256", key, "Hi There")
+    assert_equal ["b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7"].pack("H*"), digest
+    hexdigest = OpenSSL::HMAC.hexdigest("SHA256", key, "Hi There")
+    assert_equal "b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7", hexdigest
+    b64digest = OpenSSL::HMAC.base64digest("SHA256", key, "Hi There")
+    assert_equal "sDRMYdjbOFNcqK/OrwvxK4gdwgDJgz2nJuk3bC4yz/c=", b64digest
   end
 
   def test_zero_length_key
+    omit_on_fips # Key length
+
     # Empty string as the key
     hexdigest = OpenSSL::HMAC.hexdigest("SHA256", "\0"*32, "test")
     assert_equal "43b0cef99265f9e34c10ea9d3501926d27b39f57c6d674561d8ba236e7a819fb", hexdigest

--- a/test/openssl/test_pkey.rb
+++ b/test/openssl/test_pkey.rb
@@ -166,9 +166,9 @@ class OpenSSL::TestPKey < OpenSSL::PKeyTestCase
   end if ENV["OSSL_TEST_ALL"] == "1" && Process.respond_to?(:setsid)
 
   def test_hmac_sign_verify
-    pkey = OpenSSL::PKey.generate_key("HMAC", { "key" => "abcd" })
+    pkey = OpenSSL::PKey.generate_key("HMAC", { "key" => "a"*32 })
 
-    hmac = OpenSSL::HMAC.new("abcd", "SHA256").update("data").digest
+    hmac = OpenSSL::HMAC.new("a"*32, "SHA256").update("data").digest
     assert_equal hmac, pkey.sign("SHA256", "data")
 
     # EVP_PKEY_HMAC does not support verify


### PR DESCRIPTION
Fix CI with OpenSSL master in the FIPS mode. With the fips provider in OpenSSL master, HMAC keys shorter than 112 bits are rejected and MD5 is disallowed. Update tests to use SHA-2 and longer keys.