### PR TITLE
Avoid recomputing HMAC digests during comparison

### DIFF
--- a/lib/openssl/hmac.rb
+++ b/lib/openssl/hmac.rb
@@ -5,9 +5,12 @@ module OpenSSL
     # Securely compare with another HMAC instance in constant time.
     def ==(other)
       return false unless HMAC === other
-      return false unless self.digest.bytesize == other.digest.bytesize
 
-      OpenSSL.fixed_length_secure_compare(self.digest, other.digest)
+      self_digest = digest
+      other_digest = other.digest
+      return false unless self_digest.bytesize == other_digest.bytesize
+
+      OpenSSL.fixed_length_secure_compare(self_digest, other_digest)
     end
 
     # :call-seq:


### PR DESCRIPTION
## Summary

Snapshot each HMAC digest once in `HMAC#==` and reuse those strings for the size check and constant-time comparison.

## Verification

- Current candidate: 630 tests / 4,624 assertions, zero failures/errors, two expected FIPS omissions
- Release candidate: 597 tests / 4,411 assertions, zero failures/errors, two expected FIPS omissions
- 100,000 comparisons: allocations 400,018 to 200,018; elapsed 0.215s to 0.099s locally
- Native build succeeds with `-Werror`; gem build/install and Songstats HMAC integration pass

Comparison semantics and the constant-time primitive are unchanged; this only avoids two redundant digest snapshots.
