### PR TITLE
CI: Cache compiled AWS-LC by resolving the latest stable version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,12 +119,20 @@ jobs:
       - name: repo checkout
         uses: actions/checkout@v7
 
+      # Resolve the AWS-LC latest stable version as aws-lc-x.x.x for caching
+      - name: Resolve aws-lc version
+        id: resolve-aws-lc
+        if: matrix.openssl == 'aws-lc-latest'
+        run: |
+          AWS_LC_VERSION=$(git ls-remote --tags --sort=-version:refname https://github.com/aws/aws-lc.git 'v*' | head -1 | cut -f 2 | sed -e 's|refs/tags/v|aws-lc-|')
+          echo "version=$AWS_LC_VERSION" >> "$GITHUB_OUTPUT"
+
       - id: cache-openssl
         uses: actions/cache@v6
         with:
           path: ~/openssl
-          key: openssl-${{ runner.os }}-${{ matrix.openssl }}-${{ matrix.append-configure || 'default' }}
-        if: matrix.openssl != 'openssl-master' && matrix.openssl != 'libressl-master' && matrix.openssl != 'aws-lc-latest'
+          key: openssl-${{ runner.os }}-${{ steps.resolve-aws-lc.outputs.version || matrix.openssl }}-${{ matrix.append-configure || 'default' }}
+        if: matrix.openssl != 'openssl-master' && matrix.openssl != 'libressl-master'
 
       - name: Compile OpenSSL library
         if: steps.cache-openssl.outputs.cache-hit != 'true'
@@ -155,9 +163,8 @@ jobs:
             make -j4 && make install
             ;;
           aws-lc-*)
-            git clone https://github.com/aws/aws-lc.git .
-            AWS_LC_RELEASE=$(git tag --sort=-creatordate --list "v*"  | head -1)
-            git checkout $AWS_LC_RELEASE
+            AWS_LC_RELEASE=$(echo "${{ steps.resolve-aws-lc.outputs.version }}" | sed -e 's/aws-lc-/v/')
+            git clone -b $AWS_LC_RELEASE --depth 1 https://github.com/aws/aws-lc.git .
             cmake -DCMAKE_INSTALL_PREFIX=$HOME/openssl -DCMAKE_INSTALL_LIBDIR=lib
             make -j4 && make install
             ;;


### PR DESCRIPTION
When I was checking ruby/openssl's CI AWS-LC case related to the ruby/rubygems PR https://github.com/ruby/rubygems/pull/9853#issuecomment-5539729393 to support AWS-LC in ruby/rubygems, I noticed that we can cache the compiled AWS-LC in ruby/openssl's CI. So, this PR caches the compiled AWS-LC. The `steps.resolve-aws-lc.outputs.version` is such as `aws-lc-5.8.0` which aligns with the current pattern such as `openssl-4.0.1` and `libressl-4.3.2`.

I tested in my fork repository. The `steps.resolve-aws-lc.outputs.version` is `aws-lc-5.8.0`, which is the same with the actual latest version released at <https://github.com/aws/aws-lc/releases>. And I confirmed the `aws-lc-5.8.0` was used as part of the cache key, and also was used for `git clone -b $AWS_LC_RELEASE`. The log is below.

https://github.com/junaruga/ruby-openssl/actions/runs/34117715124/job/101728312189#step:4:4

```
Run actions/cache@v6
  with:
    path: ~/openssl
    key: openssl-Linux-aws-lc-5.8.0-default
    enableCrossOsArchive: false
    fail-on-cache-miss: false
    lookup-only: false
    save-always: false
Cache not found for input keys: openssl-Linux-aws-lc-5.8.0-default
```

```
+ case aws-lc-latest in
++ echo aws-lc-5.8.0
++ sed -e s/aws-lc-/v/
+ AWS_LC_RELEASE=v5.8.0
+ git clone -b v5.8.0 --depth 1 https://github.com/aws/aws-lc.git .
Cloning into '.'...
Note: switching to 'a3d1e685552f05a9ad04a2946962c03e97bdecac'.
```

## Commit message

CI: Cache compiled AWS-LC by resolving the latest stable version

Resolve the AWS-LC latest stable version tag before the cache step using `git ls-remote`, enabling the cache to use a version-specific key (e.g., aws-lc-5.8.0).

Run `git clone` with the resolved AWS-LC stable version.

Assisted-by: Claude:Opus 4.6