### PR TITLE
CI: enable caching for openssl-master, libressl-master, and aws-lc-latest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,12 +119,13 @@ jobs:
       - name: repo checkout
         uses: actions/checkout@v7
 
+      # Caches not accessed within the last week are evicted.
+      # https://github.com/actions/cache#cache-limits
       - id: cache-openssl
         uses: actions/cache@v6
         with:
           path: ~/openssl
           key: openssl-${{ runner.os }}-${{ matrix.openssl }}-${{ matrix.append-configure || 'default' }}
-        if: matrix.openssl != 'openssl-master' && matrix.openssl != 'libressl-master' && matrix.openssl != 'aws-lc-latest'
 
       - name: Compile OpenSSL library
         if: steps.cache-openssl.outputs.cache-hit != 'true'


### PR DESCRIPTION
This PR is a follow up by https://github.com/ruby/openssl/pull/1108, enables caching for openssl-master, libressl-master, and aws-lc-latest by removing these excluded conditions. Note there is no actual running libressl-master case in CI. I just removed the libressl-master condition.

In my fork repository's test, I confirmed the actions/cache caches the openssl-master and aws-lc-latest. The logs are below.

https://github.com/junaruga/ruby-openssl/actions/runs/34124430593/job/101749642583#step:3:4

```
Run actions/cache@v6
  with:
    path: ~/openssl
    key: openssl-Linux-openssl-master-default
    enableCrossOsArchive: false
    fail-on-cache-miss: false
    lookup-only: false
    save-always: false
Cache not found for input keys: openssl-Linux-openssl-master-default
```

https://github.com/junaruga/ruby-openssl/actions/runs/34124430593/job/101749642675#step:3:4

```
Run actions/cache@v6
  with:
    path: ~/openssl
    key: openssl-Linux-aws-lc-latest-default
    enableCrossOsArchive: false
    fail-on-cache-miss: false
    lookup-only: false
    save-always: false
Cache not found for input keys: openssl-Linux-aws-lc-latest-default
```

## Commit message

Remove the condition that excluded these builds from caching. Caches not accessed within the last week are evicted according to the actions/cache documentation, so the cached build is at most about a week old, which is acceptable for these builds.

https://github.com/actions/cache#cache-limits

> Cache Limits
> A repository can have up to 10GB of caches. Once the 10GB limit is reached,
> older caches will be evicted based on when the cache was last accessed. Caches
> that are not accessed within the last week will also be evicted.

Assisted-by: Claude:Opus 4.6