### PR TITLE
test_ssl.rb: Fix key numbering in test_pqc_sigalg

### DIFF
--- a/test/openssl/test_ssl.rb
+++ b/test/openssl/test_ssl.rb
@@ -2101,13 +2101,13 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
     # PQC algorithm ML-DSA (FIPS 204) is supported on OpenSSL 3.5 or later.
     return unless openssl?(3, 5, 0)
 
-    mldsa = Fixtures.pkey("mldsa65-1")
-    mldsa_ca_key  = Fixtures.pkey("mldsa65-2")
+    mldsa = Fixtures.pkey("mldsa65-2")
+    mldsa_ca_key  = Fixtures.pkey("mldsa65-1")
     mldsa_ca_cert = issue_cert(@ca, mldsa_ca_key, 1, @ca_exts, nil, nil,
                                digest: nil)
     mldsa_cert = issue_cert(@svr, mldsa, 60, [], mldsa_ca_cert, mldsa_ca_key,
                             digest: nil)
-    rsa = Fixtures.pkey("rsa-1")
+    rsa = Fixtures.pkey("rsa-2")
     rsa_cert = issue_cert(@svr, rsa, 61, [], @ca_cert, @ca_key)
     ctx_proc = -> ctx {
       # Unset values set by start_server


### PR DESCRIPTION
I noticed that the rsa-1 is used for certificate (CA) and server in the test/openssl/test_ssl.rb test_pqc_sigalg test, as `@ca_key` and `@ca_cert` are created by rsa-1 according to the following logic:


test/openssl/test_ssl.rb
```
  def setup
...
    @ca_key  = Fixtures.pkey("rsa-1")
    @svr_key = Fixtures.pkey("rsa-2")
    @cli_key = Fixtures.pkey("rsa-3")
...
    @ca_cert  = issue_cert(@ca, @ca_key, 1, @ca_exts, nil, nil)
    @svr_cert = issue_cert(@svr, @svr_key, 2, @ee_exts, @ca_cert, @ca_key)
    @cli_cert = issue_cert(@cli, @cli_key, 3, @ee_exts, @ca_cert, @ca_key)
...
  end
```

I assume that this may not be intentional. So, I changed the key numbers

---

* Align key numbers with the pattern in test/openssl/utils.rb setup: rsa-1 for
  certificate (CA), rsa-2 for server, rsa-3 for client.
* Use mldsa65-1 for certificate and mldsa65-2 for server.
* Use rsa-2 for server, because rsa-1 is already used for certificate (@ca_key,
  @ca_cert).

Assisted-by: Claude Code