### PR TITLE
Match single-label hostnames case-insensitively

### DIFF
--- a/lib/openssl/ssl.rb
+++ b/lib/openssl/ssl.rb
@@ -289,7 +289,7 @@ module OpenSSL
       san_parts = san.downcase.split(".")
 
       # TODO: this behavior should probably be more strict
-      return san == hostname if san_parts.size < 2
+      return san.casecmp?(hostname) if san_parts.size < 2
 
       # Matching is case-insensitive.
       host_parts = hostname.downcase.split(".")


### PR DESCRIPTION
## Summary

Use a case-insensitive comparison for the single-label branch in `verify_hostname`, matching the existing dotted-hostname behavior and DNS case-insensitivity.

## Reproduction

`verify_hostname('LOCALHOST', 'localhost')` currently returns false while dotted hostnames differing only by case match. The special single-label early return occurs before the normal downcased component comparison.

## Verification

- Current candidate: 630 tests / 4,624 assertions, zero failures/errors, two expected FIPS omissions
- Release candidate: 597 tests / 4,411 assertions, zero failures/errors, two expected FIPS omissions
- Focused exact/mismatched/case-varied hostname models pass
- Native build succeeds with `-Werror`; gem build/install and Songstats X.509/TLS integration pass

Wildcard and dotted-hostname behavior are unchanged.
