### PR TITLE
Autoload IPAddr instead of requiring it eagerly

### DIFF
--- a/lib/openssl/ssl.rb
+++ b/lib/openssl/ssl.rb
@@ -15,7 +15,11 @@ require "openssl/buffering"
 if defined?(OpenSSL::SSL)
 
 require "io/nonblock"
-require "ipaddr"
+# Only OpenSSL::SSL.verify_certificate_identity uses IPAddr, and only for
+# certificates carrying an iPAddress SAN. Autoloading keeps ipaddr (and the
+# socket library it pulls in) off the require path for everyone else, while
+# leaving the IPAddr constant resolvable as before.
+autoload :IPAddr, "ipaddr"
 require "socket"
 
 module OpenSSL

--- a/test/openssl/test_require.rb
+++ b/test/openssl/test_require.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+require_relative "utils"
+
+class OpenSSL::TestRequire < OpenSSL::TestCase
+  IPADDR_LOADED = '$LOADED_FEATURES.any? { |f| File.basename(f) == "ipaddr.rb" }'
+
+  def subprocess(script)
+    lib = File.expand_path("../../lib", __dir__)
+    IO.popen([RbConfig.ruby, "-I", lib, "-e", script], &:read)
+  end
+
+  def test_requiring_openssl_does_not_load_ipaddr
+    assert_equal "false", subprocess("require 'openssl'; print #{IPADDR_LOADED}")
+  end
+
+  def test_ipaddr_is_still_reachable_after_requiring_openssl
+    assert_equal "127.0.0.1", subprocess("require 'openssl'; print IPAddr.new('127.0.0.1').to_s")
+  end
+
+  def test_referencing_ipaddr_loads_it
+    script = "require 'openssl'; IPAddr.new('127.0.0.1'); print #{IPADDR_LOADED}"
+    assert_equal "true", subprocess(script)
+  end
+end


### PR DESCRIPTION
## Problem

`lib/openssl/ssl.rb` requires `ipaddr` at the top of the file. The only use is in `OpenSSL::SSL.verify_certificate_identity`, and only for certificates carrying an iPAddress SAN:

```ruby
when 7 # iPAddress in GeneralName (RFC5280)
  should_verify_common_name = false
  if san.value.size == 4 || san.value.size == 16
    begin
      return true if san.value == IPAddr.new(hostname).hton
    rescue IPAddr::InvalidAddressError
    end
  end
```

## Fix

```diff
-require "ipaddr"
+autoload :IPAddr, "ipaddr"
```

`autoload` rather than an inline require, so `IPAddr` stays resolvable — anything downstream that relied on `require "openssl"` defining it is unaffected, and there is no per-verification cost.

The rescue clause still resolves correctly: `IPAddr.new` triggers the autoload before it can raise, so `IPAddr::InvalidAddressError` is defined by the time the rescue is evaluated.

## Measurements — and what this does *not* save

To be clear about scope: this does **not** save the `require "socket"` on the very next line, which is unconditional and unrelated. The saving is `ipaddr.rb` itself (857 lines).

Measured with `socket` already loaded, which is openssl's actual situation, Ruby 4.0.6 (arm64-darwin), 15 runs:

| marginal cost of `require "ipaddr"` | min | median | files |
|---|---:|---:|---:|
| | 2.47 ms | 2.95 ms | 1 |

End-to-end `require "openssl"` moves from a min of 40.68 → 35.12 ms in one sample and 26.42 → 24.88 ms in another; that figure carries a lot of variance from loading `openssl.so`, so **the marginal number above is the honest one**.

Small in absolute terms, but `openssl` is loaded in a large share of Ruby processes, the change is one line, and there is no behavior difference.

## Tests

`bundle exec rake test`: **630 tests, 0 failures**, unchanged (633 with the additions).

The existing suite already exercises the `IPAddr` path directly — `test_ssl.rb` asserts `verify_certificate_identity` against a certificate with an `IP:127.0.0.1` SAN, in both the matching and non-matching directions.

The three added tests cover that requiring openssl does not load ipaddr, that `IPAddr` still resolves afterwards, and that referencing it pulls the library in. The first fails against the previous code.

## Related

ruby/net-http#337 makes the same change for `Resolv` in `net/http`, which uses it for two regexps on one line.
