### PR TITLE
CI: Use year and week number cache key for -master and -latest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,13 +119,21 @@ jobs:
       - name: repo checkout
         uses: actions/checkout@v7
 
-      # Caches not accessed within the last week are evicted.
+      # Caches not accessed within the last week are evicted. However, if a
+      # cache is accessed at least once a week, it can remain permanently.
+      # Use a weekly cache key for -master and -latest builds to keep them
+      # reasonably fresh, while stable versions use a fixed key.
       # https://github.com/actions/cache#cache-limits
+      - name: Get current week
+        id: current-week
+        if: matrix.openssl == 'openssl-master' || matrix.openssl == 'libressl-master' || matrix.openssl == 'aws-lc-latest'
+        run: echo "week=$(date -u '+%Y%W')" >> "$GITHUB_OUTPUT"
+
       - id: cache-openssl
         uses: actions/cache@v6
         with:
           path: ~/openssl
-          key: openssl-${{ runner.os }}-${{ matrix.openssl }}-${{ matrix.append-configure || 'default' }}
+          key: openssl-${{ runner.os }}-${{ matrix.openssl }}-${{ matrix.append-configure || 'default' }}-${{ steps.current-week.outputs.week || 'default' }}
 
       - name: Compile OpenSSL library
         if: steps.cache-openssl.outputs.cache-hit != 'true'


### PR DESCRIPTION
This PR is a follow-up for https://github.com/ruby/openssl/pull/1109 (790ed93321bf10d249e2caa95ce72143cbc5397c). This PR includes the current year and week number by `date -u '+%Y%W'` in the cache key for openssl-master, libressl-master, and aws-lc-latest to ensure the cached builds are refreshed weekly.

```
$ date -u '+%Y%W'
202636
```

I tested the openssl-master and aws-lc-latest cases in my fork repository. The log is below.

https://github.com/junaruga/ruby-openssl/actions/runs/34144869607/job/101814592780#step:4:4

```
Run actions/cache@v6
  with:
    path: ~/openssl
    key: openssl-Linux-openssl-master-default-202636
    enableCrossOsArchive: false
    fail-on-cache-miss: false
    lookup-only: false
    save-always: false
Cache not found for input keys: openssl-Linux-openssl-master-default-202636
```

https://github.com/junaruga/ruby-openssl/actions/runs/34144869607/job/101814592774#step:4:4

```
Run actions/cache@v6
  with:
    path: ~/openssl
    key: openssl-Linux-aws-lc-latest-default-202636
    enableCrossOsArchive: false
    fail-on-cache-miss: false
    lookup-only: false
    save-always: false
Cache not found for input keys: openssl-Linux-aws-lc-latest-default-202636
```

## Commit message

The commit 790ed93321bf10d249e2caa95ce72143cbc5397c ("CI: enable caching for
openssl-master, libressl-master, and aws-lc-latest") assumed that caches expire
after a week, but they only expire if not accessed within that period. On an
active repository, the cache would be accessed on every CI run and remain
permanently stale.

https://github.com/actions/cache#cache-limits

Include the current year and week number in the cache key for openssl-master,
libressl-master, and aws-lc-latest to ensure the cached builds are refreshed
weekly.

http://man7.org/linux/man-pages/man1/date.1.html

>        %W     week number of year, with Monday as first day of week
>               (00..53)

Assisted-by: Claude:Opus 4.6