### PR TITLE
Add SSLSocket server handshake aliases

### DIFF
--- a/ext/openssl/ossl_ssl.c
+++ b/ext/openssl/ossl_ssl.c
@@ -3171,6 +3171,8 @@ Init_ossl_ssl(void)
     rb_define_method(cSSLSocket, "connect_nonblock",    ossl_ssl_connect_nonblock, -1);
     rb_define_method(cSSLSocket, "accept",     ossl_ssl_accept, 0);
     rb_define_method(cSSLSocket, "accept_nonblock", ossl_ssl_accept_nonblock, -1);
+    rb_define_alias(cSSLSocket, "start", "accept");
+    rb_define_alias(cSSLSocket, "start_nonblock", "accept_nonblock");
     rb_define_method(cSSLSocket, "sysread",    ossl_ssl_read, -1);
     rb_define_private_method(cSSLSocket, "sysread_nonblock",    ossl_ssl_read_nonblock, -1);
     rb_define_method(cSSLSocket, "syswrite",   ossl_ssl_write, 1);

--- a/test/openssl/test_ssl.rb
+++ b/test/openssl/test_ssl.rb
@@ -4,6 +4,17 @@ require_relative "utils"
 if defined?(OpenSSL::SSL)
 
 class OpenSSL::TestSSL < OpenSSL::SSLTestCase
+  def test_server_handshake_aliases
+    assert_equal(
+      OpenSSL::SSL::SSLSocket.instance_method(:accept),
+      OpenSSL::SSL::SSLSocket.instance_method(:start),
+    )
+    assert_equal(
+      OpenSSL::SSL::SSLSocket.instance_method(:accept_nonblock),
+      OpenSSL::SSL::SSLSocket.instance_method(:start_nonblock),
+    )
+  end
+
   def test_bad_socket
     bad_socket = Struct.new(:sync).new
     assert_raise TypeError do


### PR DESCRIPTION
# TL;DR

Add `OpenSSL::SSL::SSLSocket#start` and `#start_nonblock` as aliases for `#accept` and `#accept_nonblock`.

# Context

When `OpenSSL::SSL::SSLServer#start_immediately` is disabled, `SSLServer#accept` returns the accepted transport before performing the TLS handshake. The caller then invokes `SSLSocket#accept` on that already-accepted socket to perform the server-side handshake.

`io-endpoint` currently defines these aliases itself so accepted connections can be dispatched to a fiber or thread and the TLS handshake can be initiated with `#start`, without treating handshake initiation as another connection acceptance operation in generic server code.

Related to https://github.com/ruby/openssl/issues/760.

# Changes

- Alias `SSLSocket#start` to `SSLSocket#accept`.
- Alias `SSLSocket#start_nonblock` to `SSLSocket#accept_nonblock`.
- Test that both aliases resolve to the existing methods.

The existing methods and behavior are unchanged.

# Tophatting

- `bundle exec rake compile`
- `bundle exec ruby -Itest -Ilib test/openssl/test_ssl.rb --name=test_server_handshake_aliases`
- `bundle exec rake test` (628 tests, 4,606 assertions, 0 failures, 0 errors, 2 expected FIPS omissions)
