### PR TITLE
Make OpenSSL::Digest classes Ractor-safe

### DIFF
--- a/lib/openssl/digest.rb
+++ b/lib/openssl/digest.rb
@@ -27,17 +27,21 @@ module OpenSSL
     end
 
     %w(MD4 MD5 RIPEMD160 SHA1 SHA224 SHA256 SHA384 SHA512).each do |name|
-      klass = Class.new(self) {
-        define_method(:initialize, ->(data = nil) {super(name, data)})
-      }
+      klass = Class.new(self)
+      klass.class_eval <<-RUBY, __FILE__, __LINE__ + 1
+        def initialize(data = nil)
+          super("#{name}", data)
+        end
+      RUBY
 
-      singleton = (class << klass; self; end)
-
-      singleton.class_eval{
-        define_method(:digest) {|data| new.digest(data)}
-        define_method(:hexdigest) {|data| new.hexdigest(data)}
-      }
-
+      klass.singleton_class.class_eval <<-RUBY, __FILE__, __LINE__ + 1
+        def digest(data)
+          new.digest(data)
+        end
+        def hexdigest(data)
+          new.hexdigest(data)
+        end
+      RUBY
       const_set(name.tr('-', '_'), klass)
     end
 

--- a/test/openssl/test_digest.rb
+++ b/test/openssl/test_digest.rb
@@ -155,6 +155,22 @@ class OpenSSL::TestDigest < OpenSSL::TestCase
     assert_include digests, "sha256"
     assert_include digests, "sha512"
   end
+
+  if respond_to?(:ractor) && defined?(Ractor.shareable_proc)
+    ractor
+
+    def test_ractor
+      assert_nothing_raised do
+        Ractor.new {
+          [
+            OpenSSL::Digest::SHA256.new(""),
+            OpenSSL::Digest::SHA256.hexdigest(""),
+            OpenSSL::Digest::SHA256.digest(""),
+          ]
+        }.value
+      end
+    end
+  end
 end
 
 end

--- a/test/openssl/test_digest.rb
+++ b/test/openssl/test_digest.rb
@@ -155,6 +155,27 @@ class OpenSSL::TestDigest < OpenSSL::TestCase
     assert_include digests, "sha256"
     assert_include digests, "sha512"
   end
+
+  if defined?(Ractor) && respond_to?(:ractor)
+    ractor
+    Ractor.alias_method(:value, :take) unless Ractor.method_defined?(:value)
+
+    def test_ractor
+      experimental_before = Warning[:experimental]
+      Warning[:experimental] = false
+      assert_nothing_raised do
+        Ractor.new {
+          [
+            OpenSSL::Digest::SHA256.new(""),
+            OpenSSL::Digest::SHA256.hexdigest(""),
+            OpenSSL::Digest::SHA256.digest(""),
+          ]
+        }.value
+      end
+    ensure
+      Warning[:experimental] = experimental_before
+    end
+  end
 end
 
 end


### PR DESCRIPTION
Use class_eval with a string so the initialize instance method, and the digest and hexdigest class methods are not defined via define_method with a Proc (which is not Ractor-safe).