### PR TITLE
pkey: expand OSSL_3_const macro

### DIFF
--- a/ext/openssl/ossl.h
+++ b/ext/openssl/ossl.h
@@ -59,12 +59,6 @@
       (LIBRESSL_VERSION_NUMBER >= ((maj << 28) | (min << 20) | (pat << 12)))
 #endif
 
-#if OSSL_OPENSSL_PREREQ(3, 0, 0)
-# define OSSL_3_const const
-#else
-# define OSSL_3_const /* const */
-#endif
-
 #if !defined(OPENSSL_NO_ENGINE) && !OSSL_OPENSSL_PREREQ(3, 0, 0)
 # define OSSL_USE_ENGINE
 #endif

--- a/ext/openssl/ossl_pkey_dh.c
+++ b/ext/openssl/ossl_pkey_dh.c
@@ -141,8 +141,7 @@ static VALUE
 ossl_dh_initialize_copy(VALUE self, VALUE other)
 {
     EVP_PKEY *pkey;
-    DH *dh;
-    OSSL_3_const DH *dh_other;
+    DH *dh, *dh_other;
     const BIGNUM *pub, *priv;
 
     TypedData_Get_Struct(self, EVP_PKEY, &ossl_evp_pkey_type, pkey);
@@ -188,7 +187,7 @@ ossl_dh_initialize_copy(VALUE self, VALUE other)
 static VALUE
 ossl_dh_is_public(VALUE self)
 {
-    OSSL_3_const DH *dh;
+    const DH *dh;
     const BIGNUM *bn;
 
     GetDH(self, dh);
@@ -207,7 +206,7 @@ ossl_dh_is_public(VALUE self)
 static VALUE
 ossl_dh_is_private(VALUE self)
 {
-    OSSL_3_const DH *dh;
+    const DH *dh;
     const BIGNUM *bn;
 
     GetDH(self, dh);
@@ -244,7 +243,7 @@ ossl_dh_is_private(VALUE self)
 static VALUE
 ossl_dh_export(VALUE self)
 {
-    OSSL_3_const DH *dh;
+    const DH *dh;
     BIO *out;
     VALUE str;
 
@@ -277,7 +276,7 @@ ossl_dh_export(VALUE self)
 static VALUE
 ossl_dh_to_der(VALUE self)
 {
-    OSSL_3_const DH *dh;
+    const DH *dh;
     unsigned char *p;
     long len;
     VALUE str;
@@ -319,7 +318,7 @@ ossl_dh_check_params(VALUE self)
     ret = EVP_PKEY_param_check(pctx);
     EVP_PKEY_CTX_free(pctx);
 #else
-    OSSL_3_const DH *dh;
+    const DH *dh;
     int codes;
 
     GetDH(self, dh);

--- a/ext/openssl/ossl_pkey_dsa.c
+++ b/ext/openssl/ossl_pkey_dsa.c
@@ -26,7 +26,7 @@
 } while (0)
 
 static inline int
-DSA_HAS_PRIVATE(OSSL_3_const DSA *dsa)
+DSA_HAS_PRIVATE(const DSA *dsa)
 {
     const BIGNUM *bn;
     DSA_get0_key(dsa, NULL, &bn);
@@ -34,7 +34,7 @@ DSA_HAS_PRIVATE(OSSL_3_const DSA *dsa)
 }
 
 static inline int
-DSA_PRIVATE(VALUE obj, OSSL_3_const DSA *dsa)
+DSA_PRIVATE(VALUE obj, const DSA *dsa)
 {
     return DSA_HAS_PRIVATE(dsa) || OSSL_PKEY_IS_PRIVATE(obj);
 }
@@ -152,7 +152,7 @@ static VALUE
 ossl_dsa_initialize_copy(VALUE self, VALUE other)
 {
     EVP_PKEY *pkey;
-    OSSL_3_const DSA *dsa;
+    const DSA *dsa;
     DSA *dsa_new;
 
     TypedData_Get_Struct(self, EVP_PKEY, &ossl_evp_pkey_type, pkey);
@@ -207,7 +207,7 @@ ossl_dsa_is_public(VALUE self)
 static VALUE
 ossl_dsa_is_private(VALUE self)
 {
-    OSSL_3_const DSA *dsa;
+    const DSA *dsa;
 
     GetDSA(self, dsa);
 
@@ -276,7 +276,7 @@ ossl_dsa_is_private(VALUE self)
 static VALUE
 ossl_dsa_export(int argc, VALUE *argv, VALUE self)
 {
-    OSSL_3_const DSA *dsa;
+    const DSA *dsa;
 
     GetDSA(self, dsa);
     if (DSA_HAS_PRIVATE(dsa))
@@ -302,7 +302,7 @@ ossl_dsa_export(int argc, VALUE *argv, VALUE self)
 static VALUE
 ossl_dsa_to_der(VALUE self)
 {
-    OSSL_3_const DSA *dsa;
+    const DSA *dsa;
 
     GetDSA(self, dsa);
     if (DSA_HAS_PRIVATE(dsa))

--- a/ext/openssl/ossl_pkey_ec.c
+++ b/ext/openssl/ossl_pkey_ec.c
@@ -199,7 +199,7 @@ static VALUE
 ossl_ec_key_initialize_copy(VALUE self, VALUE other)
 {
     EVP_PKEY *pkey;
-    OSSL_3_const EC_KEY *ec;
+    const EC_KEY *ec;
     EC_KEY *ec_new;
 
     TypedData_Get_Struct(self, EVP_PKEY, &ossl_evp_pkey_type, pkey);
@@ -232,7 +232,7 @@ ossl_ec_key_initialize_copy(VALUE self, VALUE other)
 static VALUE
 ossl_ec_key_get_group(VALUE self)
 {
-    OSSL_3_const EC_KEY *ec;
+    const EC_KEY *ec;
     const EC_GROUP *group;
 
     GetEC(self, ec);
@@ -277,7 +277,7 @@ ossl_ec_key_set_group(VALUE self, VALUE group_v)
  */
 static VALUE ossl_ec_key_get_private_key(VALUE self)
 {
-    OSSL_3_const EC_KEY *ec;
+    const EC_KEY *ec;
     const BIGNUM *bn;
 
     GetEC(self, ec);
@@ -328,7 +328,7 @@ static VALUE ossl_ec_key_set_private_key(VALUE self, VALUE private_key)
  */
 static VALUE ossl_ec_key_get_public_key(VALUE self)
 {
-    OSSL_3_const EC_KEY *ec;
+    const EC_KEY *ec;
     const EC_POINT *point;
 
     GetEC(self, ec);
@@ -380,7 +380,7 @@ static VALUE ossl_ec_key_set_public_key(VALUE self, VALUE public_key)
  */
 static VALUE ossl_ec_key_is_public(VALUE self)
 {
-    OSSL_3_const EC_KEY *ec;
+    const EC_KEY *ec;
 
     GetEC(self, ec);
 
@@ -396,7 +396,7 @@ static VALUE ossl_ec_key_is_public(VALUE self)
  */
 static VALUE ossl_ec_key_is_private(VALUE self)
 {
-    OSSL_3_const EC_KEY *ec;
+    const EC_KEY *ec;
 
     GetEC(self, ec);
 
@@ -464,7 +464,7 @@ static VALUE ossl_ec_key_is_private(VALUE self)
 static VALUE
 ossl_ec_key_export(int argc, VALUE *argv, VALUE self)
 {
-    OSSL_3_const EC_KEY *ec;
+    const EC_KEY *ec;
 
     GetEC(self, ec);
     if (EC_KEY_get0_public_key(ec) == NULL)
@@ -492,7 +492,7 @@ ossl_ec_key_export(int argc, VALUE *argv, VALUE self)
 static VALUE
 ossl_ec_key_to_der(VALUE self)
 {
-    OSSL_3_const EC_KEY *ec;
+    const EC_KEY *ec;
 
     GetEC(self, ec);
     if (EC_KEY_get0_public_key(ec) == NULL)
@@ -567,7 +567,7 @@ static VALUE ossl_ec_key_check_key(VALUE self)
 
     EVP_PKEY_CTX_free(pctx);
 #else
-    OSSL_3_const EC_KEY *ec;
+    const EC_KEY *ec;
 
     GetEC(self, ec);
     if (EC_KEY_check_key(ec) != 1)

--- a/ext/openssl/ossl_pkey_rsa.c
+++ b/ext/openssl/ossl_pkey_rsa.c
@@ -26,7 +26,7 @@
 } while (0)
 
 static inline int
-RSA_HAS_PRIVATE(OSSL_3_const RSA *rsa)
+RSA_HAS_PRIVATE(const RSA *rsa)
 {
     const BIGNUM *e, *d;
 
@@ -35,7 +35,7 @@ RSA_HAS_PRIVATE(OSSL_3_const RSA *rsa)
 }
 
 static inline int
-RSA_PRIVATE(VALUE obj, OSSL_3_const RSA *rsa)
+RSA_PRIVATE(VALUE obj, const RSA *rsa)
 {
     return RSA_HAS_PRIVATE(rsa) || OSSL_PKEY_IS_PRIVATE(obj);
 }
@@ -148,7 +148,7 @@ static VALUE
 ossl_rsa_initialize_copy(VALUE self, VALUE other)
 {
     EVP_PKEY *pkey;
-    OSSL_3_const RSA *rsa;
+    const RSA *rsa;
     RSA *rsa_new;
 
     TypedData_Get_Struct(self, EVP_PKEY, &ossl_evp_pkey_type, pkey);
@@ -183,7 +183,7 @@ ossl_rsa_initialize_copy(VALUE self, VALUE other)
 static VALUE
 ossl_rsa_is_public(VALUE self)
 {
-    OSSL_3_const RSA *rsa;
+    const RSA *rsa;
 
     GetRSA(self, rsa);
     /*
@@ -202,7 +202,7 @@ ossl_rsa_is_public(VALUE self)
 static VALUE
 ossl_rsa_is_private(VALUE self)
 {
-    OSSL_3_const RSA *rsa;
+    const RSA *rsa;
 
     GetRSA(self, rsa);
 
@@ -212,7 +212,7 @@ ossl_rsa_is_private(VALUE self)
 static int
 can_export_rsaprivatekey(VALUE self)
 {
-    OSSL_3_const RSA *rsa;
+    const RSA *rsa;
     const BIGNUM *n, *e, *d, *p, *q, *dmp1, *dmq1, *iqmp;
 
     GetRSA(self, rsa);


### PR DESCRIPTION
`OSSL_3_const` was useful when supporting OpenSSL 1.0.2-3.x at the same time. Since support for OpenSSL < 1.1.1 has been dropped, most uses can simply be replaced with plain `const`.