### PR TITLE
rand: fix error check of RAND_load_file()

### DIFF
--- a/ext/openssl/ossl_rand.c
+++ b/ext/openssl/ossl_rand.c
@@ -67,7 +67,7 @@ ossl_rand_add(VALUE self, VALUE str, VALUE entropy)
 static VALUE
 ossl_rand_load_file(VALUE self, VALUE filename)
 {
-    if(!RAND_load_file(StringValueCStr(filename), -1)) {
+    if (RAND_load_file(StringValueCStr(filename), -1) < 0) {
         ossl_raise(eRandomError, NULL);
     }
     return Qtrue;


### PR DESCRIPTION
This function returns -1 on error, or the number of bytes read on success. Preserve current behaviour and also error out on error. Discovered by an experimental static analyzer I work on.