### PR TITLE
Fix Buffering length edge cases

### DIFF
--- a/lib/openssl/buffering.rb
+++ b/lib/openssl/buffering.rb
@@ -116,6 +116,8 @@ module OpenSSL::Buffering
   # See IO#read for full details.
 
   def read(size=nil, buf=nil)
+    raise ArgumentError, "negative length #{size} given" if size && size < 0
+
     if size == 0
       if buf
         buf.clear
@@ -143,6 +145,8 @@ module OpenSSL::Buffering
   # See IO#readpartial for full details.
 
   def readpartial(maxlen, buf=nil)
+    raise ArgumentError, "negative length #{maxlen} given" if maxlen < 0
+
     if maxlen == 0
       if buf
         buf.clear
@@ -201,6 +205,8 @@ module OpenSSL::Buffering
   # it will return +nil+ instead of raising EOFError.
 
   def read_nonblock(maxlen, buf=nil, exception: true)
+    raise ArgumentError, "negative length #{maxlen} given" if maxlen < 0
+
     if maxlen == 0
       if buf
         buf.clear
@@ -232,9 +238,11 @@ module OpenSSL::Buffering
   # Unlike IO#gets the separator must be provided if a limit is provided.
 
   def gets(eol=$/, limit=nil, chomp: false)
+    return "" if limit == 0
+
     idx = @rbuffer.index(eol)
     until @eof
-      break if idx
+      break if idx || (limit && limit > 0 && @rbuffer.bytesize >= limit)
       fill_rbuff
       idx = @rbuffer.index(eol)
     end
@@ -243,8 +251,8 @@ module OpenSSL::Buffering
     else
       size = idx ? idx+eol.size : nil
     end
-    if size && limit && limit >= 0
-      size = [size, limit].min
+    if limit && limit >= 0
+      size = [size || @rbuffer.bytesize, limit].min
     end
     line = consume_rbuff(size)
     if chomp && line


### PR DESCRIPTION
## Summary

Align `OpenSSL::Buffering` read length handling with IO: reject negative read sizes, return an empty String for `gets(..., 0)`, and stop filling once a positive `gets` limit is available.

## Reproduction

The current implementation accepts negative lengths in `read`, `readpartial`, and `read_nonblock`; `gets(separator, 0)` reads through separator/EOF and returns nil at EOF; and a positive limited `gets` continues reading until separator/EOF after the requested bytes are buffered.

## Verification

- Current candidate: 630 tests / 4,624 assertions, zero failures/errors, two expected FIPS omissions
- Release candidate: 597 tests / 4,411 assertions, zero failures/errors, two expected FIPS omissions
- Focused IO-parity and bounded-read models pass
- Native build succeeds with `-Werror`; gem build/install and Songstats Rails/OpenSSL integration pass

No public API is added; this corrects documented IO-compatible edge behavior.
