### PR TITLE
Align the behavior of SSLSocket's IO-compatible methods with core IO

### DIFF
--- a/ext/openssl/ossl_ssl.c
+++ b/ext/openssl/ossl_ssl.c
@@ -2211,7 +2211,7 @@ ossl_ssl_write_internal_safe(VALUE _args)
 static VALUE
 ossl_ssl_write_internal(VALUE self, VALUE str, VALUE opts)
 {
-    StringValue(str);
+    str = rb_obj_as_string(str);
     int frozen = RB_OBJ_FROZEN(str);
     if (!frozen) {
         rb_str_locktmp(str);

--- a/lib/openssl/buffering.rb
+++ b/lib/openssl/buffering.rb
@@ -552,6 +552,21 @@ module OpenSSL::Buffering
   end
 
   ##
+  # Writes character _ch_ to the stream.
+  #
+  # See IO#putc for full details.
+
+  def putc(ch)
+    if String === ch
+      # Can be empty or more than 1 byte
+      do_write(ch[0, 1])
+    else
+      do_write((ch & 0xff).chr)
+    end
+    ch
+  end
+
+  ##
   # Writes _args_ to the stream.
   #
   # See IO#print for full details.

--- a/lib/openssl/buffering.rb
+++ b/lib/openssl/buffering.rb
@@ -22,8 +22,7 @@
 module OpenSSL::Buffering
   include Enumerable
 
-  # A buffer which will retain binary encoding.
-  class Buffer < String
+  class Buffer < String # :nodoc:
     unless String.method_defined?(:append_as_bytes)
       alias_method :_append, :<<
       def append_as_bytes(string)

--- a/lib/openssl/buffering.rb
+++ b/lib/openssl/buffering.rb
@@ -521,18 +521,31 @@ module OpenSSL::Buffering
   end
 
   ##
-  # Writes _args_ to the stream along with a record separator.
+  # Writes _args_ to the stream along with a newline.
   #
   # See IO#puts for full details.
 
   def puts(*args)
-    s = Buffer.new
     if args.empty?
-      s.append_as_bytes("\n")
+      do_write("\n")
+      return nil
     end
+    s = Buffer.new
     args.each{|arg|
-      s.append_as_bytes(arg.to_s)
-      s.sub!(/(?<!\n)\z/, "\n")
+      if String === arg || !arg.respond_to?(:to_ary)
+        b = arg.to_s
+        s.append_as_bytes(b)
+        s.append_as_bytes("\n") unless b.byteslice(-1) == "\n"
+      else
+        ary = arg.to_ary
+        # IO#puts writes "[...]" when it encounters a recursion (undocumented).
+        # We ignore that for now. Array#flatten may raise ArgumentError.
+        ary.flatten.each do |e|
+          b = e.to_s
+          s.append_as_bytes(b)
+          s.append_as_bytes("\n") unless b.byteslice(-1) == "\n"
+        end
+      end
     }
     do_write(s)
     nil

--- a/lib/openssl/buffering.rb
+++ b/lib/openssl/buffering.rb
@@ -323,7 +323,18 @@ module OpenSSL::Buffering
   # Has no effect on unbuffered reads (such as #sysread).
 
   def ungetc(c)
-    @rbuffer[0,0] = c.chr
+    @rbuffer[0, 0] = Integer === c ? c.chr : c
+    @rbuffer.force_encoding(Encoding::BINARY)
+    nil
+  end
+
+  ##
+  # Pushes byte _c_ back onto the stream such that a subsequent buffered byte
+  # read will return it.
+  def ungetbyte(c)
+    @rbuffer[0, 0] = Integer === c ? (c & 0xff).chr : c
+    @rbuffer.force_encoding(Encoding::BINARY)
+    nil
   end
 
   ##

--- a/lib/openssl/buffering.rb
+++ b/lib/openssl/buffering.rb
@@ -463,6 +463,7 @@ module OpenSSL::Buffering
 
   def write(*s)
     s.inject(0) do |written, str|
+      str = str.to_s
       do_write(str)
       written + str.bytesize
     end
@@ -515,7 +516,7 @@ module OpenSSL::Buffering
   # +.to_s+ method.
 
   def <<(s)
-    do_write(s)
+    do_write(s.to_s)
     self
   end
 

--- a/lib/openssl/buffering.rb
+++ b/lib/openssl/buffering.rb
@@ -224,32 +224,85 @@ module OpenSSL::Buffering
   # _limit_ is provided the result will not be longer than the given number of
   # bytes.
   #
-  # _eol_ may be a String or Regexp.
+  # _eol_ may be a String or Regexp. _eol_ defaults to +$/+.
   #
-  # Unlike IO#gets the line read will not be assigned to +$_+.
+  # Note that Regexp _eol_ is an extension to the standard IO#gets. This mode
+  # is incompatible with _chomp_ option.
   #
-  # Unlike IO#gets the separator must be provided if a limit is provided.
+  # Unlike IO#gets, the line read will not be assigned to +$_+.
 
-  def gets(eol=$/, limit=nil, chomp: false)
-    idx = @rbuffer.index(eol)
-    until @eof
-      break if idx
-      fill_rbuff
-      idx = @rbuffer.index(eol)
+  def gets(eol = $/, limit = nil, chomp: false)
+    if limit.nil? && Integer === eol
+      eol, limit = $/, eol
     end
-    if eol.is_a?(Regexp)
-      size = idx ? idx+$&.size : nil
+    limit = nil if limit && limit < 0
+    return String.new if limit == 0
+
+    case eol
+    when nil
+      gets_slurp(limit)
+    when Regexp
+      gets_regexp(eol, limit)
+    when ""
+      swallow_newlines
+      ret = gets_string("\n\n", limit, chomp)
+      swallow_newlines
+      ret
     else
-      size = idx ? idx+eol.size : nil
+      gets_string(eol, limit, chomp)
     end
-    if size && limit && limit >= 0
-      size = [size, limit].min
+  end
+
+  private def gets_string(eol, limit, chomp)
+    pos = 0
+    while true
+      break if idx = @rbuffer.index(eol, pos)
+      break if limit && @rbuffer.bytesize >= limit
+      pos = [0, @rbuffer.bytesize - eol.bytesize + 1].max
+      break if @eof
+      fill_rbuff
+    end
+    if idx
+      size = idx + eol.bytesize
+      size = [size, limit].min if limit
+    else
+      size = limit
     end
     line = consume_rbuff(size)
-    if chomp && line
+    if chomp && idx
       line.chomp!(eol)
     end
     line
+  end
+
+  private def gets_regexp(eol, limit)
+    while true
+      break if idx = @rbuffer.index(eol)
+      break if limit && @rbuffer.bytesize >= limit
+      break if @eof
+      fill_rbuff
+    end
+    if idx
+      size = idx + $&.size
+      size = [size, limit].min if limit
+    else
+      size = limit
+    end
+    consume_rbuff(size)
+  end
+
+  private def gets_slurp(limit)
+    ret = read(limit)
+    return nil if ret && ret.empty?
+    ret
+  end
+
+  private def swallow_newlines
+    while true
+      @rbuffer.sub!(/\A\n+/, "")
+      break if @eof || !@rbuffer.empty?
+      fill_rbuff
+    end
   end
 
   ##
@@ -258,10 +311,12 @@ module OpenSSL::Buffering
   #
   # See also #gets
 
-  def each(eol=$/)
-    while line = self.gets(eol)
+  def each(eol = $/, limit = nil, chomp: false)
+    return to_enum(__method__, eol, limit, chomp: chomp) unless block_given?
+    while line = gets(eol, limit, chomp: chomp)
       yield line
     end
+    self
   end
   alias each_line each
 
@@ -270,9 +325,9 @@ module OpenSSL::Buffering
   #
   # See also #gets
 
-  def readlines(eol=$/)
+  def readlines(eol = $/, limit = nil, chomp: false)
     ary = []
-    while line = self.gets(eol)
+    while line = gets(eol, limit, chomp: chomp)
       ary << line
     end
     ary
@@ -283,9 +338,8 @@ module OpenSSL::Buffering
   #
   # Raises EOFError if at end of file.
 
-  def readline(eol=$/)
-    raise EOFError if eof?
-    gets(eol)
+  def readline(eol = $/, limit = nil, chomp: false)
+    gets(eol, limit, chomp: chomp) or raise EOFError
   end
 
   ##

--- a/lib/openssl/buffering.rb
+++ b/lib/openssl/buffering.rb
@@ -297,12 +297,25 @@ module OpenSSL::Buffering
   end
 
   ##
+  # Calls the given block once for each character in the stream.
+
+  def each_char
+    return to_enum(__method__) unless block_given?
+    while c = getc
+      yield c
+    end
+    self
+  end
+
+  ##
   # Calls the given block once for each byte in the stream.
 
   def each_byte # :yields: byte
-    while c = getc
-      yield(c.ord)
+    return to_enum(__method__) unless block_given?
+    while c = getbyte
+      yield c
     end
+    self
   end
 
   ##

--- a/test/openssl/test_pair.rb
+++ b/test/openssl/test_pair.rb
@@ -79,6 +79,52 @@ module OpenSSL::TestPairM
     }
   end
 
+  def test_each_char
+    ssl_pair {|s1, s2|
+      s1 << "abc"
+      s1.close
+      chars = []
+      ret = s2.each_char { |c| chars << c }
+      assert_same(s2, ret)
+      assert_equal(["a", "b", "c"], chars)
+      chars = []
+      s2.each_char { |c| chars << c }
+      assert_equal([], chars)
+    }
+  end
+
+  def test_each_char_enumerator
+    ssl_pair {|s1, s2|
+      s1 << "abc"
+      s1.close
+      assert_equal(["a", "b", "c"], s2.each_char.to_a)
+      assert_equal([], s2.each_char.to_a)
+    }
+  end
+
+  def test_each_byte
+    ssl_pair {|s1, s2|
+      s1 << "abc"
+      s1.close
+      bytes = []
+      ret = s2.each_byte { |b| bytes << b }
+      assert_same(s2, ret)
+      assert_equal([97, 98, 99], bytes)
+      bytes = []
+      s2.each_byte { |b| bytes << b }
+      assert_equal([], bytes)
+    }
+  end
+
+  def test_each_byte_enumerator
+    ssl_pair {|s1, s2|
+      s1 << "abc"
+      s1.close
+      assert_equal([97, 98, 99], s2.each_byte.to_a)
+      assert_equal([], s2.each_byte.to_a)
+    }
+  end
+
   def test_ungetc
     ssl_pair {|s1, s2|
       s1 << "abc"

--- a/test/openssl/test_pair.rb
+++ b/test/openssl/test_pair.rb
@@ -585,6 +585,16 @@ module OpenSSL::TestPairM
     }
   end
 
+  def test_write_ltlt_convert_to_s
+    ssl_pair {|s1, s2|
+      def (obj = Object.new).to_s() "obj" end
+      assert_equal(6, s1.write("str", obj))
+      assert_same(s1, s1 << obj)
+      s1.close
+      assert_equal("strobjobj", s2.read)
+    }
+  end
+
   def test_write_zero
     ssl_pair {|s1, s2|
       assert_equal 0, s2.write_nonblock('', exception: false)

--- a/test/openssl/test_pair.rb
+++ b/test/openssl/test_pair.rb
@@ -184,15 +184,100 @@ module OpenSSL::TestPairM
 
   def test_gets
     ssl_pair {|s1, s2|
-      s1 << "abc\n\n$def123ghi"
+      s1 << "abc\n\n$def123ghijk\nlmno"
       s1.close
       ret = s2.gets
       assert_equal Encoding::BINARY, ret.encoding
       assert_equal "abc\n", ret
       assert_equal "\n$", s2.gets("$")
-      assert_equal "def123", s2.gets(/\d+/)
-      assert_equal "ghi", s2.gets
+      assert_equal "def123", s2.gets("123")
+      assert_equal "ghi", s2.gets(":", 3)
+      assert_equal "j", s2.gets(1)
+      assert_equal "k\n", s2.gets("\n", -1)
+      assert_equal "lmno", s2.gets(-1)
       assert_equal nil, s2.gets
+      assert_equal "", s2.gets(0)
+    }
+    # rs spans multiple sysreads
+    ssl_pair {|s1, s2|
+      s1 << "a" * 8192 + "b" * 16384
+      s1.close
+      assert_equal("a" * 8192, s2.gets("b" * 10000, chomp: true))
+    }
+  end
+
+  def test_gets_rs_nil
+    ssl_pair {|s1, s2|
+      s1 << "abc\n\ndef"
+      s1.close
+      assert_equal("", s2.gets(nil, 0))
+      assert_equal("a", s2.gets(nil, 1))
+      assert_equal("bc\n\ndef", s2.gets(nil))
+
+      # At EOF
+      assert_equal("", s2.gets(nil, 0))
+      assert_nil(s2.gets(nil))
+      assert_nil(s2.gets(nil, 1))
+      assert_nil(s2.gets(nil, -1))
+    }
+    ssl_pair {|s1, s2|
+      s1 << "abc\n\ndef"
+      s1.close
+      assert_equal("abc\n\ndef", s2.gets(nil, -1))
+    }
+  end
+
+  def test_gets_rs_empty_leading_newlines
+    ssl_pair {|s1, s2|
+      s1 << "abc\n\ndef\n\nghi"
+      s1.close
+      assert_equal("a", s2.gets("", 1))
+      assert_equal("bc", s2.gets("", 2))
+      assert_equal("def\n\n", s2.gets(""))
+      assert_equal("ghi", s2.gets(""))
+    }
+    # Leading and trailing newlines are trimmed
+    ssl_pair {|s1, s2|
+      s1 << "\n\nabc\n\n\n"
+      s1.close
+      assert_equal("abc\n\n", s2.gets(""))
+      assert_predicate(s2, :eof?)
+    }
+    # Leading and trailing newlines do not count towards limit, and
+    # trailing newlines are still trimmed after limit is reached
+    ssl_pair {|s1, s2|
+      s1 << "\n\nabc\n\n\n\ndef"
+      s1.close
+      assert_equal("a", s2.gets("", 1))
+      assert_equal("bc\n", s2.gets("", 3))
+      assert_equal("def", s2.read)
+    }
+    # chomp: true
+    ssl_pair {|s1, s2|
+      s1 << "a\n\n\ndef\n\n\n"
+      s1.close
+      assert_equal("a\n", s2.gets("", 2, chomp: true))
+      assert_equal("def", s2.gets("", chomp: true))
+    }
+    # \r does not have any special meaning in paragraph mode
+    ssl_pair {|s1, s2|
+      s1 << "\r\nabc\r\n\r\ndef\r\n"
+      s1.close
+      assert_equal("\r\nabc\r\n\r\ndef\r\n", s2.gets("", chomp: true))
+      assert_predicate(s2, :eof?)
+    }
+  end
+
+  def test_gets_rs_regexp
+    ssl_pair {|s1, s2|
+      # OpenSSL::Buffering-specific behavior
+      next unless s2.is_a?(OpenSSL::Buffering)
+
+      s1 << "abc\n\n$def123ghi"
+      s1.close
+      assert_equal("abc\n", s2.gets(/\d+/, 4))
+      assert_equal("\n$def123", s2.gets(/\d+/))
+      assert_equal("ghi", s2.gets(/\d+/))
     }
   end
 
@@ -207,11 +292,58 @@ module OpenSSL::TestPairM
     }
   end
 
+  def test_gets_chomp_rs
+    rs = ":"
+    ssl_pair {|s1, s2|
+      s1 << "aaa:bbb"
+      s1.close
+
+      assert_equal "aaa", s2.gets(rs, chomp: true)
+      assert_equal "bbb", s2.gets(rs, chomp: true)
+      assert_nil s2.gets(rs, chomp: true)
+    }
+  end
+
+  def test_gets_chomp_default_rs
+    ssl_pair {|s1, s2|
+      s1 << "aaa\r\nbbb\nccc"
+      s1.close
+
+      assert_equal "aaa", s2.gets(chomp: true)
+      assert_equal "bbb", s2.gets(chomp: true)
+      assert_equal "ccc", s2.gets(chomp: true)
+      assert_nil s2.gets
+    }
+  end
+
   def test_gets_eof_limit
     ssl_pair {|s1, s2|
       s1.write("hello")
       s1.close # trigger EOF
       assert_match "hello", s2.gets("\n", 6), "[ruby-core:70149] [Bug #11400]"
+    }
+  end
+
+  def test_each_line
+    ssl_pair {|s1, s2|
+      s1 << "a\nb\nc"
+      s1.close
+      lines = []
+      ret = s2.each_line(chomp: true) { |line| lines << line }
+      assert_same(s2, ret)
+      assert_equal(["a", "b", "c"], lines)
+      lines = []
+      s2.each_line { |line| lines << line }
+      assert_equal([], lines)
+    }
+  end
+
+  def test_each_line_enumerator
+    ssl_pair {|s1, s2|
+      s1 << "a\nb\nc"
+      s1.close
+      assert_equal(["a", "b", "c"], s2.each_line(chomp: true).to_a)
+      assert_equal([], s2.each_line.to_a)
     }
   end
 
@@ -243,6 +375,7 @@ module OpenSSL::TestPairM
   def test_readline
     ssl_pair {|s1, s2|
       s2.close
+      assert_equal("", s1.readline(0))
       assert_raise(EOFError) { s1.readline }
     }
   end

--- a/test/openssl/test_pair.rb
+++ b/test/openssl/test_pair.rb
@@ -380,6 +380,28 @@ module OpenSSL::TestPairM
     }
   end
 
