### PR TITLE
bn: support marshalling

### DIFF
--- a/lib/openssl/bn.rb
+++ b/lib/openssl/bn.rb
@@ -23,6 +23,14 @@ module OpenSSL
         q.text to_i.to_s
       }
     end
+
+    def marshal_dump # :nodoc:
+      to_i
+    end
+
+    def marshal_load(integer) # :nodoc:
+      initialize(integer)
+    end
   end # BN
 end # OpenSSL
 

--- a/test/openssl/test_bn.rb
+++ b/test/openssl/test_bn.rb
@@ -315,6 +315,14 @@ class OpenSSL::TestBN < OpenSSL::TestCase
     assert_instance_of(String, @e1.hash.to_s)
   end
 
+  def test_marshal
+    assert_equal(@e1, Marshal.load(Marshal.dump(@e1)))
+    assert_equal(@e2, Marshal.load(Marshal.dump(@e2)))
+
+    obj = Marshal.load("\x04\x08U:\x10OpenSSL::BNi\xfe\x01\x00")
+    assert_equal(-0xffff, obj)
+  end
+
   def test_argument_error
     bug15760 = '[ruby-core:92231] [Bug #15760]'
     assert_raise(ArgumentError, bug15760) { OpenSSL::BN.new(nil, 2) }


### PR DESCRIPTION
This fixes tests with Ruby master, where unshareable T_DATA is copied across Ractor via Marshal.