### PR TITLE
x509crl: add OpenSSL::X509::CRL#by_serial

### DIFF
--- a/ext/openssl/ossl_x509crl.c
+++ b/ext/openssl/ossl_x509crl.c
@@ -327,6 +327,44 @@ ossl_x509crl_set_revoked(VALUE self, VALUE ary)
     return ary;
 }
 
+/*
+ * call-seq:
+ *    crl.by_serial(serial) -> OpenSSL::X509::Revoked or nil
+ *
+ * Looks up the certificate _serial_ (an Integer or OpenSSL::BN) in the CRL and
+ * returns the matching OpenSSL::X509::Revoked entry, or +nil+ if that serial is
+ * not listed.
+ *
+ * Unlike iterating over #revoked, this does not instantiate the entire
+ * revocation list: it performs a sorted lookup (wrapping the OpenSSL function
+ * +X509_CRL_get0_by_serial+), which is significantly faster and uses far less
+ * memory for large CRLs.
+ *
+ *    crl.by_serial(cert.serial)        #=> #<OpenSSL::X509::Revoked> or nil
+ *    crl.by_serial(cert.serial)&.time  #=> revocation time, if revoked
+ */
+static VALUE
+ossl_x509crl_by_serial(VALUE self, VALUE serial)
+{
+    X509_CRL *crl;
+    X509_REVOKED *rev = NULL;
+    ASN1_INTEGER *asn1_serial;
+    int found;
+
+    GetX509CRL(self, crl);
+    asn1_serial = num_to_asn1integer(serial, NULL);
+
+    /* 0 = not found, 1 = found, 2 = found with reason removeFromCRL */
+    found = X509_CRL_get0_by_serial(crl, &rev, asn1_serial);
+    ASN1_INTEGER_free(asn1_serial);
+
+    if (found == 0)
+        return Qnil;
+
+    /* ossl_x509revoked_new dups, so the result outlives the CRL safely */
+    return ossl_x509revoked_new(rev);
+}
+
 static VALUE
 ossl_x509crl_add_revoked(VALUE self, VALUE revoked)
 {
@@ -525,6 +563,7 @@ Init_ossl_x509crl(void)
     rb_define_method(cX509CRL, "next_update=", ossl_x509crl_set_next_update, 1);
     rb_define_method(cX509CRL, "revoked", ossl_x509crl_get_revoked, 0);
     rb_define_method(cX509CRL, "revoked=", ossl_x509crl_set_revoked, 1);
+    rb_define_method(cX509CRL, "by_serial", ossl_x509crl_by_serial, 1);
     rb_define_method(cX509CRL, "add_revoked", ossl_x509crl_add_revoked, 1);
     rb_define_method(cX509CRL, "sign", ossl_x509crl_sign, 2);
     rb_define_method(cX509CRL, "verify", ossl_x509crl_verify, 1);

--- a/test/openssl/test_x509crl.rb
+++ b/test/openssl/test_x509crl.rb
@@ -105,6 +105,44 @@ class OpenSSL::TestX509CRL < OpenSSL::TestCase
     assert_equal(revoked.map(&:serial), revoked2.map(&:serial))
   end
 
+  def test_by_serial
+    now = Time.at(Time.now.to_i)
+    revoke_info = [
+      [1, Time.at(0),          1], # keyCompromise
+      [2, Time.at(0x7fffffff), 2], # cACompromise
+      [3, now,                 3], # affiliationChanged
+    ]
+    cert = issue_cert(@ca, @rsa1, 1, [], nil, nil)
+    crl = issue_crl(revoke_info, 1, Time.now, Time.now+1600, [],
+                    cert, @rsa1, "SHA256")
+
+    # Returns the matching Revoked entry for a listed serial
+    rev = crl.by_serial(2)
+    assert_instance_of(OpenSSL::X509::Revoked, rev)
+    assert_equal(2, rev.serial)
+    assert_equal(Time.at(0x7fffffff), rev.time)
+    assert_equal("CRLReason", rev.extensions[0].oid)
+    assert_equal("CA Compromise", rev.extensions[0].value)
+
+    # Accepts an OpenSSL::BN as well as an Integer
+    assert_equal(3, crl.by_serial(OpenSSL::BN.new(3)).serial)
+
+    # Returns nil for a serial that is not listed
+    assert_nil(crl.by_serial(42))
+
+    # Same answers after a DER round-trip, and consistent with #revoked
+    crl = OpenSSL::X509::CRL.new(crl.to_der)
+    revoke_info.each do |serial, time, _reason|
+      by_serial = crl.by_serial(serial)
+      from_list = crl.revoked.find {|r| r.serial == serial }
+      assert_equal(by_serial, from_list)
+      assert_equal(time, by_serial.time)
+    end
+
+    # Rejects values that can't be an integer serial
+    assert_raise(TypeError) { crl.by_serial(nil) }
+  end
+
   def test_extension
     cert_exts = [
       ["basicConstraints", "CA:TRUE", true],


### PR DESCRIPTION
Adds `OpenSSL::X509::CRL#by_serial(serial)`, which returns the
`OpenSSL::X509::Revoked` entry for a given certificate serial (Integer or
`OpenSSL::BN`), or `nil` if the serial isn't listed. It wraps the OpenSSL
function `X509_CRL_get0_by_serial`.

Implements the request in #1064.

## Why

Today the only way to check whether a serial is revoked is to iterate
`#revoked`, which instantiates the *entire* revocation list as Ruby objects
even though we only care about one entry. For large CRLs (now commonly
hundreds of thousands to millions of entries) that is very slow and allocates
a lot. `#by_serial` does a sorted lookup instead, so the cost is independent
of the CRL size.

## Notes

- Returns a dup'd `Revoked` (via the existing `ossl_x509revoked_new`), so the result is safe to keep after the CRL is gone.
- Accepts an Integer or `OpenSSL::BN` and converts it internally.
- `X509_CRL_get0_by_serial` sorts the revoked stack on first use (cached on the `X509_CRL`), so repeated lookups on the same object are O(log n).
- Available since OpenSSL 1.0.0; present in LibreSSL and AWS-LC, so no version guard is needed.
- Tests added in `test/openssl/test_x509crl.rb` (`test_by_serial`): present and absent serials, `OpenSSL::BN` argument, DER round-trip, agreement with `#revoked`, and a `TypeError` on a non-integer argument.
- I added some comments/doc at the top of the method but noticed it's not very common in this file, if you prefer I remove that and put the explanation elsewhere let me know. (It's supposed to end here I guess: https://ruby.github.io/openssl/OpenSSL/X509/CRL.html#method-i-revoked ?)
- It's been some time since I've written C so feel free to criticize :sweat_smile: 

## Benchmark

Ruby 3.3.5 / OpenSSL 3.5.5, via `benchmark-ips` / `benchmark-memory`. Two modes:
- **warm** = lookup on an already-parsed CRL (you reuse the object, so `by_serial`'s one-time sort is amortised as next queries are O(log n)). Very efficient as you can see below but not easy to leverage (you would need to verify a lot of certs agains a single CRL at the same time for this to matter). Always good to see of course :)
- **cold** = parse a fresh CRL + one lookup (the most common one-shot pattern IMO). Here the gain is a more moderate 2-3x in CPU time, but huge in ruby object allocations (=way less work for GC and memory noise).

#### Big CRL — 53.5 MB, 1,092,362 revoked entries

| mode | serial      | `revoked.find`                | `by_serial`            |
|------|-------------|-------------------------------|------------------------|
| warm | not revoked | ~0.36 s, 139.8 MB / 3.28M objs | ~0.24 µs, 40 B / 1 obj (1,500,000x)|
| warm | revoked     | ~0.13 s, 79.7 MB / 1.78M objs | ~1.1 µs, 40 B / 1 obj (100,000x)    |
| cold | not revoked | ~2.17 s,139.8 MB / 3.28M objs | ~0.95 s, 80 B / 2 objs (2.3x)       |
| cold | revoked     | ~1.69 s, 74.3 MB / 1.63M objs | ~0.84 s, 80 B / 2 objs (2.0x)       |

#### Average CRL (Let's Encrypt shard) — 0.2 MB, 5,146 revoked entries : http://r13.c.lencr.org/114.crl

| mode | serial      | `revoked.find`              | `by_serial`            |
|------|-------------|-----------------------------|------------------------|
| warm | not revoked | ~1.5 ms, 659 KB / 15.4k objs| ~0.23 µs, 40 B / 1 obj (6600x) |
| warm | revoked     | ~0.2 ms, 291 KB / 6.2k objs | ~0.60 µs, 40 B / 1 obj (352x)  |
| cold | not revoked | ~5.3 ms, 659 KB / 15.4k objs| ~1.8 ms, 80 B / 2 objs (2.8x)  |
| cold | revoked     | ~4.2 ms, 350 KB / 7.7k objs | ~1.5 ms, 80 B / 2 objs (2.7x)  |

This benchmark counts ruby allocations but not C, so some of the C allocations made by openssl are not shown here. But they are similar in both columns as `by_serial` still needs to parse the whole CRL once, we're just avoiding the instantiation of all the ruby objects (which is the most important).

```ruby
#!/usr/bin/env ruby
#
# Needs the patched openssl that defines #by_serial; point OPENSSL_LIB at the dev
# build (defaults to ../openssl/lib). gem install benchmark-ips benchmark-memory
#
#   ruby by_serial_bench.rb [CRL_URL]

dev = ENV["OPENSSL_LIB"] || File.expand_path("../openssl/lib", __dir__)
$LOAD_PATH.unshift(dev) if File.exist?(File.join(dev, "openssl.so"))

require "openssl"
require "net/http"
require "uri"
require "tmpdir"
require "benchmark/ips"
require "benchmark/memory"

abort "loaded openssl has no #by_serial (set OPENSSL_LIB to the patched build)" unless
  OpenSSL::X509::CRL.method_defined?(:by_serial)

url   = ARGV[0] || "http://c.cf-i.ssl.com/ae801ed1c55bb579d79208b0d772acfb8cc3a208.crl" # big CRL example
cache = File.join(Dir.tmpdir, "by_serial_bench_#{File.basename(URI(url).path)}")
body  = File.exist?(cache) ? File.binread(cache) :
        (warn("downloading #{url} ..."); d = Net::HTTP.get(URI(url)); File.binwrite(cache, d); d)

crl     = OpenSSL::X509::CRL.new(body)
entries = crl.revoked.size
absent  = 0xDEAD_BEEF_CAFE_F00D
present = crl.revoked[entries / 2].serial # middle of the list for median performance

puts "#{OpenSSL::OPENSSL_LIBRARY_VERSION} — #{url}"
puts "#{(body.bytesize / 1e6).round(1)} MB DER, #{entries} revoked entries"

[["not revoked", absent], ["revoked", present]].each do |label, serial|
  abort "mismatch for #{label}" unless
    crl.by_serial(serial) == crl.revoked.find { |r| r.serial == serial }
  puts "\n=== #{label} serial ==="

  puts "\n-- warm: lookup on a parsed CRL --"
  @list = nil
  Benchmark.ips do |x|
    x.config(warmup: 1, time: 3)
    x.report("revoked.find") { (@list ||= crl.revoked).find { |r| r.serial == serial } }
    x.report("by_serial")    { crl.by_serial(serial) }
    x.compare!
  end
  Benchmark.memory do |x|
    x.report("revoked.find") { crl.revoked.find { |r| r.serial == serial } }
    x.report("by_serial")    { crl.by_serial(serial) }
    x.compare!
  end

  puts "\n-- cold: parse a fresh CRL + one lookup --"
  Benchmark.ips do |x|
    x.config(warmup: 0, time: 3)
    x.report("revoked.find") { OpenSSL::X509::CRL.new(body).revoked.find { |r| r.serial == serial } }
    x.report("by_serial")    { OpenSSL::X509::CRL.new(body).by_serial(serial) }
    x.compare!
  end
  Benchmark.memory do |x|
    x.report("revoked.find") { OpenSSL::X509::CRL.new(body).revoked.find { |r| r.serial == serial } }
    x.report("by_serial")    { OpenSSL::X509::CRL.new(body).by_serial(serial) }
    x.compare!
  end
end
```