### PR TITLE
fix: unchecked *_set_* calls

### DIFF
--- a/ext/openssl/ossl_ssl_session.c
+++ b/ext/openssl/ossl_ssl_session.c
@@ -183,7 +183,9 @@ static VALUE ossl_ssl_session_set_time(VALUE self, VALUE time_v)
         time_v = rb_funcall(time_v, rb_intern("to_i"), 0);
     }
     t = NUM2LONG(time_v);
-    SSL_SESSION_set_time(ctx, t);
+    if (SSL_SESSION_set_time(ctx, t) != t) {
+        ossl_raise(eSSLSession, "SSL_SESSION_set_time");
+    }
     return ossl_ssl_session_get_time(self);
 }
 
@@ -200,7 +202,9 @@ static VALUE ossl_ssl_session_set_timeout(VALUE self, VALUE time_v)
 
     GetSSLSession(self, ctx);
     t = NUM2LONG(time_v);
-    SSL_SESSION_set_timeout(ctx, t);
+    if (SSL_SESSION_set_timeout(ctx, t) != 1) {
+        ossl_raise(eSSLSession, "SSL_SESSION_set_timeout");
+    }
     return ossl_ssl_session_get_timeout(self);
 }
 

--- a/ext/openssl/ossl_ts.c
+++ b/ext/openssl/ossl_ts.c
@@ -441,7 +441,9 @@ ossl_ts_req_set_cert_requested(VALUE self, VALUE requested)
     TS_REQ *req;
 
     GetTSRequest(self, req);
-    TS_REQ_set_cert_req(req, RTEST(requested));
+    if (!TS_REQ_set_cert_req(req, RTEST(requested))) {
+        ossl_raise(eTimestampError, "TS_REQ_set_cert_req");
+    }
 
     return requested;
 }
@@ -1229,11 +1231,17 @@ ossl_tsfac_create_ts(VALUE self, VALUE key, VALUE certificate, VALUE request)
             goto end;
 
         /* this dups the sk_X509 and ups each cert's ref count */
-        TS_RESP_CTX_set_certs(ctx, inter_certs);
+        if (!TS_RESP_CTX_set_certs(ctx, inter_certs)) {
+            err_msg = "Certificates could not be set";
+            goto end;
+        }
         sk_X509_pop_free(inter_certs, X509_free);
     }
 
-    TS_RESP_CTX_set_signer_key(ctx, sign_key);
+    if (!TS_RESP_CTX_set_signer_key(ctx, sign_key)) {
+        err_msg = "Signer key could not be set";
+        goto end;
+    }
     if (!NIL_P(def_policy_id) && !TS_REQ_get_policy_id(req))
         TS_RESP_CTX_set_def_policy(ctx, def_policy_id_obj);
     if (TS_REQ_get_policy_id(req))

--- a/ext/openssl/ossl_ts.c
+++ b/ext/openssl/ossl_ts.c
@@ -442,7 +442,9 @@ ossl_ts_req_set_cert_requested(VALUE self, VALUE requested)
     TS_REQ *req;
 
     GetTSRequest(self, req);
-    TS_REQ_set_cert_req(req, RTEST(requested));
+    if (!TS_REQ_set_cert_req(req, RTEST(requested))) {
+        ossl_raise(eTimestampError, "TS_REQ_set_cert_req");
+    }
 
     return requested;
 }
@@ -1232,11 +1234,17 @@ ossl_tsfac_create_ts(VALUE self, VALUE key, VALUE certificate, VALUE request)
             goto end;
 
         /* this dups the sk_X509 and ups each cert's ref count */
-        TS_RESP_CTX_set_certs(ctx, inter_certs);
+        if (!TS_RESP_CTX_set_certs(ctx, inter_certs)) {
+            err_msg = "Certificates could not be set";
+            goto end;
+        }
         sk_X509_pop_free(inter_certs, X509_free);
     }
 
-    TS_RESP_CTX_set_signer_key(ctx, sign_key);
+    if (!TS_RESP_CTX_set_signer_key(ctx, sign_key)) {
+        err_msg = "Signer key could not be set";
+        goto end;
+    }
     if (!NIL_P(def_policy_id) && !TS_REQ_get_policy_id(req))
         TS_RESP_CTX_set_def_policy(ctx, def_policy_id_obj);
     if (TS_REQ_get_policy_id(req))

--- a/ext/openssl/ossl_x509ext.c
+++ b/ext/openssl/ossl_x509ext.c
@@ -363,7 +363,9 @@ ossl_x509ext_set_critical(VALUE self, VALUE flag)
     X509_EXTENSION *ext;
 
     GetX509Ext(self, ext);
-    X509_EXTENSION_set_critical(ext, RTEST(flag) ? 1 : 0);
+    if (!X509_EXTENSION_set_critical(ext, RTEST(flag) ? 1 : 0)) {
+        ossl_raise(eX509ExtError, "X509_EXTENSION_set_critical");
+    }
 
     return flag;
 }

--- a/ext/openssl/ossl_x509store.c
+++ b/ext/openssl/ossl_x509store.c
@@ -246,7 +246,9 @@ ossl_x509store_set_flags(VALUE self, VALUE flags)
     long f = NUM2LONG(flags);
 
     GetX509Store(self, store);
-    X509_STORE_set_flags(store, f);
+    if (!X509_STORE_set_flags(store, f)) {
+        ossl_raise(eX509StoreError, "X509_STORE_set_flags");
+    }
 
     return flags;
 }
@@ -281,7 +283,9 @@ ossl_x509store_set_purpose(VALUE self, VALUE purpose)
     int p = NUM2INT(purpose);
 
     GetX509Store(self, store);
-    X509_STORE_set_purpose(store, p);
+    if (!X509_STORE_set_purpose(store, p)) {
+        ossl_raise(eX509StoreError, "X509_STORE_set_purpose");
+    }
 
     return purpose;
 }
@@ -305,7 +309,9 @@ ossl_x509store_set_trust(VALUE self, VALUE trust)
     int t = NUM2INT(trust);
 
     GetX509Store(self, store);
-    X509_STORE_set_trust(store, t);
+    if (!X509_STORE_set_trust(store, t)) {
+        ossl_raise(eX509StoreError, "X509_STORE_set_trust");
+    }
 
     return trust;
 }

--- a/ext/openssl/ossl_x509store.c
+++ b/ext/openssl/ossl_x509store.c
@@ -348,7 +348,9 @@ ossl_x509store_set_purpose(VALUE self, VALUE purpose)
     int p = NUM2INT(purpose);
 
     GetX509Store(self, store);
-    X509_STORE_set_purpose(store, p);
+    if (!X509_STORE_set_purpose(store, p)) {
+        ossl_raise(eX509StoreError, "X509_STORE_set_purpose");
+    }
 
     return purpose;
 }
@@ -372,7 +374,9 @@ ossl_x509store_set_trust(VALUE self, VALUE trust)
     int t = NUM2INT(trust);
 
     GetX509Store(self, store);
-    X509_STORE_set_trust(store, t);
+    if (!X509_STORE_set_trust(store, t)) {
+        ossl_raise(eX509StoreError, "X509_STORE_set_trust");
+    }
 
     return trust;
 }


### PR DESCRIPTION
Fixes #1038

This was found by a hybrid static-dynamic analyser that looks for inconsistent handling of error checks in bindings.