### PR TITLE
ts: refactor decoding DER

### DIFF
--- a/ext/openssl/ossl_pkcs12.c
+++ b/ext/openssl/ossl_pkcs12.c
@@ -191,6 +191,7 @@ ossl_x509_sk2ary_i(VALUE arg)
 static VALUE
 ossl_pkcs12_initialize(int argc, VALUE *argv, VALUE self)
 {
+    PKCS12 *p12, *p12_orig = DATA_PTR(self);
     BIO *in;
     VALUE arg, pass, pkey, cert, ca;
     char *passphrase;
@@ -198,17 +199,19 @@ ossl_pkcs12_initialize(int argc, VALUE *argv, VALUE self)
     X509 *x509;
     STACK_OF(X509) *x509s = NULL;
     int st = 0;
-    PKCS12 *pkcs = DATA_PTR(self);
 
     if(rb_scan_args(argc, argv, "02", &arg, &pass) == 0) return self;
     passphrase = NIL_P(pass) ? NULL : StringValueCStr(pass);
     in = ossl_obj2bio(&arg);
-    d2i_PKCS12_bio(in, &pkcs);
-    DATA_PTR(self) = pkcs;
+    p12 = d2i_PKCS12_bio(in, NULL);
     BIO_free(in);
+    if (!p12)
+        ossl_raise(ePKCS12Error, "d2i_PKCS12_bio");
+    PKCS12_free(p12_orig);
+    RTYPEDDATA_DATA(self) = p12;
 
     pkey = cert = ca = Qnil;
-    if(!PKCS12_parse(pkcs, passphrase, &key, &x509, &x509s))
+    if (!PKCS12_parse(p12, passphrase, &key, &x509, &x509s))
         ossl_raise(ePKCS12Error, "PKCS12_parse");
     if (key) {
         pkey = rb_protect(ossl_pkey_wrap_i, (VALUE)key, &st);

--- a/ext/openssl/ossl_ts.c
+++ b/ext/openssl/ossl_ts.c
@@ -168,7 +168,7 @@ ossl_ts_req_alloc(VALUE klass)
 static VALUE
 ossl_ts_req_initialize(int argc, VALUE *argv, VALUE self)
 {
-    TS_REQ *ts_req = DATA_PTR(self);
+    TS_REQ *req, *req_orig = DATA_PTR(self);
     BIO *in;
     VALUE arg;
 
@@ -178,13 +178,14 @@ ossl_ts_req_initialize(int argc, VALUE *argv, VALUE self)
 
     arg = ossl_to_der_if_possible(arg);
     in = ossl_obj2bio(&arg);
-    ts_req = d2i_TS_REQ_bio(in, &ts_req);
+    req = d2i_TS_REQ_bio(in, NULL);
     BIO_free(in);
-    if (!ts_req) {
-        DATA_PTR(self) = NULL;
-        ossl_raise(eTimestampError, "Error when decoding the timestamp request");
+    if (!req) {
+        ossl_raise(eTimestampError,
+                   "Error when decoding the timestamp request");
     }
-    DATA_PTR(self) = ts_req;
+    TS_REQ_free(req_orig);
+    RTYPEDDATA_DATA(self) = req;
 
     return self;
 }
@@ -522,18 +523,19 @@ ossl_ts_resp_alloc(VALUE klass)
 static VALUE
 ossl_ts_resp_initialize(VALUE self, VALUE der)
 {
-    TS_RESP *ts_resp = DATA_PTR(self);
+    TS_RESP *resp, *resp_orig = DATA_PTR(self);
     BIO *in;
 
     der = ossl_to_der_if_possible(der);
-    in  = ossl_obj2bio(&der);
-    ts_resp = d2i_TS_RESP_bio(in, &ts_resp);
+    in = ossl_obj2bio(&der);
+    resp = d2i_TS_RESP_bio(in, NULL);
     BIO_free(in);
-    if (!ts_resp) {
-        DATA_PTR(self) = NULL;
-        ossl_raise(eTimestampError, "Error when decoding the timestamp response");
+    if (!resp) {
+        ossl_raise(eTimestampError,
+                   "Error when decoding the timestamp response");
     }
-    DATA_PTR(self) = ts_resp;
+    TS_RESP_free(resp_orig);
+    RTYPEDDATA_DATA(self) = resp;
 
     return self;
 }
@@ -876,18 +878,19 @@ ossl_ts_token_info_alloc(VALUE klass)
 static VALUE
 ossl_ts_token_info_initialize(VALUE self, VALUE der)
 {
-    TS_TST_INFO *info = DATA_PTR(self);
+    TS_TST_INFO *info, *info_orig = DATA_PTR(self);
     BIO *in;
 
     der = ossl_to_der_if_possible(der);
-    in  = ossl_obj2bio(&der);
-    info = d2i_TS_TST_INFO_bio(in, &info);
+    in = ossl_obj2bio(&der);
+    info = d2i_TS_TST_INFO_bio(in, NULL);
     BIO_free(in);
     if (!info) {
-        DATA_PTR(self) = NULL;
-        ossl_raise(eTimestampError, "Error when decoding the timestamp token info");
+        ossl_raise(eTimestampError,
+                   "Error when decoding the timestamp token info");
     }
-    DATA_PTR(self) = info;
+    TS_TST_INFO_free(info_orig);
+    RTYPEDDATA_DATA(self) = info;
 
     return self;
 }


### PR DESCRIPTION
Do not rely on the "reuse" behavior of d2i_*{,_bio}() functions which has been discouraged in the man page. This also fixes a potential memory leak reported in <https://github.com/ruby/openssl/issues/1011>.
