### PR TITLE
pkcs7: fix flaky test test_enveloped

### DIFF
--- a/test/openssl/test_pkcs7.rb
+++ b/test/openssl/test_pkcs7.rb
@@ -238,8 +238,6 @@ IQCJVpo1FTLZOHSc9UpjS+VKR4cg50Iz0HiPyo6hwjCrwA==
     assert_equal(@ee2_cert.serial, recip[1].serial)
     assert_equal(data, p7.decrypt(@ee2_key, @ee2_cert))
 
-    assert_equal(data, p7.decrypt(@ee1_key))
-
     assert_raise(OpenSSL::PKCS7::PKCS7Error) {
       p7.decrypt(@ca_key, @ca_cert)
     }
@@ -248,6 +246,16 @@ IQCJVpo1FTLZOHSc9UpjS+VKR4cg50Iz0HiPyo6hwjCrwA==
     assert_raise_with_message(ArgumentError, /RC2-40-CBC/) {
       OpenSSL::PKCS7.encrypt(certs, data)
     }
+  end
+
+  def test_enveloped_decrypt_key_only
+    omit_on_fips # PKCS #1 v1.5 padding
+
+    data = "aaaaa\nbbbbb\nccccc\n"
+    cipher = "AES-128-CBC"
+
+    p7 = OpenSSL::PKCS7.encrypt([@ee1_cert], data, cipher, OpenSSL::PKCS7::BINARY)
+    assert_equal(data, p7.decrypt(@ee1_key))
   end
 
   def test_enveloped_add_recipient


### PR DESCRIPTION
`OpenSSL::PKCS7#decrypt` is unreliable when given only a private key and the PKCS#7 structure contains multiple recipients. It may occasionally raise an exception or return garbage data. Update the test to avoid this.

This became much more visible in CI after upgrading to OpenSSL versions released on 2026-06-09, which enable the implicit rejection mechanism for PKCS#1 v1.5 decryption in PKCS#7.