+  def test_puts
+    ssl_pair {|s1, s2|
+      s1.puts "a\n", "b"
+      s1.puts nil
+      s1.close
+      assert_equal("a\nb\n\n", s2.read)
+    }
+  end
+
+  def test_puts_array
+    ssl_pair {|s1, s2|
+      s1.puts ["a\n", ["b", ["c"]]]
+      s1.puts [], [[]]
+      def (obj = Object.new).to_ary
+        ["d", []]
+      end
+      s1.puts obj
+      s1.close
+      assert_equal("a\nb\nc\nd\n", s2.read)
+    }
+  end
+
   def test_puts_empty
     ssl_pair {|s1, s2|
       s1.puts

--- a/test/openssl/test_pair.rb
+++ b/test/openssl/test_pair.rb
@@ -4,44 +4,6 @@ require_relative 'ut_eof'
 
 return unless defined?(OpenSSL::SSL)
 
-module OpenSSL::SSLPair
-  def ssl_pair
-    svr_dn = OpenSSL::X509::Name.parse("/DC=org/DC=ruby-lang/CN=localhost")
-    ee_exts = [
-      ["keyUsage", "keyEncipherment,digitalSignature", true],
-    ]
-    svr_key = OpenSSL::TestUtils::Fixtures.pkey("rsa-1")
-    svr_cert = issue_cert(svr_dn, svr_key, 1, ee_exts, nil, nil)
-
-    host = "127.0.0.1"
-    svr = TCPServer.new(host, 0)
-    svr.setsockopt(:TCP, :NODELAY, 1)
-    port = svr.connect_address.ip_port
-
-    tcps = nil
-    th = Thread.new {
-      tcps = svr.accept
-      sctx = OpenSSL::SSL::SSLContext.new
-      sctx.add_certificate(svr_cert, svr_key)
-      ssl = OpenSSL::SSL::SSLSocket.new(tcps, sctx)
-      ssl.accept
-      ssl
-    }
-
-    tcpc = TCPSocket.new(host, port)
-    tcpc.setsockopt(:TCP, :NODELAY, 1)
-    c = OpenSSL::SSL::SSLSocket.new(tcpc)
-    c.connect
-    s = th.value
-
-    yield c, s
-  ensure
-    tcpc&.close
-    tcps&.close
-    svr&.close
-  end
-end
-
 module OpenSSL::TestPairM
   def test_getc
     ssl_pair {|s1, s2|
@@ -466,15 +428,12 @@ module OpenSSL::TestPairM
 
   def test_read_nonblock
     ssl_pair {|s1, s2|
-      err = nil
-      assert_raise(OpenSSL::SSL::SSLErrorWaitReadable) {
-        begin
-          s2.read_nonblock(10)
-        ensure
-          err = $!
-        end
+      err = assert_raise(IO::WaitReadable) {
+        s2.read_nonblock(10)
       }
-      assert_kind_of(IO::WaitReadable, err)
+      if s2.is_a?(OpenSSL::SSL::SSLSocket)
+        assert_instance_of(OpenSSL::SSL::SSLErrorWaitReadable, err)
+      end
       s1.write "abc\ndef\n"
       IO.select([s2])
       assert_equal("ab", s2.read_nonblock(2))
@@ -595,14 +554,12 @@ module OpenSSL::TestPairM
   def test_write_nonblock_retry
     ssl_pair {|s1, s2|
       # fill up a socket so we hit EAGAIN
-      written = String.new
       n = 0
       buf = 'a' * 4099
       case ret = s1.write_nonblock(buf, exception: false)
       when :wait_readable then break
       when :wait_writable then break
       when Integer
-        written << buf
         n += ret
         exp = buf.bytesize
         if ret != exp
@@ -613,7 +570,7 @@ module OpenSSL::TestPairM
 
       # make more space for subsequent write:
       readed = s2.read(n)
-      assert_equal written, readed
+      assert_equal "a"*n, readed
 
       # this fails if SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER is missing:
       buf2 = Marshal.load(Marshal.dump(buf))
@@ -677,7 +634,67 @@ module OpenSSL::TestPairM
 end
 
 class OpenSSL::TestSSLPair < OpenSSL::TestCase
-  include OpenSSL::SSLPair
   include OpenSSL::TestPairM
   include OpenSSL::TestEOF
+
+  def ssl_pair
+    svr_dn = OpenSSL::X509::Name.parse("/DC=org/DC=ruby-lang/CN=localhost")
+    ee_exts = [
+      ["keyUsage", "keyEncipherment,digitalSignature", true],
+    ]
+    svr_key = OpenSSL::TestUtils::Fixtures.pkey("rsa-1")
+    svr_cert = issue_cert(svr_dn, svr_key, 1, ee_exts, nil, nil)
+
+    host = "127.0.0.1"
+    svr = TCPServer.new(host, 0)
+    svr.setsockopt(:TCP, :NODELAY, 1)
+    port = svr.connect_address.ip_port
+
+    tcps = nil
+    th = Thread.new {
+      tcps = svr.accept
+      sctx = OpenSSL::SSL::SSLContext.new
+      sctx.add_certificate(svr_cert, svr_key)
+      ssl = OpenSSL::SSL::SSLSocket.new(tcps, sctx)
+      ssl.accept
+      ssl
+    }
+
+    tcpc = TCPSocket.new(host, port)
+    tcpc.setsockopt(:TCP, :NODELAY, 1)
+    c = OpenSSL::SSL::SSLSocket.new(tcpc)
+    c.connect
+    s = th.value
+
+    yield c, s
+  ensure
+    tcpc&.close
+    tcps&.close
+    svr&.close
+  end
+end
+
+class OpenSSL::TestSocketPair < OpenSSL::TestCase
+  include OpenSSL::TestPairM
+  include OpenSSL::TestEOF
+
+  def ssl_pair
+    host = "127.0.0.1"
+    svr = TCPServer.new(host, 0)
+    svr.setsockopt(:TCP, :NODELAY, 1)
+    port = svr.connect_address.ip_port
+
+    tcps = nil
+    th = Thread.new { tcps = svr.accept }
+
+    tcpc = TCPSocket.new(host, port)
+    tcpc.setsockopt(:TCP, :NODELAY, 1)
+    th.join
+
+    yield tcpc, tcps
+  ensure
+    tcpc&.close
+    tcps&.close
+    svr&.close
+  end
 end

--- a/test/openssl/test_pair.rb
+++ b/test/openssl/test_pair.rb
@@ -422,7 +422,7 @@ module OpenSSL::TestPairM
       assert_equal(str, buf)
 
       obj = Object.new
-      obj.define_singleton_method(:to_str) { str }
+      obj.define_singleton_method(:to_s) { str }
       s1.syswrite(obj)
       assert_equal(str, s2.sysread(str.bytesize))
     }

--- a/test/openssl/test_pair.rb
+++ b/test/openssl/test_pair.rb
@@ -410,6 +410,20 @@ module OpenSSL::TestPairM
     }
   end
 
+  def test_putc
+    ssl_pair {|s1, s2|
+      ret = s1.putc("a")
+      assert_equal("a", ret)
+      s1.putc(98)
+      s1.putc(99 + 256)
+      s1.putc(100 - 256)
+      s1.putc("")
+      s1.putc("\u3042") # \xe3\x81\x82
+      s1.close
+      assert_equal("abcd\u3042".b, s2.read)
+    }
+  end
+
   def test_multibyte_read_write
     # German a umlaut
     auml = [%w{ C3 A4 }.join('')].pack('H*')

--- a/test/openssl/test_pair.rb
+++ b/test/openssl/test_pair.rb
@@ -79,6 +79,63 @@ module OpenSSL::TestPairM
     }
   end
 
+  def test_ungetc
+    ssl_pair {|s1, s2|
+      s1 << "abc"
+      s1.close
+      assert_equal("a", s2.read(1))
+      assert_nil(s2.ungetc("A"))
+      assert_equal("Abc", s2.read(3))
+      assert_predicate(s2, :eof?)
+
+      s2.ungetc("B")
+      assert_not_predicate(s2, :eof?)
+      assert_equal("B", s2.read)
+
+      s2.ungetc("あ") # \xe3\x81\x82
+      s = s2.read(2)
+      assert_equal("\xe3\x81".b, s)
+      assert_equal(Encoding::BINARY, s.encoding)
+      s2.ungetc("")
+      assert_equal("\x82".b, s2.read)
+
+      s2.ungetc(1)
+      assert_equal("\x01".b, s2.read)
+      assert_raise(RangeError) { s2.ungetc(258) }
+      assert_raise(RangeError) { s2.ungetc(-1) }
+    }
+  end
+
+  def test_ungetbyte
+    ssl_pair {|s1, s2|
+      s1 << "abc"
+      s1.close
+
+      assert_equal("a", s2.read(1))
+      assert_nil(s2.ungetbyte("A"))
+      assert_equal("Abc", s2.read(3))
+      assert_predicate(s2, :eof?)
+
+      s2.ungetbyte("B")
+      assert_not_predicate(s2, :eof?)
+      assert_equal("B", s2.read)
+
+      s2.ungetbyte("あ") # \xe3\x81\x82
+      s = s2.read(2)
+      assert_equal("\xe3\x81".b, s)
+      assert_equal(Encoding::BINARY, s.encoding)
+      s2.ungetbyte("")
+      assert_equal("\x82".b, s2.read)
+
+      s2.ungetbyte(1)
+      assert_equal("\x01".b, s2.read)
+      s2.ungetbyte(258)
+      assert_equal("\x02".b, s2.read)
+      s2.ungetbyte(-1)
+      assert_equal("\xff".b, s2.read)
+    }
+  end
+
   def test_gets
     ssl_pair {|s1, s2|
       s1 << "abc\n\n$def123ghi"


### PR DESCRIPTION
Update the following methods on `OpenSSL::Buffering` for better consistency with IO in modern Ruby:

  - `#ungetc`: Accept strings.
  - `#each_byte`: Return `Enumerator` if called without a block.
  - `#gets`: Really complex method and had many issues. I've tried to match the behavior as closely as possible.
  - `#writ`e, `#<<`, `#syswrite`, `#write_nonblock`: Convert arguments with `to_s` rather than `to_str`.
  - `#each_char`, `#puts`, `#ungetbyte`: Added missing methods.

Also run the same tests against actual `IO` objects to catch accidental discrepancy.
