### PR TITLE
Look the SSLContext up from the SSL_CTX in the ALPN/NPN callbacks

### DIFF
--- a/ext/openssl/ossl_ssl.c
+++ b/ext/openssl/ossl_ssl.c
@@ -579,12 +579,21 @@ ssl_npn_select_cb_common(SSL *ssl, VALUE cb, const unsigned char **out,
     return SSL_TLSEXT_ERR_OK;
 }
 
+static VALUE
+ossl_sslctx_obj_from_ssl(const SSL *ssl)
+{
+    SSL_CTX *ctx = SSL_get_SSL_CTX(ssl);
+
+    return (VALUE)SSL_CTX_get_ex_data(ctx, ossl_sslctx_ex_ptr_idx);
+}
+
 #ifdef OSSL_USE_NEXTPROTONEG
 static int
 ssl_npn_advertise_cb(SSL *ssl, const unsigned char **out, unsigned int *outlen,
                      void *arg)
 {
-    VALUE protocols = rb_attr_get((VALUE)arg, id_npn_protocols_encoded);
+    VALUE protocols = rb_attr_get(ossl_sslctx_obj_from_ssl(ssl),
+                                  id_npn_protocols_encoded);
 
     *out = (const unsigned char *) RSTRING_PTR(protocols);
     *outlen = RSTRING_LENINT(protocols);
@@ -598,7 +607,7 @@ ssl_npn_select_cb(SSL *ssl, unsigned char **out, unsigned char *outlen,
 {
     VALUE sslctx_obj, cb;
 
-    sslctx_obj = (VALUE) arg;
+    sslctx_obj = ossl_sslctx_obj_from_ssl(ssl);
     cb = rb_attr_get(sslctx_obj, id_i_npn_select_cb);
 
     return ssl_npn_select_cb_common(ssl, cb, (const unsigned char **)out,
@@ -612,7 +621,7 @@ ssl_alpn_select_cb(SSL *ssl, const unsigned char **out, unsigned char *outlen,
 {
     VALUE sslctx_obj, cb;
 
-    sslctx_obj = (VALUE) arg;
+    sslctx_obj = ossl_sslctx_obj_from_ssl(ssl);
     cb = rb_attr_get(sslctx_obj, id_i_alpn_select_cb);
 
     return ssl_npn_select_cb_common(ssl, cb, out, outlen, in, inlen);
@@ -807,11 +816,11 @@ ossl_sslctx_setup(VALUE self)
     if (!NIL_P(val)) {
         VALUE encoded = ssl_encode_npn_protocols(val);
         rb_ivar_set(self, id_npn_protocols_encoded, encoded);
-        SSL_CTX_set_next_protos_advertised_cb(ctx, ssl_npn_advertise_cb, (void *)self);
+        SSL_CTX_set_next_protos_advertised_cb(ctx, ssl_npn_advertise_cb, NULL);
         OSSL_Debug("SSL NPN advertise callback added");
     }
     if (RTEST(rb_attr_get(self, id_i_npn_select_cb))) {
-        SSL_CTX_set_next_proto_select_cb(ctx, ssl_npn_select_cb, (void *) self);
+        SSL_CTX_set_next_proto_select_cb(ctx, ssl_npn_select_cb, NULL);
         OSSL_Debug("SSL NPN select callback added");
     }
 #endif
@@ -827,7 +836,7 @@ ossl_sslctx_setup(VALUE self)
         OSSL_Debug("SSL ALPN values added");
     }
     if (RTEST(rb_attr_get(self, id_i_alpn_select_cb))) {
-        SSL_CTX_set_alpn_select_cb(ctx, ssl_alpn_select_cb, (void *) self);
+        SSL_CTX_set_alpn_select_cb(ctx, ssl_alpn_select_cb, NULL);
         OSSL_Debug("SSL ALPN select callback added");
     }
 


### PR DESCRIPTION
Fixes #1088.

`ossl_sslctx_mark` uses `rb_gc_mark_movable`, so the SSLContext relocates. Its `VALUE` is stored in four places:

| where | updated on compaction? |
|---|---|
| `SSL_CTX` ex_data | yes, by `ossl_sslctx_compact` |
| `SSL_CTX_set_next_protos_advertised_cb` arg (`:810`) | no |
| `SSL_CTX_set_next_proto_select_cb` arg (`:814`) | no |
| `SSL_CTX_set_alpn_select_cb` arg (`:830`) | no |

After a compaction the three callback arguments hold the pre-move address, and each callback does `rb_attr_get` on it. Registration is one-shot — `ossl_sslctx_setup` returns early when `self` is frozen — so the address is captured at the first handshake and never refreshed.

This is a regression from the switch to `rb_gc_mark_movable`; every release pins with `rb_gc_mark` and is unaffected.

## Approach

Rather than adding three fix-ups to `ossl_sslctx_compact`, this removes the three extra copies. All three callbacks already receive the `SSL`, and `SSL_get_SSL_CTX(ssl)`'s ex_data is the copy that is already maintained — so they can look the object up and pass `NULL` as the callback argument.

That leaves exactly one stored copy and one place to keep current, which seemed worth more than the alternative: `ossl_sslctx_compact` would otherwise have to re-register all three callbacks from inside a GC compaction callback, since OpenSSL exposes no getter for these arguments.

The helper sits next to the other ex_data accessors and mirrors the idiom already used in the session-remove callback.

## Verification

Built HEAD (`9796ee8`) and the patched tree in the same step that ran the tests, so the artifact can't drift from the source. Ruby 4.0.6, OpenSSL 3.5.6, in a container.

```
                          master     with this patch
NPN :810 (server side)    3/3 fail   3/3 pass
NPN :814 (client side)    3/3 fail   3/3 pass
ALPN :830                 3/3 fail   3/3 pass
control (no compaction)   3/3 pass   3/3 pass
```

The two NPN sites are isolated by putting the server and client contexts in *different processes* (fork + pipes), so exactly one of them is subject to the compaction — otherwise the server fails first and masks the client site entirely.

Both ends pin `max_version` to TLS 1.2. That detail is why #1088 recorded the NPN sites as "code reading only": NPN isn't sent at TLS 1.3, so an unconstrained test negotiates 1.3, neither callback fires, and the run looks clean. The scripts now assert the callbacks actually ran before reporting anything.

Failure modes observed on master, both from the same defect depending on what lands in the vacated slot:

- `:810` — SEGV in `ssl_npn_advertise_cb`, faulting at `0x4`, i.e. `RSTRING_PTR(Qnil)`
- `:814` — `NoMethodError: undefined method 'call' for nil` out of `SSLSocket#connect`, with the peer logging `sslv3 alert handshake failure`

## Reachability

`npn_protocols=`, `npn_select_cb=` and `alpn_select_cb=` are public documented accessors. The trigger is the application's own `GC.compact`, not anything an attacker supplies, which is why this is a public issue rather than a private report.

One honest caveat: confirmed under `GC.verify_compaction_references`. I could not get a plain `GC.compact` to relocate the SSLContext in a small process, so I'm not claiming a spontaneous production rate — every run where the context did relocate failed (30/30), and every run where it didn't survived (60/60).